### PR TITLE
OWNERS: add team:ide and own the environments integration tests

### DIFF
--- a/.github/OWNERS
+++ b/.github/OWNERS
@@ -15,9 +15,9 @@
 /cmd/labs/                  @alexott @asnare
 
 # Local environments / DB Connect
-/libs/localenv/             @rugpanov @rclarey @anton-107 @misha-db
-/cmd/environments/          @rugpanov @rclarey @anton-107 @misha-db
-/acceptance/localenv/       @rugpanov @rclarey @anton-107 @misha-db
+/libs/localenv/             team:ide
+/cmd/environments/          team:ide
+/acceptance/localenv/       team:ide
 
 # Apps
 /cmd/apps/                  team:eng-apps-devex
@@ -66,7 +66,7 @@
 
 # Must stay below /integration/: rules are last-match-wins, so the broader
 # team:platform rule above would otherwise take precedence for these paths.
-/integration/cmd/environments/  @rugpanov @rclarey @anton-107 @misha-db
+/integration/cmd/environments/  team:ide
 
 # Internal
 /internal/                  team:platform

--- a/.github/OWNERS
+++ b/.github/OWNERS
@@ -64,6 +64,10 @@
 # Integration tests
 /integration/               team:platform
 
+# Must stay below /integration/: rules are last-match-wins, so the broader
+# team:platform rule above would otherwise take precedence for these paths.
+/integration/cmd/environments/  @rugpanov @rclarey @anton-107 @misha-db
+
 # Internal
 /internal/                  team:platform
 

--- a/.github/OWNERTEAMS
+++ b/.github/OWNERTEAMS
@@ -16,4 +16,5 @@ team:bundle     @andrewnester @anton-107 @denik @janniklasrose @lennartkats-db @
 team:platform   @simonfaltum @renaudhartert-db @hectorcast-db @parthban-db @tanmay-db @Divyansh-db @tejaskochar-db @mihaimitrea-db @chrisst @rauchy
 team:eng-apps-devex @fjakobs @Shridhad @atilafassina @keugenek @igrekun @pkosiec @MarioCadenas @pffigueiredo @ditadi @calvarjorge
 team:eng-sandbox @pietern @shuochen0311 @akshaysingla-db @anwell-db @samhuan-db
+team:ide        @rugpanov @rclarey @anton-107 @misha-db
 team:ai-training @apeforest @bfontain @lu-wang-dl @panchalhp-db @vinchenzo-db @maggiewang-db @riddhibhagwat-db @ben-hansen-db @pardis-beikzadeh-db


### PR DESCRIPTION
## Changes

Two related changes to ownership of the DB Connect / local-environments code:

1. **Define `team:ide`** in `.github/OWNERTEAMS` — `@rugpanov @rclarey @anton-107 @misha-db`.
2. **Own `/integration/cmd/environments/`** so the `setup-local` integration tests are reviewed by the same people who own the code they exercise.

The three existing localenv paths each repeated the same four handles, so a roster change meant four separate edits that could silently drift apart. They now reference the alias instead:

```
/libs/localenv/                 team:ide
/cmd/environments/              team:ide
/acceptance/localenv/           team:ide
/integration/cmd/environments/  team:ide   # new
```

**Ownership is unchanged** for the three pre-existing paths — same four people, one source of truth. The rest of `/integration/` stays with `team:platform`.

### Why the new entry sits below `/integration/`

`findOwners` is **last-match-wins**. Putting the new rule next to the other localenv lines (line ~17) looks natural but silently does nothing: the broader `/integration/  team:platform` rule at line 65 matches later and wins. My first attempt did exactly that, and `owners.js validate` passed anyway — the misplacement is invisible to the validator. Hence the position after `/integration/`, plus a comment so it doesn't get "tidied" back up.

### No GitHub org team yet

There's no `github.com/orgs/databricks/teams/ide` page, so the validator emits its non-blocking `no GitHub team-page URL` warning — the same one `team:ai-training` already produces. Per `validateOwners`, this is by design: *"A team may legitimately predate its GitHub team page, so this never blocks a merge."*

The alias is fully functional standalone, which is how the existing aliases already work — neither `cli-maintainers` nor `cli-platform` (both listed in the OWNERTEAMS header) exists as an org team today, and OWNERTEAMS is explicitly the source of truth because `GITHUB_TOKEN` can't resolve org team membership. Creating the real org team needs org-owner access; the header URL can be added later.

## Tests

- `node .github/scripts/owners.js validate` → passes (2 non-blocking warnings: the new `team:ide` and the pre-existing `team:ai-training`).
- `node --test .github/scripts/owners.test.js .github/workflows/maintainer-approval.test.js` → 64/64 pass.
- Resolution verified with `findOwners`:

| path | owners |
| --- | --- |
| `libs/localenv/uv.go` | `rugpanov rclarey anton-107 misha-db` (unchanged) |
| `cmd/environments/setup_local.go` | `rugpanov rclarey anton-107 misha-db` (unchanged) |
| `acceptance/localenv/…` | `rugpanov rclarey anton-107 misha-db` (unchanged) |
| `integration/cmd/environments/setup_local_test.go` | `rugpanov rclarey anton-107 misha-db` ✅ new |
| `integration/cmd/jobs/foo_test.go` | `team:platform` (unchanged) |

## Note on the base branch

Based on `dbconnect/setup-local-integration` (#6155) rather than `main`, because `owners.js validate` errors on rules whose path doesn't exist in the tree, and `integration/cmd/environments/` is created by that PR. Once #6155 lands this can be retargeted to `main`.

_This pull request and its description were written by Isaac._