### PR TITLE
Pass compute_min_instances and compute_max_instances for apps update call

### DIFF
--- a/acceptance/bundle/resources/apps/lifecycle-started/output.txt
+++ b/acceptance/bundle/resources/apps/lifecycle-started/output.txt
@@ -90,7 +90,7 @@ Deployment complete!
       "description": "MY_APP_DESCRIPTION_2",
       "name": "[UNIQUE_NAME]"
     },
-    "update_mask": "description,budget_policy_id,usage_policy_id,resources,user_api_scopes,compute_size,git_repository,telemetry_export_destinations"
+    "update_mask": "description,budget_policy_id,usage_policy_id,resources,user_api_scopes,compute_size,compute_min_instances,compute_max_instances,git_repository,telemetry_export_destinations"
   }
 }
 
@@ -117,7 +117,7 @@ Deployment complete!
       "description": "MY_APP_DESCRIPTION_3",
       "name": "[UNIQUE_NAME]"
     },
-    "update_mask": "description,budget_policy_id,usage_policy_id,resources,user_api_scopes,compute_size,git_repository,telemetry_export_destinations"
+    "update_mask": "description,budget_policy_id,usage_policy_id,resources,user_api_scopes,compute_size,compute_min_instances,compute_max_instances,git_repository,telemetry_export_destinations"
   }
 }
 {

--- a/acceptance/bundle/resources/apps/update/out.requests.direct.json
+++ b/acceptance/bundle/resources/apps/update/out.requests.direct.json
@@ -17,7 +17,7 @@
       "description": "MY_APP_DESCRIPTION",
       "name": "myappname"
     },
-    "update_mask": "description,budget_policy_id,usage_policy_id,resources,user_api_scopes,compute_size,git_repository,telemetry_export_destinations"
+    "update_mask": "description,budget_policy_id,usage_policy_id,resources,user_api_scopes,compute_size,compute_min_instances,compute_max_instances,git_repository,telemetry_export_destinations"
   }
 }
 {

--- a/bundle/direct/dresources/app.go
+++ b/bundle/direct/dresources/app.go
@@ -164,8 +164,8 @@ var UpdateMaskFields = []string{
 	"resources",
 	"user_api_scopes",
 	"compute_size",
-	// "compute_min_instances", // TODO: add back when update APIs correctly support it
-	// "compute_max_instances", // TODO: add back when update APIs correctly support it
+	"compute_min_instances",
+	"compute_max_instances",
 	"git_repository",
 	"telemetry_export_destinations",
 }

--- a/bundle/direct/dresources/resources.yml
+++ b/bundle/direct/dresources/resources.yml
@@ -527,10 +527,6 @@ resources:
     ignore_remote_changes:
       - field: space # This field is not yet supported by Update APIs but exposed in the API spec. TODO: fix when update APIs supports it.
         reason: managed
-      - field: compute_min_instances # This field does not work correctly in update_mask but exposed in the API spec. TODO: add back when update APIs correctly support it
-        reason: managed
-      - field: compute_max_instances # This field does not work correctly in update_mask but exposed in the API spec. TODO: add back when update APIs correctly support it
-        reason: managed
 
   secret_scopes:
     backend_defaults:


### PR DESCRIPTION
## Changes
Pass compute_min_instances and compute_max_instances for apps update call

## Why
Reverts https://github.com/databricks/cli/pull/5444

Apps backend now correctly support these fields in update mask

## Tests
Acceptance test pass

<!-- If your PR needs to be included in the release notes for next release,
add a changelog fragment: create .nextchanges/<section>/<name>.md with a
one-line description (e.g. .nextchanges/cli/quickstart.md). See .nextchanges/README.md. -->
