### PR TITLE
Update bugbash instructions

### DIFF
--- a/internal/bugbash/README.md
+++ b/internal/bugbash/README.md
@@ -3,11 +3,17 @@
 The script in this directory can be used to conveniently exec into a shell
 where a CLI build for a specific branch is made available.
 
+
+## Prerequisites
+
+A snapshot build for your branch needs to exist.
+These are automatically created for branches named `demo-*` and `bugbash-*`.
+
 ## Usage
 
 This script prompts if you do NOT have at least Bash 5 installed,
 but works without command completion with earlier versions.
 
 ```shell
-bash <(curl -fsSL https://raw.githubusercontent.com/databricks/cli/main/internal/bugbash/exec.sh) my-branch
+bash <(curl -fsSL https://raw.githubusercontent.com/databricks/cli/main/internal/bugbash/exec.sh) bugbash-my-branch
 ```

--- a/internal/bugbash/exec.sh
+++ b/internal/bugbash/exec.sh
@@ -68,8 +68,8 @@ echo "Looking for a snapshot build of the Databricks CLI on branch $BRANCH..."
 
 # Find last successful build on $BRANCH.
 last_successful_run_id=$(
-  gh run list -b "$BRANCH" -w release-build --json 'databaseId,conclusion' |
-      jq 'limit(1; .[] | select(.conclusion == "success")) | .databaseId'
+  gh run --repo databricks/cli list --branch "$BRANCH" --workflow release-build \
+    --json 'databaseId,conclusion' --jq 'limit(1; .[] | select(.conclusion == "success")) | .databaseId'
 )
 if [ -z "$last_successful_run_id" ]; then
   echo "Unable to find last successful build of the release-build workflow for branch $BRANCH."
@@ -81,7 +81,7 @@ dir=$(mktemp -d)
 
 # Download the artifact.
 echo "Downloading the snapshot build..."
-gh run download "$last_successful_run_id" -n cli -D "$dir/.download"
+gh run --repo databricks/cli download "$last_successful_run_id" --name cli --dir "$dir/.download"
 
 # Extract the archive for this platform.
 archive=$(cli_snapshot_archive)


### PR DESCRIPTION
- Clarify bugbash instructions README
- Update `gh run` commands
  - remove dependency on `jq`, since `gh` natively supports `--jq`
  - add `--repo` in case someone doesn't have the default repo for `gh` CLI set up or isn't running it from a local CLI copy
  - expand command options to make it more readable