### PR TITLE
direct: restore Apps scaling fields in update requests

### DIFF
--- a/.nextchanges/bundles/apps-update-scaling.md
+++ b/.nextchanges/bundles/apps-update-scaling.md
@@ -1,0 +1,1 @@
+Restore Apps scaling fields in bundle update requests.

--- a/acceptance/bundle/resources/apps/lifecycle-started/output.txt
+++ b/acceptance/bundle/resources/apps/lifecycle-started/output.txt
@@ -90,7 +90,7 @@ Deployment complete!
       "description": "MY_APP_DESCRIPTION_2",
       "name": "[UNIQUE_NAME]"
     },
-    "update_mask": "description,budget_policy_id,usage_policy_id,resources,user_api_scopes,compute_size,git_repository,telemetry_export_destinations"
+    "update_mask": "description,budget_policy_id,usage_policy_id,resources,user_api_scopes,compute_size,compute_min_instances,compute_max_instances,git_repository,telemetry_export_destinations"
   }
 }
 
@@ -117,7 +117,7 @@ Deployment complete!
       "description": "MY_APP_DESCRIPTION_3",
       "name": "[UNIQUE_NAME]"
     },
-    "update_mask": "description,budget_policy_id,usage_policy_id,resources,user_api_scopes,compute_size,git_repository,telemetry_export_destinations"
+    "update_mask": "description,budget_policy_id,usage_policy_id,resources,user_api_scopes,compute_size,compute_min_instances,compute_max_instances,git_repository,telemetry_export_destinations"
   }
 }
 {

--- a/acceptance/bundle/resources/apps/update/out.requests.direct.json
+++ b/acceptance/bundle/resources/apps/update/out.requests.direct.json
@@ -17,7 +17,7 @@
       "description": "MY_APP_DESCRIPTION",
       "name": "myappname"
     },
-    "update_mask": "description,budget_policy_id,usage_policy_id,resources,user_api_scopes,compute_size,git_repository,telemetry_export_destinations"
+    "update_mask": "description,budget_policy_id,usage_policy_id,resources,user_api_scopes,compute_size,compute_min_instances,compute_max_instances,git_repository,telemetry_export_destinations"
   }
 }
 {

--- a/bundle/direct/dresources/app.go
+++ b/bundle/direct/dresources/app.go
@@ -164,8 +164,8 @@ var UpdateMaskFields = []string{
 	"resources",
 	"user_api_scopes",
 	"compute_size",
-	// "compute_min_instances", // TODO: add back when update APIs correctly support it
-	// "compute_max_instances", // TODO: add back when update APIs correctly support it
+	"compute_min_instances",
+	"compute_max_instances",
 	"git_repository",
 	"telemetry_export_destinations",
 }

--- a/bundle/direct/dresources/resources.yml
+++ b/bundle/direct/dresources/resources.yml
@@ -527,10 +527,6 @@ resources:
     ignore_remote_changes:
       - field: space # This field is not yet supported by Update APIs but exposed in the API spec. TODO: fix when update APIs supports it.
         reason: managed
-      - field: compute_min_instances # This field does not work correctly in update_mask but exposed in the API spec. TODO: add back when update APIs correctly support it
-        reason: managed
-      - field: compute_max_instances # This field does not work correctly in update_mask but exposed in the API spec. TODO: add back when update APIs correctly support it
-        reason: managed
 
   secret_scopes:
     backend_defaults:


### PR DESCRIPTION
## Changes

Revert the temporary Apps scaling workaround from [#5444](https://github.com/databricks/cli/pull/5444):

- restore `compute_min_instances` and `compute_max_instances` to direct-engine update masks
- stop suppressing remote changes to those fields
- update acceptance expectations and add a changelog fragment

## Why

The Apps backend now supports the DAB update request shape: unset instance fields in a bundled update are ignored without converting a standard app, while instance-count changes on an already-scalable app can be applied alongside ordinary fields.

Keeping the CLI workaround causes DAB updates to omit scaling fields and suppress their drift.

## Tests

- `go test ./bundle/direct/dresources`
- `go test ./acceptance -run 'TestAccept/bundle/resources/apps/update' -tail -test.v`
- `./task fmt-q-go`
- `./task fmt-yaml`
- `./task lint-q-go-root`
- Staging E2E with this locally built CLI and the direct bundle engine:
  - ordinary app description update succeeded with min/max omitted and remained non-scalable
  - created a scalable app with `min=1,max=1`
  - description update on the scalable app succeeded and preserved `min=1,max=1`
