### PR TITLE
Revert usage of RedactSensitiveFields

### DIFF
--- a/.nextchanges/bundles/revert-redact-sensitive.md
+++ b/.nextchanges/bundles/revert-redact-sensitive.md
@@ -1,0 +1,1 @@
+Revert usage of RedactiveSenstiveFields which lead to incorrect behaviour for duration field in Postgres resources.

--- a/.nextchanges/bundles/revert-redact-sensitive.md
+++ b/.nextchanges/bundles/revert-redact-sensitive.md
@@ -1,1 +1,1 @@
-Revert usage of RedactiveSenstiveFields which lead to incorrect behaviour for duration field in Postgres resources.
+Revert usage of RedactiveSenstiveFields (added in #5896, released in 1.10.0) which lead to incorrect behaviour (permanent drift) for duration field in Postgres resources.

--- a/.nextchanges/bundles/revert-redact-sensitive.md
+++ b/.nextchanges/bundles/revert-redact-sensitive.md
@@ -1,1 +1,1 @@
-Revert usage of RedactiveSenstiveFields (added in #5896, released in 1.10.0) which lead to incorrect behaviour (permanent drift) for duration field in Postgres resources.
+Revert usage of RedactiveSenstiveFields (added in [#5896](https://github.com/databricks/cli/pull/5896), released in 1.10.0) which lead to incorrect behaviour (permanent drift) for duration field in Postgres resources.

--- a/acceptance/bundle/resources/postgres_endpoints/update_autoscaling/out.plan.no_change.direct.json
+++ b/acceptance/bundle/resources/postgres_endpoints/update_autoscaling/out.plan.no_change.direct.json
@@ -29,7 +29,7 @@
     "suspend_timeout_duration": {
       "action": "skip",
       "reason": "empty",
-      "old": "0s",
+      "old": "300s",
       "new": "300s"
     }
   }

--- a/acceptance/bundle/resources/postgres_endpoints/update_autoscaling/out.plan.restore.direct.json
+++ b/acceptance/bundle/resources/postgres_endpoints/update_autoscaling/out.plan.restore.direct.json
@@ -38,7 +38,7 @@
     "suspend_timeout_duration": {
       "action": "skip",
       "reason": "empty",
-      "old": "0s",
+      "old": "300s",
       "new": "300s"
     }
   }

--- a/acceptance/bundle/resources/postgres_endpoints/update_autoscaling/out.plan.update.direct.json
+++ b/acceptance/bundle/resources/postgres_endpoints/update_autoscaling/out.plan.update.direct.json
@@ -38,7 +38,7 @@
     "suspend_timeout_duration": {
       "action": "skip",
       "reason": "empty",
-      "old": "0s",
+      "old": "300s",
       "new": "300s"
     }
   }

--- a/acceptance/bundle/resources/postgres_projects/update_display_name/out.plan.no_change.direct.json
+++ b/acceptance/bundle/resources/postgres_projects/update_display_name/out.plan.no_change.direct.json
@@ -30,7 +30,7 @@
       "old": {
         "autoscaling_limit_max_cu": 4,
         "autoscaling_limit_min_cu": 0.5,
-        "suspend_timeout_duration": "0s"
+        "suspend_timeout_duration": "300s"
       },
       "new": {
         "autoscaling_limit_max_cu": 4,
@@ -47,7 +47,7 @@
     "history_retention_duration": {
       "action": "skip",
       "reason": "empty",
-      "old": "0s",
+      "old": "604800s",
       "new": "604800s"
     },
     "pg_version": {

--- a/acceptance/bundle/resources/postgres_projects/update_display_name/out.plan.restore.direct.json
+++ b/acceptance/bundle/resources/postgres_projects/update_display_name/out.plan.restore.direct.json
@@ -43,7 +43,7 @@
       "old": {
         "autoscaling_limit_max_cu": 4,
         "autoscaling_limit_min_cu": 0.5,
-        "suspend_timeout_duration": "0s"
+        "suspend_timeout_duration": "300s"
       },
       "new": {
         "autoscaling_limit_max_cu": 4,
@@ -59,7 +59,7 @@
     "history_retention_duration": {
       "action": "skip",
       "reason": "empty",
-      "old": "0s",
+      "old": "604800s",
       "new": "604800s"
     },
     "pg_version": {

--- a/acceptance/bundle/resources/postgres_projects/update_display_name/out.plan.update.direct.json
+++ b/acceptance/bundle/resources/postgres_projects/update_display_name/out.plan.update.direct.json
@@ -43,7 +43,7 @@
       "old": {
         "autoscaling_limit_max_cu": 4,
         "autoscaling_limit_min_cu": 0.5,
-        "suspend_timeout_duration": "0s"
+        "suspend_timeout_duration": "300s"
       },
       "new": {
         "autoscaling_limit_max_cu": 4,
@@ -59,7 +59,7 @@
     "history_retention_duration": {
       "action": "skip",
       "reason": "empty",
-      "old": "0s",
+      "old": "604800s",
       "new": "604800s"
     },
     "pg_version": {

--- a/bundle/direct/dstate/state.go
+++ b/bundle/direct/dstate/state.go
@@ -16,9 +16,7 @@ import (
 	"github.com/databricks/cli/bundle/deployplan"
 	"github.com/databricks/cli/bundle/statemgmt/resourcestate"
 	"github.com/databricks/cli/internal/build"
-	"github.com/databricks/cli/libs/dyn"
 	"github.com/databricks/cli/libs/log"
-	"github.com/databricks/cli/libs/structs/structwalk"
 	"github.com/google/uuid"
 )
 
@@ -129,10 +127,7 @@ func (db *DeploymentState) SaveState(key, newID string, state any, dependsOn []d
 		db.Data.State = make(map[string]ResourceEntry)
 	}
 
-	// Redact sensitive fields before persisting: secrets must not appear on disk
-	// in plaintext. The original struct is not modified; the plan uses the
-	// unredacted in-memory value for API calls.
-	jsonMessage, err := structwalk.RedactSensitiveFields(state, dyn.SensitiveValueRedacted)
+	jsonMessage, err := json.Marshal(state)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Changes
Revert usage of RedactSensitiveFields

## Why
RedactSensitiveFields (added in #5896, merged 2026-07-22) deep-clones the state struct field-by-field via reflection, then marshals the clone. The clone skips unexported fields (libs/structs/structwalk/redact.go:44-46), and duration.Duration stores its whole value in an unexported field while marshalling through a custom MarshalJSON
So on main, every duration written to the direct-engine state file is silently corrupted to 0s.

## Tests
Golden fiels updated

<!-- If your PR needs to be included in the release notes for next release,
add a changelog fragment: create .nextchanges/<section>/<name>.md with a
one-line description (e.g. .nextchanges/cli/quickstart.md). See .nextchanges/README.md. -->
