### PR TITLE
Bump Terraform provider to v1.124.0

### DIFF
--- a/.nextchanges/dependency-updates/tf-provider-1.124.0.md
+++ b/.nextchanges/dependency-updates/tf-provider-1.124.0.md
@@ -1,0 +1,1 @@
+Upgrade Terraform provider to 1.124.0

--- a/bundle/internal/tf/codegen/schema/version.go
+++ b/bundle/internal/tf/codegen/schema/version.go
@@ -1,4 +1,4 @@
 package schema
 
 // ProviderVersion is the version of the Databricks Terraform provider used for codegen.
-const ProviderVersion = "1.123.0"
+const ProviderVersion = "1.124.0"

--- a/bundle/internal/tf/schema/data_source_ai_gateway_mcp_service.go
+++ b/bundle/internal/tf/schema/data_source_ai_gateway_mcp_service.go
@@ -1,0 +1,44 @@
+// Generated from Databricks Terraform provider schema. DO NOT EDIT.
+
+package schema
+
+type DataSourceAiGatewayMcpServiceConfigRateLimits struct {
+	Key             string `json:"key"`
+	Principal       string `json:"principal,omitempty"`
+	RenewalPeriod   string `json:"renewal_period"`
+	RequestTagKey   string `json:"request_tag_key,omitempty"`
+	RequestTagValue string `json:"request_tag_value,omitempty"`
+	Requests        int    `json:"requests,omitempty"`
+	Tokens          int    `json:"tokens,omitempty"`
+}
+
+type DataSourceAiGatewayMcpServiceConfigSourceConnection struct {
+	IsDeleted bool   `json:"is_deleted,omitempty"`
+	Name      string `json:"name"`
+}
+
+type DataSourceAiGatewayMcpServiceConfig struct {
+	IncludeToolSelectors []string                                             `json:"include_tool_selectors,omitempty"`
+	RateLimits           []DataSourceAiGatewayMcpServiceConfigRateLimits      `json:"rate_limits,omitempty"`
+	SourceConnection     *DataSourceAiGatewayMcpServiceConfigSourceConnection `json:"source_connection,omitempty"`
+}
+
+type DataSourceAiGatewayMcpServiceProviderConfig struct {
+	WorkspaceId string `json:"workspace_id,omitempty"`
+}
+
+type DataSourceAiGatewayMcpService struct {
+	BrowseOnly     bool                                         `json:"browse_only,omitempty"`
+	Comment        string                                       `json:"comment,omitempty"`
+	Config         *DataSourceAiGatewayMcpServiceConfig         `json:"config,omitempty"`
+	CreateTime     string                                       `json:"create_time,omitempty"`
+	CreatedBy      string                                       `json:"created_by,omitempty"`
+	EffectiveOwner string                                       `json:"effective_owner,omitempty"`
+	Etag           string                                       `json:"etag,omitempty"`
+	MetastoreId    string                                       `json:"metastore_id,omitempty"`
+	Name           string                                       `json:"name"`
+	Owner          string                                       `json:"owner,omitempty"`
+	ProviderConfig *DataSourceAiGatewayMcpServiceProviderConfig `json:"provider_config,omitempty"`
+	UpdateTime     string                                       `json:"update_time,omitempty"`
+	UpdatedBy      string                                       `json:"updated_by,omitempty"`
+}

--- a/bundle/internal/tf/schema/data_source_ai_gateway_mcp_services.go
+++ b/bundle/internal/tf/schema/data_source_ai_gateway_mcp_services.go
@@ -1,0 +1,57 @@
+// Generated from Databricks Terraform provider schema. DO NOT EDIT.
+
+package schema
+
+type DataSourceAiGatewayMcpServicesMcpServicesConfigRateLimits struct {
+	Key             string `json:"key"`
+	Principal       string `json:"principal,omitempty"`
+	RenewalPeriod   string `json:"renewal_period"`
+	RequestTagKey   string `json:"request_tag_key,omitempty"`
+	RequestTagValue string `json:"request_tag_value,omitempty"`
+	Requests        int    `json:"requests,omitempty"`
+	Tokens          int    `json:"tokens,omitempty"`
+}
+
+type DataSourceAiGatewayMcpServicesMcpServicesConfigSourceConnection struct {
+	IsDeleted bool   `json:"is_deleted,omitempty"`
+	Name      string `json:"name"`
+}
+
+type DataSourceAiGatewayMcpServicesMcpServicesConfig struct {
+	IncludeToolSelectors []string                                                         `json:"include_tool_selectors,omitempty"`
+	RateLimits           []DataSourceAiGatewayMcpServicesMcpServicesConfigRateLimits      `json:"rate_limits,omitempty"`
+	SourceConnection     *DataSourceAiGatewayMcpServicesMcpServicesConfigSourceConnection `json:"source_connection,omitempty"`
+}
+
+type DataSourceAiGatewayMcpServicesMcpServicesProviderConfig struct {
+	WorkspaceId string `json:"workspace_id,omitempty"`
+}
+
+type DataSourceAiGatewayMcpServicesMcpServices struct {
+	BrowseOnly     bool                                                     `json:"browse_only,omitempty"`
+	Comment        string                                                   `json:"comment,omitempty"`
+	Config         *DataSourceAiGatewayMcpServicesMcpServicesConfig         `json:"config,omitempty"`
+	CreateTime     string                                                   `json:"create_time,omitempty"`
+	CreatedBy      string                                                   `json:"created_by,omitempty"`
+	EffectiveOwner string                                                   `json:"effective_owner,omitempty"`
+	Etag           string                                                   `json:"etag,omitempty"`
+	MetastoreId    string                                                   `json:"metastore_id,omitempty"`
+	Name           string                                                   `json:"name"`
+	Owner          string                                                   `json:"owner,omitempty"`
+	ProviderConfig *DataSourceAiGatewayMcpServicesMcpServicesProviderConfig `json:"provider_config,omitempty"`
+	UpdateTime     string                                                   `json:"update_time,omitempty"`
+	UpdatedBy      string                                                   `json:"updated_by,omitempty"`
+}
+
+type DataSourceAiGatewayMcpServicesProviderConfig struct {
+	WorkspaceId string `json:"workspace_id,omitempty"`
+}
+
+type DataSourceAiGatewayMcpServices struct {
+	IncludeBrowse  bool                                          `json:"include_browse,omitempty"`
+	McpServices    []DataSourceAiGatewayMcpServicesMcpServices   `json:"mcp_services,omitempty"`
+	PageSize       int                                           `json:"page_size,omitempty"`
+	Parent         string                                        `json:"parent,omitempty"`
+	ProviderConfig *DataSourceAiGatewayMcpServicesProviderConfig `json:"provider_config,omitempty"`
+	View           string                                        `json:"view,omitempty"`
+}

--- a/bundle/internal/tf/schema/data_source_ai_gateway_model_provider_service.go
+++ b/bundle/internal/tf/schema/data_source_ai_gateway_model_provider_service.go
@@ -1,0 +1,191 @@
+// Generated from Databricks Terraform provider schema. DO NOT EDIT.
+
+package schema
+
+type DataSourceAiGatewayModelProviderServiceConfigAmazonBedrockDirectAwsSecretAccessKey struct {
+	Plaintext string `json:"plaintext,omitempty"`
+}
+
+type DataSourceAiGatewayModelProviderServiceConfigAmazonBedrockDirectServiceCredential struct {
+	Name string `json:"name"`
+}
+
+type DataSourceAiGatewayModelProviderServiceConfigAmazonBedrockDirect struct {
+	AwsAccessKeyId     string                                                                              `json:"aws_access_key_id,omitempty"`
+	AwsSecretAccessKey *DataSourceAiGatewayModelProviderServiceConfigAmazonBedrockDirectAwsSecretAccessKey `json:"aws_secret_access_key,omitempty"`
+	Region             string                                                                              `json:"region,omitempty"`
+	ServiceCredential  *DataSourceAiGatewayModelProviderServiceConfigAmazonBedrockDirectServiceCredential  `json:"service_credential,omitempty"`
+}
+
+type DataSourceAiGatewayModelProviderServiceConfigAmazonBedrock struct {
+	Direct *DataSourceAiGatewayModelProviderServiceConfigAmazonBedrockDirect `json:"direct,omitempty"`
+}
+
+type DataSourceAiGatewayModelProviderServiceConfigAnthropicDirectApiKey struct {
+	Plaintext string `json:"plaintext,omitempty"`
+}
+
+type DataSourceAiGatewayModelProviderServiceConfigAnthropicDirect struct {
+	ApiKey *DataSourceAiGatewayModelProviderServiceConfigAnthropicDirectApiKey `json:"api_key,omitempty"`
+}
+
+type DataSourceAiGatewayModelProviderServiceConfigAnthropicRelayed struct {
+	PlanType string `json:"plan_type,omitempty"`
+}
+
+type DataSourceAiGatewayModelProviderServiceConfigAnthropic struct {
+	Direct  *DataSourceAiGatewayModelProviderServiceConfigAnthropicDirect  `json:"direct,omitempty"`
+	Relayed *DataSourceAiGatewayModelProviderServiceConfigAnthropicRelayed `json:"relayed,omitempty"`
+}
+
+type DataSourceAiGatewayModelProviderServiceConfigAzureOpenaiDirectApiKey struct {
+	Plaintext string `json:"plaintext,omitempty"`
+}
+
+type DataSourceAiGatewayModelProviderServiceConfigAzureOpenaiDirectClientSecret struct {
+	Plaintext string `json:"plaintext,omitempty"`
+}
+
+type DataSourceAiGatewayModelProviderServiceConfigAzureOpenaiDirectServiceCredential struct {
+	Name string `json:"name"`
+}
+
+type DataSourceAiGatewayModelProviderServiceConfigAzureOpenaiDirect struct {
+	ApiKey            *DataSourceAiGatewayModelProviderServiceConfigAzureOpenaiDirectApiKey            `json:"api_key,omitempty"`
+	BaseUrl           string                                                                           `json:"base_url,omitempty"`
+	ClientId          string                                                                           `json:"client_id,omitempty"`
+	ClientSecret      *DataSourceAiGatewayModelProviderServiceConfigAzureOpenaiDirectClientSecret      `json:"client_secret,omitempty"`
+	ServiceCredential *DataSourceAiGatewayModelProviderServiceConfigAzureOpenaiDirectServiceCredential `json:"service_credential,omitempty"`
+	TenantId          string                                                                           `json:"tenant_id,omitempty"`
+}
+
+type DataSourceAiGatewayModelProviderServiceConfigAzureOpenai struct {
+	Direct *DataSourceAiGatewayModelProviderServiceConfigAzureOpenaiDirect `json:"direct,omitempty"`
+}
+
+type DataSourceAiGatewayModelProviderServiceConfigCustomDirectApiKey struct {
+	Plaintext string `json:"plaintext,omitempty"`
+}
+
+type DataSourceAiGatewayModelProviderServiceConfigCustomDirect struct {
+	ApiKey  *DataSourceAiGatewayModelProviderServiceConfigCustomDirectApiKey `json:"api_key,omitempty"`
+	BaseUrl string                                                           `json:"base_url,omitempty"`
+}
+
+type DataSourceAiGatewayModelProviderServiceConfigCustom struct {
+	Direct *DataSourceAiGatewayModelProviderServiceConfigCustomDirect `json:"direct,omitempty"`
+}
+
+type DataSourceAiGatewayModelProviderServiceConfigGeminiEnterpriseDirectApiKey struct {
+	Plaintext string `json:"plaintext,omitempty"`
+}
+
+type DataSourceAiGatewayModelProviderServiceConfigGeminiEnterpriseDirect struct {
+	ApiKey    *DataSourceAiGatewayModelProviderServiceConfigGeminiEnterpriseDirectApiKey `json:"api_key,omitempty"`
+	ProjectId string                                                                     `json:"project_id,omitempty"`
+	Region    string                                                                     `json:"region,omitempty"`
+}
+
+type DataSourceAiGatewayModelProviderServiceConfigGeminiEnterprise struct {
+	Direct *DataSourceAiGatewayModelProviderServiceConfigGeminiEnterpriseDirect `json:"direct,omitempty"`
+}
+
+type DataSourceAiGatewayModelProviderServiceConfigInferenceTable struct {
+	Disabled        bool   `json:"disabled,omitempty"`
+	IsDeleted       bool   `json:"is_deleted,omitempty"`
+	Parent          string `json:"parent"`
+	Table           string `json:"table,omitempty"`
+	TableNamePrefix string `json:"table_name_prefix,omitempty"`
+}
+
+type DataSourceAiGatewayModelProviderServiceConfigMicrosoftFoundryDirectApiKey struct {
+	Plaintext string `json:"plaintext,omitempty"`
+}
+
+type DataSourceAiGatewayModelProviderServiceConfigMicrosoftFoundryDirectClientSecret struct {
+	Plaintext string `json:"plaintext,omitempty"`
+}
+
+type DataSourceAiGatewayModelProviderServiceConfigMicrosoftFoundryDirectServiceCredential struct {
+	Name string `json:"name"`
+}
+
+type DataSourceAiGatewayModelProviderServiceConfigMicrosoftFoundryDirect struct {
+	ApiKey            *DataSourceAiGatewayModelProviderServiceConfigMicrosoftFoundryDirectApiKey            `json:"api_key,omitempty"`
+	BaseUrl           string                                                                                `json:"base_url,omitempty"`
+	ClientId          string                                                                                `json:"client_id,omitempty"`
+	ClientSecret      *DataSourceAiGatewayModelProviderServiceConfigMicrosoftFoundryDirectClientSecret      `json:"client_secret,omitempty"`
+	ServiceCredential *DataSourceAiGatewayModelProviderServiceConfigMicrosoftFoundryDirectServiceCredential `json:"service_credential,omitempty"`
+	TenantId          string                                                                                `json:"tenant_id,omitempty"`
+}
+
+type DataSourceAiGatewayModelProviderServiceConfigMicrosoftFoundry struct {
+	Direct *DataSourceAiGatewayModelProviderServiceConfigMicrosoftFoundryDirect `json:"direct,omitempty"`
+}
+
+type DataSourceAiGatewayModelProviderServiceConfigOpenaiDirectApiKey struct {
+	Plaintext string `json:"plaintext,omitempty"`
+}
+
+type DataSourceAiGatewayModelProviderServiceConfigOpenaiDirect struct {
+	ApiKey       *DataSourceAiGatewayModelProviderServiceConfigOpenaiDirectApiKey `json:"api_key,omitempty"`
+	BaseUrl      string                                                           `json:"base_url,omitempty"`
+	Organization string                                                           `json:"organization,omitempty"`
+}
+
+type DataSourceAiGatewayModelProviderServiceConfigOpenai struct {
+	Direct *DataSourceAiGatewayModelProviderServiceConfigOpenaiDirect `json:"direct,omitempty"`
+}
+
+type DataSourceAiGatewayModelProviderServiceConfigRateLimits struct {
+	Key             string `json:"key"`
+	Principal       string `json:"principal,omitempty"`
+	RenewalPeriod   string `json:"renewal_period"`
+	RequestTagKey   string `json:"request_tag_key,omitempty"`
+	RequestTagValue string `json:"request_tag_value,omitempty"`
+	Requests        int    `json:"requests,omitempty"`
+	Tokens          int    `json:"tokens,omitempty"`
+}
+
+type DataSourceAiGatewayModelProviderServiceConfigTargets struct {
+	Model          string   `json:"model"`
+	NativeApiTypes []string `json:"native_api_types,omitempty"`
+}
+
+type DataSourceAiGatewayModelProviderServiceConfig struct {
+	AllowAllTargets        bool                                                           `json:"allow_all_targets,omitempty"`
+	AmazonBedrock          *DataSourceAiGatewayModelProviderServiceConfigAmazonBedrock    `json:"amazon_bedrock,omitempty"`
+	Anthropic              *DataSourceAiGatewayModelProviderServiceConfigAnthropic        `json:"anthropic,omitempty"`
+	AzureOpenai            *DataSourceAiGatewayModelProviderServiceConfigAzureOpenai      `json:"azure_openai,omitempty"`
+	Custom                 *DataSourceAiGatewayModelProviderServiceConfigCustom           `json:"custom,omitempty"`
+	ForwardHeaders         bool                                                           `json:"forward_headers,omitempty"`
+	ForwardQueryParameters bool                                                           `json:"forward_query_parameters,omitempty"`
+	ForwardUnmanagedPaths  bool                                                           `json:"forward_unmanaged_paths,omitempty"`
+	GeminiEnterprise       *DataSourceAiGatewayModelProviderServiceConfigGeminiEnterprise `json:"gemini_enterprise,omitempty"`
+	InferenceTable         *DataSourceAiGatewayModelProviderServiceConfigInferenceTable   `json:"inference_table,omitempty"`
+	MicrosoftFoundry       *DataSourceAiGatewayModelProviderServiceConfigMicrosoftFoundry `json:"microsoft_foundry,omitempty"`
+	Openai                 *DataSourceAiGatewayModelProviderServiceConfigOpenai           `json:"openai,omitempty"`
+	ProviderType           string                                                         `json:"provider_type,omitempty"`
+	RateLimits             []DataSourceAiGatewayModelProviderServiceConfigRateLimits      `json:"rate_limits,omitempty"`
+	Targets                []DataSourceAiGatewayModelProviderServiceConfigTargets         `json:"targets,omitempty"`
+}
+
+type DataSourceAiGatewayModelProviderServiceProviderConfig struct {
+	WorkspaceId string `json:"workspace_id,omitempty"`
+}
+
+type DataSourceAiGatewayModelProviderService struct {
+	BrowseOnly     bool                                                   `json:"browse_only,omitempty"`
+	Comment        string                                                 `json:"comment,omitempty"`
+	Config         *DataSourceAiGatewayModelProviderServiceConfig         `json:"config,omitempty"`
+	CreateTime     string                                                 `json:"create_time,omitempty"`
+	CreatedBy      string                                                 `json:"created_by,omitempty"`
+	EffectiveOwner string                                                 `json:"effective_owner,omitempty"`
+	Etag           string                                                 `json:"etag,omitempty"`
+	MetastoreId    string                                                 `json:"metastore_id,omitempty"`
+	Name           string                                                 `json:"name"`
+	Owner          string                                                 `json:"owner,omitempty"`
+	ProviderConfig *DataSourceAiGatewayModelProviderServiceProviderConfig `json:"provider_config,omitempty"`
+	UpdateTime     string                                                 `json:"update_time,omitempty"`
+	UpdatedBy      string                                                 `json:"updated_by,omitempty"`
+}

--- a/bundle/internal/tf/schema/data_source_ai_gateway_model_provider_services.go
+++ b/bundle/internal/tf/schema/data_source_ai_gateway_model_provider_services.go
@@ -1,0 +1,204 @@
+// Generated from Databricks Terraform provider schema. DO NOT EDIT.
+
+package schema
+
+type DataSourceAiGatewayModelProviderServicesModelProviderServicesConfigAmazonBedrockDirectAwsSecretAccessKey struct {
+	Plaintext string `json:"plaintext,omitempty"`
+}
+
+type DataSourceAiGatewayModelProviderServicesModelProviderServicesConfigAmazonBedrockDirectServiceCredential struct {
+	Name string `json:"name"`
+}
+
+type DataSourceAiGatewayModelProviderServicesModelProviderServicesConfigAmazonBedrockDirect struct {
+	AwsAccessKeyId     string                                                                                                    `json:"aws_access_key_id,omitempty"`
+	AwsSecretAccessKey *DataSourceAiGatewayModelProviderServicesModelProviderServicesConfigAmazonBedrockDirectAwsSecretAccessKey `json:"aws_secret_access_key,omitempty"`
+	Region             string                                                                                                    `json:"region,omitempty"`
+	ServiceCredential  *DataSourceAiGatewayModelProviderServicesModelProviderServicesConfigAmazonBedrockDirectServiceCredential  `json:"service_credential,omitempty"`
+}
+
+type DataSourceAiGatewayModelProviderServicesModelProviderServicesConfigAmazonBedrock struct {
+	Direct *DataSourceAiGatewayModelProviderServicesModelProviderServicesConfigAmazonBedrockDirect `json:"direct,omitempty"`
+}
+
+type DataSourceAiGatewayModelProviderServicesModelProviderServicesConfigAnthropicDirectApiKey struct {
+	Plaintext string `json:"plaintext,omitempty"`
+}
+
+type DataSourceAiGatewayModelProviderServicesModelProviderServicesConfigAnthropicDirect struct {
+	ApiKey *DataSourceAiGatewayModelProviderServicesModelProviderServicesConfigAnthropicDirectApiKey `json:"api_key,omitempty"`
+}
+
+type DataSourceAiGatewayModelProviderServicesModelProviderServicesConfigAnthropicRelayed struct {
+	PlanType string `json:"plan_type,omitempty"`
+}
+
+type DataSourceAiGatewayModelProviderServicesModelProviderServicesConfigAnthropic struct {
+	Direct  *DataSourceAiGatewayModelProviderServicesModelProviderServicesConfigAnthropicDirect  `json:"direct,omitempty"`
+	Relayed *DataSourceAiGatewayModelProviderServicesModelProviderServicesConfigAnthropicRelayed `json:"relayed,omitempty"`
+}
+
+type DataSourceAiGatewayModelProviderServicesModelProviderServicesConfigAzureOpenaiDirectApiKey struct {
+	Plaintext string `json:"plaintext,omitempty"`
+}
+
+type DataSourceAiGatewayModelProviderServicesModelProviderServicesConfigAzureOpenaiDirectClientSecret struct {
+	Plaintext string `json:"plaintext,omitempty"`
+}
+
+type DataSourceAiGatewayModelProviderServicesModelProviderServicesConfigAzureOpenaiDirectServiceCredential struct {
+	Name string `json:"name"`
+}
+
+type DataSourceAiGatewayModelProviderServicesModelProviderServicesConfigAzureOpenaiDirect struct {
+	ApiKey            *DataSourceAiGatewayModelProviderServicesModelProviderServicesConfigAzureOpenaiDirectApiKey            `json:"api_key,omitempty"`
+	BaseUrl           string                                                                                                 `json:"base_url,omitempty"`
+	ClientId          string                                                                                                 `json:"client_id,omitempty"`
+	ClientSecret      *DataSourceAiGatewayModelProviderServicesModelProviderServicesConfigAzureOpenaiDirectClientSecret      `json:"client_secret,omitempty"`
+	ServiceCredential *DataSourceAiGatewayModelProviderServicesModelProviderServicesConfigAzureOpenaiDirectServiceCredential `json:"service_credential,omitempty"`
+	TenantId          string                                                                                                 `json:"tenant_id,omitempty"`
+}
+
+type DataSourceAiGatewayModelProviderServicesModelProviderServicesConfigAzureOpenai struct {
+	Direct *DataSourceAiGatewayModelProviderServicesModelProviderServicesConfigAzureOpenaiDirect `json:"direct,omitempty"`
+}
+
+type DataSourceAiGatewayModelProviderServicesModelProviderServicesConfigCustomDirectApiKey struct {
+	Plaintext string `json:"plaintext,omitempty"`
+}
+
+type DataSourceAiGatewayModelProviderServicesModelProviderServicesConfigCustomDirect struct {
+	ApiKey  *DataSourceAiGatewayModelProviderServicesModelProviderServicesConfigCustomDirectApiKey `json:"api_key,omitempty"`
+	BaseUrl string                                                                                 `json:"base_url,omitempty"`
+}
+
+type DataSourceAiGatewayModelProviderServicesModelProviderServicesConfigCustom struct {
+	Direct *DataSourceAiGatewayModelProviderServicesModelProviderServicesConfigCustomDirect `json:"direct,omitempty"`
+}
+
+type DataSourceAiGatewayModelProviderServicesModelProviderServicesConfigGeminiEnterpriseDirectApiKey struct {
+	Plaintext string `json:"plaintext,omitempty"`
+}
+
+type DataSourceAiGatewayModelProviderServicesModelProviderServicesConfigGeminiEnterpriseDirect struct {
+	ApiKey    *DataSourceAiGatewayModelProviderServicesModelProviderServicesConfigGeminiEnterpriseDirectApiKey `json:"api_key,omitempty"`
+	ProjectId string                                                                                           `json:"project_id,omitempty"`
+	Region    string                                                                                           `json:"region,omitempty"`
+}
+
+type DataSourceAiGatewayModelProviderServicesModelProviderServicesConfigGeminiEnterprise struct {
+	Direct *DataSourceAiGatewayModelProviderServicesModelProviderServicesConfigGeminiEnterpriseDirect `json:"direct,omitempty"`
+}
+
+type DataSourceAiGatewayModelProviderServicesModelProviderServicesConfigInferenceTable struct {
+	Disabled        bool   `json:"disabled,omitempty"`
+	IsDeleted       bool   `json:"is_deleted,omitempty"`
+	Parent          string `json:"parent"`
+	Table           string `json:"table,omitempty"`
+	TableNamePrefix string `json:"table_name_prefix,omitempty"`
+}
+
+type DataSourceAiGatewayModelProviderServicesModelProviderServicesConfigMicrosoftFoundryDirectApiKey struct {
+	Plaintext string `json:"plaintext,omitempty"`
+}
+
+type DataSourceAiGatewayModelProviderServicesModelProviderServicesConfigMicrosoftFoundryDirectClientSecret struct {
+	Plaintext string `json:"plaintext,omitempty"`
+}
+
+type DataSourceAiGatewayModelProviderServicesModelProviderServicesConfigMicrosoftFoundryDirectServiceCredential struct {
+	Name string `json:"name"`
+}
+
+type DataSourceAiGatewayModelProviderServicesModelProviderServicesConfigMicrosoftFoundryDirect struct {
+	ApiKey            *DataSourceAiGatewayModelProviderServicesModelProviderServicesConfigMicrosoftFoundryDirectApiKey            `json:"api_key,omitempty"`
+	BaseUrl           string                                                                                                      `json:"base_url,omitempty"`
+	ClientId          string                                                                                                      `json:"client_id,omitempty"`
+	ClientSecret      *DataSourceAiGatewayModelProviderServicesModelProviderServicesConfigMicrosoftFoundryDirectClientSecret      `json:"client_secret,omitempty"`
+	ServiceCredential *DataSourceAiGatewayModelProviderServicesModelProviderServicesConfigMicrosoftFoundryDirectServiceCredential `json:"service_credential,omitempty"`
+	TenantId          string                                                                                                      `json:"tenant_id,omitempty"`
+}
+
+type DataSourceAiGatewayModelProviderServicesModelProviderServicesConfigMicrosoftFoundry struct {
+	Direct *DataSourceAiGatewayModelProviderServicesModelProviderServicesConfigMicrosoftFoundryDirect `json:"direct,omitempty"`
+}
+
+type DataSourceAiGatewayModelProviderServicesModelProviderServicesConfigOpenaiDirectApiKey struct {
+	Plaintext string `json:"plaintext,omitempty"`
+}
+
+type DataSourceAiGatewayModelProviderServicesModelProviderServicesConfigOpenaiDirect struct {
+	ApiKey       *DataSourceAiGatewayModelProviderServicesModelProviderServicesConfigOpenaiDirectApiKey `json:"api_key,omitempty"`
+	BaseUrl      string                                                                                 `json:"base_url,omitempty"`
+	Organization string                                                                                 `json:"organization,omitempty"`
+}
+
+type DataSourceAiGatewayModelProviderServicesModelProviderServicesConfigOpenai struct {
+	Direct *DataSourceAiGatewayModelProviderServicesModelProviderServicesConfigOpenaiDirect `json:"direct,omitempty"`
+}
+
+type DataSourceAiGatewayModelProviderServicesModelProviderServicesConfigRateLimits struct {
+	Key             string `json:"key"`
+	Principal       string `json:"principal,omitempty"`
+	RenewalPeriod   string `json:"renewal_period"`
+	RequestTagKey   string `json:"request_tag_key,omitempty"`
+	RequestTagValue string `json:"request_tag_value,omitempty"`
+	Requests        int    `json:"requests,omitempty"`
+	Tokens          int    `json:"tokens,omitempty"`
+}
+
+type DataSourceAiGatewayModelProviderServicesModelProviderServicesConfigTargets struct {
+	Model          string   `json:"model"`
+	NativeApiTypes []string `json:"native_api_types,omitempty"`
+}
+
+type DataSourceAiGatewayModelProviderServicesModelProviderServicesConfig struct {
+	AllowAllTargets        bool                                                                                 `json:"allow_all_targets,omitempty"`
+	AmazonBedrock          *DataSourceAiGatewayModelProviderServicesModelProviderServicesConfigAmazonBedrock    `json:"amazon_bedrock,omitempty"`
+	Anthropic              *DataSourceAiGatewayModelProviderServicesModelProviderServicesConfigAnthropic        `json:"anthropic,omitempty"`
+	AzureOpenai            *DataSourceAiGatewayModelProviderServicesModelProviderServicesConfigAzureOpenai      `json:"azure_openai,omitempty"`
+	Custom                 *DataSourceAiGatewayModelProviderServicesModelProviderServicesConfigCustom           `json:"custom,omitempty"`
+	ForwardHeaders         bool                                                                                 `json:"forward_headers,omitempty"`
+	ForwardQueryParameters bool                                                                                 `json:"forward_query_parameters,omitempty"`
+	ForwardUnmanagedPaths  bool                                                                                 `json:"forward_unmanaged_paths,omitempty"`
+	GeminiEnterprise       *DataSourceAiGatewayModelProviderServicesModelProviderServicesConfigGeminiEnterprise `json:"gemini_enterprise,omitempty"`
+	InferenceTable         *DataSourceAiGatewayModelProviderServicesModelProviderServicesConfigInferenceTable   `json:"inference_table,omitempty"`
+	MicrosoftFoundry       *DataSourceAiGatewayModelProviderServicesModelProviderServicesConfigMicrosoftFoundry `json:"microsoft_foundry,omitempty"`
+	Openai                 *DataSourceAiGatewayModelProviderServicesModelProviderServicesConfigOpenai           `json:"openai,omitempty"`
+	ProviderType           string                                                                               `json:"provider_type,omitempty"`
+	RateLimits             []DataSourceAiGatewayModelProviderServicesModelProviderServicesConfigRateLimits      `json:"rate_limits,omitempty"`
+	Targets                []DataSourceAiGatewayModelProviderServicesModelProviderServicesConfigTargets         `json:"targets,omitempty"`
+}
+
+type DataSourceAiGatewayModelProviderServicesModelProviderServicesProviderConfig struct {
+	WorkspaceId string `json:"workspace_id,omitempty"`
+}
+
+type DataSourceAiGatewayModelProviderServicesModelProviderServices struct {
+	BrowseOnly     bool                                                                         `json:"browse_only,omitempty"`
+	Comment        string                                                                       `json:"comment,omitempty"`
+	Config         *DataSourceAiGatewayModelProviderServicesModelProviderServicesConfig         `json:"config,omitempty"`
+	CreateTime     string                                                                       `json:"create_time,omitempty"`
+	CreatedBy      string                                                                       `json:"created_by,omitempty"`
+	EffectiveOwner string                                                                       `json:"effective_owner,omitempty"`
+	Etag           string                                                                       `json:"etag,omitempty"`
+	MetastoreId    string                                                                       `json:"metastore_id,omitempty"`
+	Name           string                                                                       `json:"name"`
+	Owner          string                                                                       `json:"owner,omitempty"`
+	ProviderConfig *DataSourceAiGatewayModelProviderServicesModelProviderServicesProviderConfig `json:"provider_config,omitempty"`
+	UpdateTime     string                                                                       `json:"update_time,omitempty"`
+	UpdatedBy      string                                                                       `json:"updated_by,omitempty"`
+}
+
+type DataSourceAiGatewayModelProviderServicesProviderConfig struct {
+	WorkspaceId string `json:"workspace_id,omitempty"`
+}
+
+type DataSourceAiGatewayModelProviderServices struct {
+	IncludeBrowse         bool                                                            `json:"include_browse,omitempty"`
+	ModelProviderServices []DataSourceAiGatewayModelProviderServicesModelProviderServices `json:"model_provider_services,omitempty"`
+	PageSize              int                                                             `json:"page_size,omitempty"`
+	Parent                string                                                          `json:"parent,omitempty"`
+	ProviderConfig        *DataSourceAiGatewayModelProviderServicesProviderConfig         `json:"provider_config,omitempty"`
+	View                  string                                                          `json:"view,omitempty"`
+}

--- a/bundle/internal/tf/schema/data_source_ai_gateway_model_service.go
+++ b/bundle/internal/tf/schema/data_source_ai_gateway_model_service.go
@@ -1,0 +1,119 @@
+// Generated from Databricks Terraform provider schema. DO NOT EDIT.
+
+package schema
+
+type DataSourceAiGatewayModelServiceConfigInferenceTable struct {
+	Disabled        bool   `json:"disabled,omitempty"`
+	IsDeleted       bool   `json:"is_deleted,omitempty"`
+	Parent          string `json:"parent"`
+	Table           string `json:"table,omitempty"`
+	TableNamePrefix string `json:"table_name_prefix,omitempty"`
+}
+
+type DataSourceAiGatewayModelServiceConfigRateLimits struct {
+	Key             string `json:"key"`
+	Principal       string `json:"principal,omitempty"`
+	RenewalPeriod   string `json:"renewal_period"`
+	RequestTagKey   string `json:"request_tag_key,omitempty"`
+	RequestTagValue string `json:"request_tag_value,omitempty"`
+	Requests        int    `json:"requests,omitempty"`
+	Tokens          int    `json:"tokens,omitempty"`
+}
+
+type DataSourceAiGatewayModelServiceConfigRoutingDestinationsExternalModelConfigTarget struct {
+	Model          string   `json:"model"`
+	NativeApiTypes []string `json:"native_api_types,omitempty"`
+}
+
+type DataSourceAiGatewayModelServiceConfigRoutingDestinationsExternalModelConfig struct {
+	ModelProviderService string                                                                             `json:"model_provider_service"`
+	Target               *DataSourceAiGatewayModelServiceConfigRoutingDestinationsExternalModelConfigTarget `json:"target,omitempty"`
+}
+
+type DataSourceAiGatewayModelServiceConfigRoutingDestinationsPayPerTokenConfig struct {
+	Model string `json:"model"`
+}
+
+type DataSourceAiGatewayModelServiceConfigRoutingDestinationsProvisionedThroughputConfig struct {
+	Model                string `json:"model,omitempty"`
+	ModelServingEndpoint string `json:"model_serving_endpoint"`
+}
+
+type DataSourceAiGatewayModelServiceConfigRoutingDestinations struct {
+	DestinationType             string                                                                               `json:"destination_type"`
+	ExternalModelConfig         *DataSourceAiGatewayModelServiceConfigRoutingDestinationsExternalModelConfig         `json:"external_model_config,omitempty"`
+	IsDeleted                   bool                                                                                 `json:"is_deleted,omitempty"`
+	Name                        string                                                                               `json:"name"`
+	PayPerTokenConfig           *DataSourceAiGatewayModelServiceConfigRoutingDestinationsPayPerTokenConfig           `json:"pay_per_token_config,omitempty"`
+	ProvisionedThroughputConfig *DataSourceAiGatewayModelServiceConfigRoutingDestinationsProvisionedThroughputConfig `json:"provisioned_throughput_config,omitempty"`
+	TrafficPercentage           int                                                                                  `json:"traffic_percentage,omitempty"`
+}
+
+type DataSourceAiGatewayModelServiceConfigRoutingFallbackDestinationsExternalModelConfigTarget struct {
+	Model          string   `json:"model"`
+	NativeApiTypes []string `json:"native_api_types,omitempty"`
+}
+
+type DataSourceAiGatewayModelServiceConfigRoutingFallbackDestinationsExternalModelConfig struct {
+	ModelProviderService string                                                                                     `json:"model_provider_service"`
+	Target               *DataSourceAiGatewayModelServiceConfigRoutingFallbackDestinationsExternalModelConfigTarget `json:"target,omitempty"`
+}
+
+type DataSourceAiGatewayModelServiceConfigRoutingFallbackDestinationsPayPerTokenConfig struct {
+	Model string `json:"model"`
+}
+
+type DataSourceAiGatewayModelServiceConfigRoutingFallbackDestinationsProvisionedThroughputConfig struct {
+	Model                string `json:"model,omitempty"`
+	ModelServingEndpoint string `json:"model_serving_endpoint"`
+}
+
+type DataSourceAiGatewayModelServiceConfigRoutingFallbackDestinations struct {
+	DestinationType             string                                                                                       `json:"destination_type"`
+	ExternalModelConfig         *DataSourceAiGatewayModelServiceConfigRoutingFallbackDestinationsExternalModelConfig         `json:"external_model_config,omitempty"`
+	IsDeleted                   bool                                                                                         `json:"is_deleted,omitempty"`
+	Name                        string                                                                                       `json:"name"`
+	PayPerTokenConfig           *DataSourceAiGatewayModelServiceConfigRoutingFallbackDestinationsPayPerTokenConfig           `json:"pay_per_token_config,omitempty"`
+	ProvisionedThroughputConfig *DataSourceAiGatewayModelServiceConfigRoutingFallbackDestinationsProvisionedThroughputConfig `json:"provisioned_throughput_config,omitempty"`
+	TrafficPercentage           int                                                                                          `json:"traffic_percentage,omitempty"`
+}
+
+type DataSourceAiGatewayModelServiceConfigRoutingFallback struct {
+	Destinations []DataSourceAiGatewayModelServiceConfigRoutingFallbackDestinations `json:"destinations,omitempty"`
+}
+
+type DataSourceAiGatewayModelServiceConfigRoutingTrafficSplitting struct{}
+
+type DataSourceAiGatewayModelServiceConfigRouting struct {
+	Destinations      []DataSourceAiGatewayModelServiceConfigRoutingDestinations    `json:"destinations,omitempty"`
+	Fallback          *DataSourceAiGatewayModelServiceConfigRoutingFallback         `json:"fallback,omitempty"`
+	FirstTokenTimeout string                                                        `json:"first_token_timeout,omitempty"`
+	TrafficSplitting  *DataSourceAiGatewayModelServiceConfigRoutingTrafficSplitting `json:"traffic_splitting,omitempty"`
+}
+
+type DataSourceAiGatewayModelServiceConfig struct {
+	InferenceTable *DataSourceAiGatewayModelServiceConfigInferenceTable `json:"inference_table,omitempty"`
+	RateLimits     []DataSourceAiGatewayModelServiceConfigRateLimits    `json:"rate_limits,omitempty"`
+	Routing        *DataSourceAiGatewayModelServiceConfigRouting        `json:"routing,omitempty"`
+}
+
+type DataSourceAiGatewayModelServiceProviderConfig struct {
+	WorkspaceId string `json:"workspace_id,omitempty"`
+}
+
+type DataSourceAiGatewayModelService struct {
+	BrowseOnly        bool                                           `json:"browse_only,omitempty"`
+	Comment           string                                         `json:"comment,omitempty"`
+	Config            *DataSourceAiGatewayModelServiceConfig         `json:"config,omitempty"`
+	CreateTime        string                                         `json:"create_time,omitempty"`
+	CreatedBy         string                                         `json:"created_by,omitempty"`
+	EffectiveOwner    string                                         `json:"effective_owner,omitempty"`
+	Etag              string                                         `json:"etag,omitempty"`
+	MetastoreId       string                                         `json:"metastore_id,omitempty"`
+	Name              string                                         `json:"name"`
+	Owner             string                                         `json:"owner,omitempty"`
+	ProviderConfig    *DataSourceAiGatewayModelServiceProviderConfig `json:"provider_config,omitempty"`
+	SupportedApiTypes []string                                       `json:"supported_api_types,omitempty"`
+	UpdateTime        string                                         `json:"update_time,omitempty"`
+	UpdatedBy         string                                         `json:"updated_by,omitempty"`
+}

--- a/bundle/internal/tf/schema/data_source_ai_gateway_model_services.go
+++ b/bundle/internal/tf/schema/data_source_ai_gateway_model_services.go
@@ -1,0 +1,132 @@
+// Generated from Databricks Terraform provider schema. DO NOT EDIT.
+
+package schema
+
+type DataSourceAiGatewayModelServicesModelServicesConfigInferenceTable struct {
+	Disabled        bool   `json:"disabled,omitempty"`
+	IsDeleted       bool   `json:"is_deleted,omitempty"`
+	Parent          string `json:"parent"`
+	Table           string `json:"table,omitempty"`
+	TableNamePrefix string `json:"table_name_prefix,omitempty"`
+}
+
+type DataSourceAiGatewayModelServicesModelServicesConfigRateLimits struct {
+	Key             string `json:"key"`
+	Principal       string `json:"principal,omitempty"`
+	RenewalPeriod   string `json:"renewal_period"`
+	RequestTagKey   string `json:"request_tag_key,omitempty"`
+	RequestTagValue string `json:"request_tag_value,omitempty"`
+	Requests        int    `json:"requests,omitempty"`
+	Tokens          int    `json:"tokens,omitempty"`
+}
+
+type DataSourceAiGatewayModelServicesModelServicesConfigRoutingDestinationsExternalModelConfigTarget struct {
+	Model          string   `json:"model"`
+	NativeApiTypes []string `json:"native_api_types,omitempty"`
+}
+
+type DataSourceAiGatewayModelServicesModelServicesConfigRoutingDestinationsExternalModelConfig struct {
+	ModelProviderService string                                                                                           `json:"model_provider_service"`
+	Target               *DataSourceAiGatewayModelServicesModelServicesConfigRoutingDestinationsExternalModelConfigTarget `json:"target,omitempty"`
+}
+
+type DataSourceAiGatewayModelServicesModelServicesConfigRoutingDestinationsPayPerTokenConfig struct {
+	Model string `json:"model"`
+}
+
+type DataSourceAiGatewayModelServicesModelServicesConfigRoutingDestinationsProvisionedThroughputConfig struct {
+	Model                string `json:"model,omitempty"`
+	ModelServingEndpoint string `json:"model_serving_endpoint"`
+}
+
+type DataSourceAiGatewayModelServicesModelServicesConfigRoutingDestinations struct {
+	DestinationType             string                                                                                             `json:"destination_type"`
+	ExternalModelConfig         *DataSourceAiGatewayModelServicesModelServicesConfigRoutingDestinationsExternalModelConfig         `json:"external_model_config,omitempty"`
+	IsDeleted                   bool                                                                                               `json:"is_deleted,omitempty"`
+	Name                        string                                                                                             `json:"name"`
+	PayPerTokenConfig           *DataSourceAiGatewayModelServicesModelServicesConfigRoutingDestinationsPayPerTokenConfig           `json:"pay_per_token_config,omitempty"`
+	ProvisionedThroughputConfig *DataSourceAiGatewayModelServicesModelServicesConfigRoutingDestinationsProvisionedThroughputConfig `json:"provisioned_throughput_config,omitempty"`
+	TrafficPercentage           int                                                                                                `json:"traffic_percentage,omitempty"`
+}
+
+type DataSourceAiGatewayModelServicesModelServicesConfigRoutingFallbackDestinationsExternalModelConfigTarget struct {
+	Model          string   `json:"model"`
+	NativeApiTypes []string `json:"native_api_types,omitempty"`
+}
+
+type DataSourceAiGatewayModelServicesModelServicesConfigRoutingFallbackDestinationsExternalModelConfig struct {
+	ModelProviderService string                                                                                                   `json:"model_provider_service"`
+	Target               *DataSourceAiGatewayModelServicesModelServicesConfigRoutingFallbackDestinationsExternalModelConfigTarget `json:"target,omitempty"`
+}
+
+type DataSourceAiGatewayModelServicesModelServicesConfigRoutingFallbackDestinationsPayPerTokenConfig struct {
+	Model string `json:"model"`
+}
+
+type DataSourceAiGatewayModelServicesModelServicesConfigRoutingFallbackDestinationsProvisionedThroughputConfig struct {
+	Model                string `json:"model,omitempty"`
+	ModelServingEndpoint string `json:"model_serving_endpoint"`
+}
+
+type DataSourceAiGatewayModelServicesModelServicesConfigRoutingFallbackDestinations struct {
+	DestinationType             string                                                                                                     `json:"destination_type"`
+	ExternalModelConfig         *DataSourceAiGatewayModelServicesModelServicesConfigRoutingFallbackDestinationsExternalModelConfig         `json:"external_model_config,omitempty"`
+	IsDeleted                   bool                                                                                                       `json:"is_deleted,omitempty"`
+	Name                        string                                                                                                     `json:"name"`
+	PayPerTokenConfig           *DataSourceAiGatewayModelServicesModelServicesConfigRoutingFallbackDestinationsPayPerTokenConfig           `json:"pay_per_token_config,omitempty"`
+	ProvisionedThroughputConfig *DataSourceAiGatewayModelServicesModelServicesConfigRoutingFallbackDestinationsProvisionedThroughputConfig `json:"provisioned_throughput_config,omitempty"`
+	TrafficPercentage           int                                                                                                        `json:"traffic_percentage,omitempty"`
+}
+
+type DataSourceAiGatewayModelServicesModelServicesConfigRoutingFallback struct {
+	Destinations []DataSourceAiGatewayModelServicesModelServicesConfigRoutingFallbackDestinations `json:"destinations,omitempty"`
+}
+
+type DataSourceAiGatewayModelServicesModelServicesConfigRoutingTrafficSplitting struct{}
+
+type DataSourceAiGatewayModelServicesModelServicesConfigRouting struct {
+	Destinations      []DataSourceAiGatewayModelServicesModelServicesConfigRoutingDestinations    `json:"destinations,omitempty"`
+	Fallback          *DataSourceAiGatewayModelServicesModelServicesConfigRoutingFallback         `json:"fallback,omitempty"`
+	FirstTokenTimeout string                                                                      `json:"first_token_timeout,omitempty"`
+	TrafficSplitting  *DataSourceAiGatewayModelServicesModelServicesConfigRoutingTrafficSplitting `json:"traffic_splitting,omitempty"`
+}
+
+type DataSourceAiGatewayModelServicesModelServicesConfig struct {
+	InferenceTable *DataSourceAiGatewayModelServicesModelServicesConfigInferenceTable `json:"inference_table,omitempty"`
+	RateLimits     []DataSourceAiGatewayModelServicesModelServicesConfigRateLimits    `json:"rate_limits,omitempty"`
+	Routing        *DataSourceAiGatewayModelServicesModelServicesConfigRouting        `json:"routing,omitempty"`
+}
+
+type DataSourceAiGatewayModelServicesModelServicesProviderConfig struct {
+	WorkspaceId string `json:"workspace_id,omitempty"`
+}
+
+type DataSourceAiGatewayModelServicesModelServices struct {
+	BrowseOnly        bool                                                         `json:"browse_only,omitempty"`
+	Comment           string                                                       `json:"comment,omitempty"`
+	Config            *DataSourceAiGatewayModelServicesModelServicesConfig         `json:"config,omitempty"`
+	CreateTime        string                                                       `json:"create_time,omitempty"`
+	CreatedBy         string                                                       `json:"created_by,omitempty"`
+	EffectiveOwner    string                                                       `json:"effective_owner,omitempty"`
+	Etag              string                                                       `json:"etag,omitempty"`
+	MetastoreId       string                                                       `json:"metastore_id,omitempty"`
+	Name              string                                                       `json:"name"`
+	Owner             string                                                       `json:"owner,omitempty"`
+	ProviderConfig    *DataSourceAiGatewayModelServicesModelServicesProviderConfig `json:"provider_config,omitempty"`
+	SupportedApiTypes []string                                                     `json:"supported_api_types,omitempty"`
+	UpdateTime        string                                                       `json:"update_time,omitempty"`
+	UpdatedBy         string                                                       `json:"updated_by,omitempty"`
+}
+
+type DataSourceAiGatewayModelServicesProviderConfig struct {
+	WorkspaceId string `json:"workspace_id,omitempty"`
+}
+
+type DataSourceAiGatewayModelServices struct {
+	IncludeBrowse  bool                                            `json:"include_browse,omitempty"`
+	ModelServices  []DataSourceAiGatewayModelServicesModelServices `json:"model_services,omitempty"`
+	PageSize       int                                             `json:"page_size,omitempty"`
+	Parent         string                                          `json:"parent,omitempty"`
+	ProviderConfig *DataSourceAiGatewayModelServicesProviderConfig `json:"provider_config,omitempty"`
+	View           string                                          `json:"view,omitempty"`
+}

--- a/bundle/internal/tf/schema/data_sources.go
+++ b/bundle/internal/tf/schema/data_sources.go
@@ -9,6 +9,12 @@ type DataSources struct {
 	AccountNetworkPolicy                        map[string]any `json:"databricks_account_network_policy,omitempty"`
 	AccountSettingUserPreferenceV2              map[string]any `json:"databricks_account_setting_user_preference_v2,omitempty"`
 	AccountSettingV2                            map[string]any `json:"databricks_account_setting_v2,omitempty"`
+	AiGatewayMcpService                         map[string]any `json:"databricks_ai_gateway_mcp_service,omitempty"`
+	AiGatewayMcpServices                        map[string]any `json:"databricks_ai_gateway_mcp_services,omitempty"`
+	AiGatewayModelProviderService               map[string]any `json:"databricks_ai_gateway_model_provider_service,omitempty"`
+	AiGatewayModelProviderServices              map[string]any `json:"databricks_ai_gateway_model_provider_services,omitempty"`
+	AiGatewayModelService                       map[string]any `json:"databricks_ai_gateway_model_service,omitempty"`
+	AiGatewayModelServices                      map[string]any `json:"databricks_ai_gateway_model_services,omitempty"`
 	AiSearchEndpoint                            map[string]any `json:"databricks_ai_search_endpoint,omitempty"`
 	AiSearchEndpoints                           map[string]any `json:"databricks_ai_search_endpoints,omitempty"`
 	AiSearchIndex                               map[string]any `json:"databricks_ai_search_index,omitempty"`
@@ -171,6 +177,12 @@ func NewDataSources() *DataSources {
 		AccountNetworkPolicy:            make(map[string]any),
 		AccountSettingUserPreferenceV2:  make(map[string]any),
 		AccountSettingV2:                make(map[string]any),
+		AiGatewayMcpService:             make(map[string]any),
+		AiGatewayMcpServices:            make(map[string]any),
+		AiGatewayModelProviderService:   make(map[string]any),
+		AiGatewayModelProviderServices:  make(map[string]any),
+		AiGatewayModelService:           make(map[string]any),
+		AiGatewayModelServices:          make(map[string]any),
 		AiSearchEndpoint:                make(map[string]any),
 		AiSearchEndpoints:               make(map[string]any),
 		AiSearchIndex:                   make(map[string]any),

--- a/bundle/internal/tf/schema/resource_ai_gateway_mcp_service.go
+++ b/bundle/internal/tf/schema/resource_ai_gateway_mcp_service.go
@@ -1,0 +1,46 @@
+// Generated from Databricks Terraform provider schema. DO NOT EDIT.
+
+package schema
+
+type ResourceAiGatewayMcpServiceConfigRateLimits struct {
+	Key             string `json:"key"`
+	Principal       string `json:"principal,omitempty"`
+	RenewalPeriod   string `json:"renewal_period"`
+	RequestTagKey   string `json:"request_tag_key,omitempty"`
+	RequestTagValue string `json:"request_tag_value,omitempty"`
+	Requests        int    `json:"requests,omitempty"`
+	Tokens          int    `json:"tokens,omitempty"`
+}
+
+type ResourceAiGatewayMcpServiceConfigSourceConnection struct {
+	IsDeleted bool   `json:"is_deleted,omitempty"`
+	Name      string `json:"name"`
+}
+
+type ResourceAiGatewayMcpServiceConfig struct {
+	IncludeToolSelectors []string                                           `json:"include_tool_selectors,omitempty"`
+	RateLimits           []ResourceAiGatewayMcpServiceConfigRateLimits      `json:"rate_limits,omitempty"`
+	SourceConnection     *ResourceAiGatewayMcpServiceConfigSourceConnection `json:"source_connection,omitempty"`
+}
+
+type ResourceAiGatewayMcpServiceProviderConfig struct {
+	WorkspaceId string `json:"workspace_id,omitempty"`
+}
+
+type ResourceAiGatewayMcpService struct {
+	BrowseOnly     bool                                       `json:"browse_only,omitempty"`
+	Comment        string                                     `json:"comment,omitempty"`
+	Config         *ResourceAiGatewayMcpServiceConfig         `json:"config,omitempty"`
+	CreateTime     string                                     `json:"create_time,omitempty"`
+	CreatedBy      string                                     `json:"created_by,omitempty"`
+	EffectiveOwner string                                     `json:"effective_owner,omitempty"`
+	Etag           string                                     `json:"etag,omitempty"`
+	McpServiceId   string                                     `json:"mcp_service_id"`
+	MetastoreId    string                                     `json:"metastore_id,omitempty"`
+	Name           string                                     `json:"name,omitempty"`
+	Owner          string                                     `json:"owner,omitempty"`
+	Parent         string                                     `json:"parent"`
+	ProviderConfig *ResourceAiGatewayMcpServiceProviderConfig `json:"provider_config,omitempty"`
+	UpdateTime     string                                     `json:"update_time,omitempty"`
+	UpdatedBy      string                                     `json:"updated_by,omitempty"`
+}

--- a/bundle/internal/tf/schema/resource_ai_gateway_model_provider_service.go
+++ b/bundle/internal/tf/schema/resource_ai_gateway_model_provider_service.go
@@ -1,0 +1,193 @@
+// Generated from Databricks Terraform provider schema. DO NOT EDIT.
+
+package schema
+
+type ResourceAiGatewayModelProviderServiceConfigAmazonBedrockDirectAwsSecretAccessKey struct {
+	Plaintext string `json:"plaintext,omitempty"`
+}
+
+type ResourceAiGatewayModelProviderServiceConfigAmazonBedrockDirectServiceCredential struct {
+	Name string `json:"name"`
+}
+
+type ResourceAiGatewayModelProviderServiceConfigAmazonBedrockDirect struct {
+	AwsAccessKeyId     string                                                                            `json:"aws_access_key_id,omitempty"`
+	AwsSecretAccessKey *ResourceAiGatewayModelProviderServiceConfigAmazonBedrockDirectAwsSecretAccessKey `json:"aws_secret_access_key,omitempty"`
+	Region             string                                                                            `json:"region,omitempty"`
+	ServiceCredential  *ResourceAiGatewayModelProviderServiceConfigAmazonBedrockDirectServiceCredential  `json:"service_credential,omitempty"`
+}
+
+type ResourceAiGatewayModelProviderServiceConfigAmazonBedrock struct {
+	Direct *ResourceAiGatewayModelProviderServiceConfigAmazonBedrockDirect `json:"direct,omitempty"`
+}
+
+type ResourceAiGatewayModelProviderServiceConfigAnthropicDirectApiKey struct {
+	Plaintext string `json:"plaintext,omitempty"`
+}
+
+type ResourceAiGatewayModelProviderServiceConfigAnthropicDirect struct {
+	ApiKey *ResourceAiGatewayModelProviderServiceConfigAnthropicDirectApiKey `json:"api_key,omitempty"`
+}
+
+type ResourceAiGatewayModelProviderServiceConfigAnthropicRelayed struct {
+	PlanType string `json:"plan_type,omitempty"`
+}
+
+type ResourceAiGatewayModelProviderServiceConfigAnthropic struct {
+	Direct  *ResourceAiGatewayModelProviderServiceConfigAnthropicDirect  `json:"direct,omitempty"`
+	Relayed *ResourceAiGatewayModelProviderServiceConfigAnthropicRelayed `json:"relayed,omitempty"`
+}
+
+type ResourceAiGatewayModelProviderServiceConfigAzureOpenaiDirectApiKey struct {
+	Plaintext string `json:"plaintext,omitempty"`
+}
+
+type ResourceAiGatewayModelProviderServiceConfigAzureOpenaiDirectClientSecret struct {
+	Plaintext string `json:"plaintext,omitempty"`
+}
+
+type ResourceAiGatewayModelProviderServiceConfigAzureOpenaiDirectServiceCredential struct {
+	Name string `json:"name"`
+}
+
+type ResourceAiGatewayModelProviderServiceConfigAzureOpenaiDirect struct {
+	ApiKey            *ResourceAiGatewayModelProviderServiceConfigAzureOpenaiDirectApiKey            `json:"api_key,omitempty"`
+	BaseUrl           string                                                                         `json:"base_url,omitempty"`
+	ClientId          string                                                                         `json:"client_id,omitempty"`
+	ClientSecret      *ResourceAiGatewayModelProviderServiceConfigAzureOpenaiDirectClientSecret      `json:"client_secret,omitempty"`
+	ServiceCredential *ResourceAiGatewayModelProviderServiceConfigAzureOpenaiDirectServiceCredential `json:"service_credential,omitempty"`
+	TenantId          string                                                                         `json:"tenant_id,omitempty"`
+}
+
+type ResourceAiGatewayModelProviderServiceConfigAzureOpenai struct {
+	Direct *ResourceAiGatewayModelProviderServiceConfigAzureOpenaiDirect `json:"direct,omitempty"`
+}
+
+type ResourceAiGatewayModelProviderServiceConfigCustomDirectApiKey struct {
+	Plaintext string `json:"plaintext,omitempty"`
+}
+
+type ResourceAiGatewayModelProviderServiceConfigCustomDirect struct {
+	ApiKey  *ResourceAiGatewayModelProviderServiceConfigCustomDirectApiKey `json:"api_key,omitempty"`
+	BaseUrl string                                                         `json:"base_url,omitempty"`
+}
+
+type ResourceAiGatewayModelProviderServiceConfigCustom struct {
+	Direct *ResourceAiGatewayModelProviderServiceConfigCustomDirect `json:"direct,omitempty"`
+}
+
+type ResourceAiGatewayModelProviderServiceConfigGeminiEnterpriseDirectApiKey struct {
+	Plaintext string `json:"plaintext,omitempty"`
+}
+
+type ResourceAiGatewayModelProviderServiceConfigGeminiEnterpriseDirect struct {
+	ApiKey    *ResourceAiGatewayModelProviderServiceConfigGeminiEnterpriseDirectApiKey `json:"api_key,omitempty"`
+	ProjectId string                                                                   `json:"project_id,omitempty"`
+	Region    string                                                                   `json:"region,omitempty"`
+}
+
+type ResourceAiGatewayModelProviderServiceConfigGeminiEnterprise struct {
+	Direct *ResourceAiGatewayModelProviderServiceConfigGeminiEnterpriseDirect `json:"direct,omitempty"`
+}
+
+type ResourceAiGatewayModelProviderServiceConfigInferenceTable struct {
+	Disabled        bool   `json:"disabled,omitempty"`
+	IsDeleted       bool   `json:"is_deleted,omitempty"`
+	Parent          string `json:"parent"`
+	Table           string `json:"table,omitempty"`
+	TableNamePrefix string `json:"table_name_prefix,omitempty"`
+}
+
+type ResourceAiGatewayModelProviderServiceConfigMicrosoftFoundryDirectApiKey struct {
+	Plaintext string `json:"plaintext,omitempty"`
+}
+
+type ResourceAiGatewayModelProviderServiceConfigMicrosoftFoundryDirectClientSecret struct {
+	Plaintext string `json:"plaintext,omitempty"`
+}
+
+type ResourceAiGatewayModelProviderServiceConfigMicrosoftFoundryDirectServiceCredential struct {
+	Name string `json:"name"`
+}
+
+type ResourceAiGatewayModelProviderServiceConfigMicrosoftFoundryDirect struct {
+	ApiKey            *ResourceAiGatewayModelProviderServiceConfigMicrosoftFoundryDirectApiKey            `json:"api_key,omitempty"`
+	BaseUrl           string                                                                              `json:"base_url,omitempty"`
+	ClientId          string                                                                              `json:"client_id,omitempty"`
+	ClientSecret      *ResourceAiGatewayModelProviderServiceConfigMicrosoftFoundryDirectClientSecret      `json:"client_secret,omitempty"`
+	ServiceCredential *ResourceAiGatewayModelProviderServiceConfigMicrosoftFoundryDirectServiceCredential `json:"service_credential,omitempty"`
+	TenantId          string                                                                              `json:"tenant_id,omitempty"`
+}
+
+type ResourceAiGatewayModelProviderServiceConfigMicrosoftFoundry struct {
+	Direct *ResourceAiGatewayModelProviderServiceConfigMicrosoftFoundryDirect `json:"direct,omitempty"`
+}
+
+type ResourceAiGatewayModelProviderServiceConfigOpenaiDirectApiKey struct {
+	Plaintext string `json:"plaintext,omitempty"`
+}
+
+type ResourceAiGatewayModelProviderServiceConfigOpenaiDirect struct {
+	ApiKey       *ResourceAiGatewayModelProviderServiceConfigOpenaiDirectApiKey `json:"api_key,omitempty"`
+	BaseUrl      string                                                         `json:"base_url,omitempty"`
+	Organization string                                                         `json:"organization,omitempty"`
+}
+
+type ResourceAiGatewayModelProviderServiceConfigOpenai struct {
+	Direct *ResourceAiGatewayModelProviderServiceConfigOpenaiDirect `json:"direct,omitempty"`
+}
+
+type ResourceAiGatewayModelProviderServiceConfigRateLimits struct {
+	Key             string `json:"key"`
+	Principal       string `json:"principal,omitempty"`
+	RenewalPeriod   string `json:"renewal_period"`
+	RequestTagKey   string `json:"request_tag_key,omitempty"`
+	RequestTagValue string `json:"request_tag_value,omitempty"`
+	Requests        int    `json:"requests,omitempty"`
+	Tokens          int    `json:"tokens,omitempty"`
+}
+
+type ResourceAiGatewayModelProviderServiceConfigTargets struct {
+	Model          string   `json:"model"`
+	NativeApiTypes []string `json:"native_api_types,omitempty"`
+}
+
+type ResourceAiGatewayModelProviderServiceConfig struct {
+	AllowAllTargets        bool                                                         `json:"allow_all_targets,omitempty"`
+	AmazonBedrock          *ResourceAiGatewayModelProviderServiceConfigAmazonBedrock    `json:"amazon_bedrock,omitempty"`
+	Anthropic              *ResourceAiGatewayModelProviderServiceConfigAnthropic        `json:"anthropic,omitempty"`
+	AzureOpenai            *ResourceAiGatewayModelProviderServiceConfigAzureOpenai      `json:"azure_openai,omitempty"`
+	Custom                 *ResourceAiGatewayModelProviderServiceConfigCustom           `json:"custom,omitempty"`
+	ForwardHeaders         bool                                                         `json:"forward_headers,omitempty"`
+	ForwardQueryParameters bool                                                         `json:"forward_query_parameters,omitempty"`
+	ForwardUnmanagedPaths  bool                                                         `json:"forward_unmanaged_paths,omitempty"`
+	GeminiEnterprise       *ResourceAiGatewayModelProviderServiceConfigGeminiEnterprise `json:"gemini_enterprise,omitempty"`
+	InferenceTable         *ResourceAiGatewayModelProviderServiceConfigInferenceTable   `json:"inference_table,omitempty"`
+	MicrosoftFoundry       *ResourceAiGatewayModelProviderServiceConfigMicrosoftFoundry `json:"microsoft_foundry,omitempty"`
+	Openai                 *ResourceAiGatewayModelProviderServiceConfigOpenai           `json:"openai,omitempty"`
+	ProviderType           string                                                       `json:"provider_type,omitempty"`
+	RateLimits             []ResourceAiGatewayModelProviderServiceConfigRateLimits      `json:"rate_limits,omitempty"`
+	Targets                []ResourceAiGatewayModelProviderServiceConfigTargets         `json:"targets,omitempty"`
+}
+
+type ResourceAiGatewayModelProviderServiceProviderConfig struct {
+	WorkspaceId string `json:"workspace_id,omitempty"`
+}
+
+type ResourceAiGatewayModelProviderService struct {
+	BrowseOnly             bool                                                 `json:"browse_only,omitempty"`
+	Comment                string                                               `json:"comment,omitempty"`
+	Config                 *ResourceAiGatewayModelProviderServiceConfig         `json:"config,omitempty"`
+	CreateTime             string                                               `json:"create_time,omitempty"`
+	CreatedBy              string                                               `json:"created_by,omitempty"`
+	EffectiveOwner         string                                               `json:"effective_owner,omitempty"`
+	Etag                   string                                               `json:"etag,omitempty"`
+	MetastoreId            string                                               `json:"metastore_id,omitempty"`
+	ModelProviderServiceId string                                               `json:"model_provider_service_id"`
+	Name                   string                                               `json:"name,omitempty"`
+	Owner                  string                                               `json:"owner,omitempty"`
+	Parent                 string                                               `json:"parent"`
+	ProviderConfig         *ResourceAiGatewayModelProviderServiceProviderConfig `json:"provider_config,omitempty"`
+	UpdateTime             string                                               `json:"update_time,omitempty"`
+	UpdatedBy              string                                               `json:"updated_by,omitempty"`
+}

--- a/bundle/internal/tf/schema/resource_ai_gateway_model_service.go
+++ b/bundle/internal/tf/schema/resource_ai_gateway_model_service.go
@@ -1,0 +1,121 @@
+// Generated from Databricks Terraform provider schema. DO NOT EDIT.
+
+package schema
+
+type ResourceAiGatewayModelServiceConfigInferenceTable struct {
+	Disabled        bool   `json:"disabled,omitempty"`
+	IsDeleted       bool   `json:"is_deleted,omitempty"`
+	Parent          string `json:"parent"`
+	Table           string `json:"table,omitempty"`
+	TableNamePrefix string `json:"table_name_prefix,omitempty"`
+}
+
+type ResourceAiGatewayModelServiceConfigRateLimits struct {
+	Key             string `json:"key"`
+	Principal       string `json:"principal,omitempty"`
+	RenewalPeriod   string `json:"renewal_period"`
+	RequestTagKey   string `json:"request_tag_key,omitempty"`
+	RequestTagValue string `json:"request_tag_value,omitempty"`
+	Requests        int    `json:"requests,omitempty"`
+	Tokens          int    `json:"tokens,omitempty"`
+}
+
+type ResourceAiGatewayModelServiceConfigRoutingDestinationsExternalModelConfigTarget struct {
+	Model          string   `json:"model"`
+	NativeApiTypes []string `json:"native_api_types,omitempty"`
+}
+
+type ResourceAiGatewayModelServiceConfigRoutingDestinationsExternalModelConfig struct {
+	ModelProviderService string                                                                           `json:"model_provider_service"`
+	Target               *ResourceAiGatewayModelServiceConfigRoutingDestinationsExternalModelConfigTarget `json:"target,omitempty"`
+}
+
+type ResourceAiGatewayModelServiceConfigRoutingDestinationsPayPerTokenConfig struct {
+	Model string `json:"model"`
+}
+
+type ResourceAiGatewayModelServiceConfigRoutingDestinationsProvisionedThroughputConfig struct {
+	Model                string `json:"model,omitempty"`
+	ModelServingEndpoint string `json:"model_serving_endpoint"`
+}
+
+type ResourceAiGatewayModelServiceConfigRoutingDestinations struct {
+	DestinationType             string                                                                             `json:"destination_type"`
+	ExternalModelConfig         *ResourceAiGatewayModelServiceConfigRoutingDestinationsExternalModelConfig         `json:"external_model_config,omitempty"`
+	IsDeleted                   bool                                                                               `json:"is_deleted,omitempty"`
+	Name                        string                                                                             `json:"name"`
+	PayPerTokenConfig           *ResourceAiGatewayModelServiceConfigRoutingDestinationsPayPerTokenConfig           `json:"pay_per_token_config,omitempty"`
+	ProvisionedThroughputConfig *ResourceAiGatewayModelServiceConfigRoutingDestinationsProvisionedThroughputConfig `json:"provisioned_throughput_config,omitempty"`
+	TrafficPercentage           int                                                                                `json:"traffic_percentage,omitempty"`
+}
+
+type ResourceAiGatewayModelServiceConfigRoutingFallbackDestinationsExternalModelConfigTarget struct {
+	Model          string   `json:"model"`
+	NativeApiTypes []string `json:"native_api_types,omitempty"`
+}
+
+type ResourceAiGatewayModelServiceConfigRoutingFallbackDestinationsExternalModelConfig struct {
+	ModelProviderService string                                                                                   `json:"model_provider_service"`
+	Target               *ResourceAiGatewayModelServiceConfigRoutingFallbackDestinationsExternalModelConfigTarget `json:"target,omitempty"`
+}
+
+type ResourceAiGatewayModelServiceConfigRoutingFallbackDestinationsPayPerTokenConfig struct {
+	Model string `json:"model"`
+}
+
+type ResourceAiGatewayModelServiceConfigRoutingFallbackDestinationsProvisionedThroughputConfig struct {
+	Model                string `json:"model,omitempty"`
+	ModelServingEndpoint string `json:"model_serving_endpoint"`
+}
+
+type ResourceAiGatewayModelServiceConfigRoutingFallbackDestinations struct {
+	DestinationType             string                                                                                     `json:"destination_type"`
+	ExternalModelConfig         *ResourceAiGatewayModelServiceConfigRoutingFallbackDestinationsExternalModelConfig         `json:"external_model_config,omitempty"`
+	IsDeleted                   bool                                                                                       `json:"is_deleted,omitempty"`
+	Name                        string                                                                                     `json:"name"`
+	PayPerTokenConfig           *ResourceAiGatewayModelServiceConfigRoutingFallbackDestinationsPayPerTokenConfig           `json:"pay_per_token_config,omitempty"`
+	ProvisionedThroughputConfig *ResourceAiGatewayModelServiceConfigRoutingFallbackDestinationsProvisionedThroughputConfig `json:"provisioned_throughput_config,omitempty"`
+	TrafficPercentage           int                                                                                        `json:"traffic_percentage,omitempty"`
+}
+
+type ResourceAiGatewayModelServiceConfigRoutingFallback struct {
+	Destinations []ResourceAiGatewayModelServiceConfigRoutingFallbackDestinations `json:"destinations,omitempty"`
+}
+
+type ResourceAiGatewayModelServiceConfigRoutingTrafficSplitting struct{}
+
+type ResourceAiGatewayModelServiceConfigRouting struct {
+	Destinations      []ResourceAiGatewayModelServiceConfigRoutingDestinations    `json:"destinations,omitempty"`
+	Fallback          *ResourceAiGatewayModelServiceConfigRoutingFallback         `json:"fallback,omitempty"`
+	FirstTokenTimeout string                                                      `json:"first_token_timeout,omitempty"`
+	TrafficSplitting  *ResourceAiGatewayModelServiceConfigRoutingTrafficSplitting `json:"traffic_splitting,omitempty"`
+}
+
+type ResourceAiGatewayModelServiceConfig struct {
+	InferenceTable *ResourceAiGatewayModelServiceConfigInferenceTable `json:"inference_table,omitempty"`
+	RateLimits     []ResourceAiGatewayModelServiceConfigRateLimits    `json:"rate_limits,omitempty"`
+	Routing        *ResourceAiGatewayModelServiceConfigRouting        `json:"routing,omitempty"`
+}
+
+type ResourceAiGatewayModelServiceProviderConfig struct {
+	WorkspaceId string `json:"workspace_id,omitempty"`
+}
+
+type ResourceAiGatewayModelService struct {
+	BrowseOnly        bool                                         `json:"browse_only,omitempty"`
+	Comment           string                                       `json:"comment,omitempty"`
+	Config            *ResourceAiGatewayModelServiceConfig         `json:"config,omitempty"`
+	CreateTime        string                                       `json:"create_time,omitempty"`
+	CreatedBy         string                                       `json:"created_by,omitempty"`
+	EffectiveOwner    string                                       `json:"effective_owner,omitempty"`
+	Etag              string                                       `json:"etag,omitempty"`
+	MetastoreId       string                                       `json:"metastore_id,omitempty"`
+	ModelServiceId    string                                       `json:"model_service_id"`
+	Name              string                                       `json:"name,omitempty"`
+	Owner             string                                       `json:"owner,omitempty"`
+	Parent            string                                       `json:"parent"`
+	ProviderConfig    *ResourceAiGatewayModelServiceProviderConfig `json:"provider_config,omitempty"`
+	SupportedApiTypes []string                                     `json:"supported_api_types,omitempty"`
+	UpdateTime        string                                       `json:"update_time,omitempty"`
+	UpdatedBy         string                                       `json:"updated_by,omitempty"`
+}

--- a/bundle/internal/tf/schema/resource_all.go
+++ b/bundle/internal/tf/schema/resource_all.go
@@ -12,6 +12,9 @@ type AllResources struct {
 	AccountNetworkPolicy                         ResourceAccountNetworkPolicy                         `json:"databricks_account_network_policy,omitempty"`
 	AccountSettingUserPreferenceV2               ResourceAccountSettingUserPreferenceV2               `json:"databricks_account_setting_user_preference_v2,omitempty"`
 	AccountSettingV2                             ResourceAccountSettingV2                             `json:"databricks_account_setting_v2,omitempty"`
+	AiGatewayMcpService                          ResourceAiGatewayMcpService                          `json:"databricks_ai_gateway_mcp_service,omitempty"`
+	AiGatewayModelProviderService                ResourceAiGatewayModelProviderService                `json:"databricks_ai_gateway_model_provider_service,omitempty"`
+	AiGatewayModelService                        ResourceAiGatewayModelService                        `json:"databricks_ai_gateway_model_service,omitempty"`
 	AiSearchEndpoint                             ResourceAiSearchEndpoint                             `json:"databricks_ai_search_endpoint,omitempty"`
 	AiSearchIndex                                ResourceAiSearchIndex                                `json:"databricks_ai_search_index,omitempty"`
 	AibiDashboardEmbeddingAccessPolicySetting    ResourceAibiDashboardEmbeddingAccessPolicySetting    `json:"databricks_aibi_dashboard_embedding_access_policy_setting,omitempty"`

--- a/bundle/internal/tf/schema/resources.go
+++ b/bundle/internal/tf/schema/resources.go
@@ -8,6 +8,9 @@ type Resources struct {
 	AccountNetworkPolicy                         map[string]any `json:"databricks_account_network_policy,omitempty"`
 	AccountSettingUserPreferenceV2               map[string]any `json:"databricks_account_setting_user_preference_v2,omitempty"`
 	AccountSettingV2                             map[string]any `json:"databricks_account_setting_v2,omitempty"`
+	AiGatewayMcpService                          map[string]any `json:"databricks_ai_gateway_mcp_service,omitempty"`
+	AiGatewayModelProviderService                map[string]any `json:"databricks_ai_gateway_model_provider_service,omitempty"`
+	AiGatewayModelService                        map[string]any `json:"databricks_ai_gateway_model_service,omitempty"`
 	AiSearchEndpoint                             map[string]any `json:"databricks_ai_search_endpoint,omitempty"`
 	AiSearchIndex                                map[string]any `json:"databricks_ai_search_index,omitempty"`
 	AibiDashboardEmbeddingAccessPolicySetting    map[string]any `json:"databricks_aibi_dashboard_embedding_access_policy_setting,omitempty"`
@@ -173,6 +176,9 @@ func NewResources() *Resources {
 		AccountNetworkPolicy:                         make(map[string]any),
 		AccountSettingUserPreferenceV2:               make(map[string]any),
 		AccountSettingV2:                             make(map[string]any),
+		AiGatewayMcpService:                          make(map[string]any),
+		AiGatewayModelProviderService:                make(map[string]any),
+		AiGatewayModelService:                        make(map[string]any),
 		AiSearchEndpoint:                             make(map[string]any),
 		AiSearchIndex:                                make(map[string]any),
 		AibiDashboardEmbeddingAccessPolicySetting:    make(map[string]any),

--- a/bundle/internal/tf/schema/root.go
+++ b/bundle/internal/tf/schema/root.go
@@ -22,9 +22,9 @@ type Root struct {
 const (
 	ProviderHost               = "registry.terraform.io"
 	ProviderSource             = "databricks/databricks"
-	ProviderVersion            = "1.123.0"
-	ProviderChecksumLinuxAmd64 = "e313f21a8d6181c4a239c2ac8a692adc824660cba8e069ed400782938628c0ef"
-	ProviderChecksumLinuxArm64 = "11da912f542246f642ff2e2169dc11ff486ec18d76e7dfc21a7930b2f8f8f8db"
+	ProviderVersion            = "1.124.0"
+	ProviderChecksumLinuxAmd64 = "3906550da66adc334c8eca6a5c2a06590a2359fa0ca89e7db16c36fd3467ebab"
+	ProviderChecksumLinuxArm64 = "947ee85262993412855ea0d0b7d4a11b06dc1e0e64e1f9bb51dcc93f43479919"
 )
 
 func NewRoot() *Root {


### PR DESCRIPTION
## Changes

Bump the pinned Databricks Terraform provider from v1.123.0 to v1.124.0.

Notable schema changes:
- Added `databricks_ai_gateway_mcp_service`, `databricks_ai_gateway_model_provider_service` and `databricks_ai_gateway_model_service` resources.
- Added the corresponding singular and plural AI Gateway data sources.

The change is additive: no fields were removed or became required, and the DABs/Terraform field map (`bundle/terraform_dabs_map/generated.go`) is unchanged.

## Why

Dependency update.

## Tests

Schema and field map regenerated. The acceptance suite passes without `-update` and required no golden changes at all.

Note: `./task generate-tf-schema` initially failed with `no available releases match the given constraints 1.124.0`. On a Databricks machine `~/.terraformrc` redirects `registry.terraform.io` to the internal `terraform-proxy.cloud.databricks.com`, whose mirror had not yet indexed v1.124.0, so codegen ran against a local filesystem mirror of the GitHub release zip. Codegen still fetched and verified the real GitHub SHA256 checksums for `root.go`.

_This PR was written by Claude Code._