### PR TITLE
Fix bundle.deployment.lock.force being ignored

### DIFF
--- a/.nextchanges/bundles/force-lock-config.md
+++ b/.nextchanges/bundles/force-lock-config.md
@@ -1,1 +1,1 @@
-Fix `bundle.deployment.lock.force` being ignored. The `--force-lock` flag's default value overwrote the value configured in `databricks.yml`, so setting the field had no effect and a stale deployment lock could only be overridden with the flag.
+Fix `bundle.deployment.lock.force` being ignored. The `--force-lock` flag's default value overwrote the value configured in `databricks.yml`, so setting the field had no effect and a stale deployment lock could only be overridden with the flag. ([#6188](https://github.com/databricks/cli/pull/6188))

--- a/.nextchanges/bundles/force-lock-config.md
+++ b/.nextchanges/bundles/force-lock-config.md
@@ -1,0 +1,1 @@
+Fix `bundle.deployment.lock.force` being ignored. The `--force-lock` flag's default value overwrote the value configured in `databricks.yml`, so setting the field had no effect and a stale deployment lock could only be overridden with the flag.

--- a/acceptance/bundle/deploy/force-lock-config/databricks.yml
+++ b/acceptance/bundle/deploy/force-lock-config/databricks.yml
@@ -1,0 +1,11 @@
+bundle:
+  name: test-bundle-force-lock
+
+  deployment:
+    lock:
+      force: true
+
+resources:
+  jobs:
+    foo:
+      name: test-job

--- a/acceptance/bundle/deploy/force-lock-config/deploy.lock
+++ b/acceptance/bundle/deploy/force-lock-config/deploy.lock
@@ -1,0 +1,6 @@
+{
+  "ID": "12345678-1234-1234-1234-123456789abc",
+  "AcquisitionTime": "2024-01-15T15:40:00Z",
+  "IsForced": false,
+  "User": "user-with-lock@databricks.com"
+}

--- a/acceptance/bundle/deploy/force-lock-config/out.test.toml
+++ b/acceptance/bundle/deploy/force-lock-config/out.test.toml
@@ -1,0 +1,3 @@
+Local = true
+Cloud = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deploy/force-lock-config/output.txt
+++ b/acceptance/bundle/deploy/force-lock-config/output.txt
@@ -1,0 +1,10 @@
+
+=== upload a stale lock file held by another user
+>>> [CLI] workspace import /Workspace/Users/[USERNAME]/.bundle/test-bundle-force-lock/default/state/deploy.lock --format AUTO --file ./deploy.lock
+
+=== bundle.deployment.lock.force is set in databricks.yml, so the stale lock is overridden
+>>> [CLI] bundle deploy
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle-force-lock/default/files...
+Deploying resources...
+Updating deployment state...
+Deployment complete!

--- a/acceptance/bundle/deploy/force-lock-config/script
+++ b/acceptance/bundle/deploy/force-lock-config/script
@@ -1,0 +1,11 @@
+export username=$($CLI current-user me | jq -r .userName)
+export MSYS_NO_PATHCONV=1
+
+title "upload a stale lock file held by another user"
+# The import API returns a 404 if the parent directory does not exist. No deploy has
+# run yet, so create the state directory before uploading the lock file into it.
+$CLI workspace mkdirs /Workspace/Users/$username/.bundle/test-bundle-force-lock/default/state
+trace $CLI workspace import /Workspace/Users/$username/.bundle/test-bundle-force-lock/default/state/deploy.lock --format AUTO --file ./deploy.lock
+
+title "bundle.deployment.lock.force is set in databricks.yml, so the stale lock is overridden"
+trace $CLI bundle deploy

--- a/acceptance/bundle/deploy/force-lock-config/test.toml
+++ b/acceptance/bundle/deploy/force-lock-config/test.toml
@@ -1,0 +1,2 @@
+Local = true
+Cloud = false

--- a/cmd/apps/deploy_bundle.go
+++ b/cmd/apps/deploy_bundle.go
@@ -50,7 +50,7 @@ type bundleDeployOptions struct {
 // Flags that override bundle YAML are only applied when explicitly set by the user.
 func applyDeployFlags(cmd *cobra.Command, b *bundle.Bundle, opts bundleDeployOptions) {
 	b.Config.Bundle.Force = opts.force
-	b.Config.Bundle.Deployment.Lock.Force = opts.forceLock
+	utils.SetForceLock(cmd, b, opts.forceLock)
 	b.AutoApprove = opts.autoApprove
 
 	if cmd.Flag("compute-id").Changed {

--- a/cmd/apps/deploy_bundle_test.go
+++ b/cmd/apps/deploy_bundle_test.go
@@ -122,18 +122,43 @@ func TestApplyDeployFlags(t *testing.T) {
 	noopWrapper := func(cmd *cobra.Command, appName string, err error) error { return err }
 
 	tests := []struct {
-		name      string
-		args      []string
-		opts      bundleDeployOptions
+		name string
+		args []string
+		opts bundleDeployOptions
+		// configure seeds the bundle config as if it had been loaded from
+		// databricks.yml, so a test can assert a flag does not clobber it.
+		configure func(*bundle.Bundle)
 		assertion func(*testing.T, *bundle.Bundle)
 	}{
 		{
-			name: "force, forceLock, autoApprove always apply",
-			opts: bundleDeployOptions{force: true, forceLock: true, autoApprove: true},
+			name: "force and autoApprove always apply",
+			opts: bundleDeployOptions{force: true, autoApprove: true},
 			assertion: func(t *testing.T, b *bundle.Bundle) {
 				assert.True(t, b.Config.Bundle.Force)
-				assert.True(t, b.Config.Bundle.Deployment.Lock.Force)
 				assert.True(t, b.AutoApprove)
+			},
+		},
+		{
+			name: "forceLock ignored when force-lock flag unchanged",
+			opts: bundleDeployOptions{forceLock: true},
+			assertion: func(t *testing.T, b *bundle.Bundle) {
+				assert.False(t, b.Config.Bundle.Deployment.Lock.Force)
+			},
+		},
+		{
+			name:      "lock.force from databricks.yml survives an unset force-lock flag",
+			opts:      bundleDeployOptions{},
+			configure: func(b *bundle.Bundle) { b.Config.Bundle.Deployment.Lock.Force = true },
+			assertion: func(t *testing.T, b *bundle.Bundle) {
+				assert.True(t, b.Config.Bundle.Deployment.Lock.Force)
+			},
+		},
+		{
+			name: "forceLock applies when --force-lock is set",
+			args: []string{"--force-lock"},
+			opts: bundleDeployOptions{forceLock: true},
+			assertion: func(t *testing.T, b *bundle.Bundle) {
+				assert.True(t, b.Config.Bundle.Deployment.Lock.Force)
 			},
 		},
 		{
@@ -181,6 +206,9 @@ func TestApplyDeployFlags(t *testing.T) {
 			require.NoError(t, cmd.ParseFlags(tc.args))
 
 			b := &bundle.Bundle{}
+			if tc.configure != nil {
+				tc.configure(b)
+			}
 			applyDeployFlags(cmd, b, tc.opts)
 
 			tc.assertion(t, b)

--- a/cmd/bundle/deploy.go
+++ b/cmd/bundle/deploy.go
@@ -49,7 +49,7 @@ See https://docs.databricks.com/en/dev-tools/bundles/index.html for more informa
 		_, err := utils.ProcessBundle(cmd, utils.ProcessOptions{
 			InitFunc: func(b *bundle.Bundle) {
 				b.Config.Bundle.Force = force
-				b.Config.Bundle.Deployment.Lock.Force = forceLock
+				utils.SetForceLock(cmd, b, forceLock)
 				b.AutoApprove = autoApprove
 				b.Select = selectResources
 

--- a/cmd/bundle/deployment/bind_resource.go
+++ b/cmd/bundle/deployment/bind_resource.go
@@ -20,7 +20,7 @@ func BindResource(cmd *cobra.Command, resourceKey, resourceId string, autoApprov
 		SkipInitContext: skipInitContext,
 		AlwaysPull:      true,
 		InitFunc: func(b *bundle.Bundle) {
-			b.Config.Bundle.Deployment.Lock.Force = forceLock
+			utils.SetForceLock(cmd, b, forceLock)
 		},
 	})
 	if err != nil {

--- a/cmd/bundle/deployment/unbind.go
+++ b/cmd/bundle/deployment/unbind.go
@@ -54,7 +54,7 @@ To re-bind the resource later, use:
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		b, stateDesc, err := utils.ProcessBundleRet(cmd, utils.ProcessOptions{
 			InitFunc: func(b *bundle.Bundle) {
-				b.Config.Bundle.Deployment.Lock.Force = forceLock
+				utils.SetForceLock(cmd, b, forceLock)
 			},
 			AlwaysPull: true,
 		})

--- a/cmd/bundle/destroy.go
+++ b/cmd/bundle/destroy.go
@@ -63,7 +63,7 @@ func CommandBundleDestroy(cmd *cobra.Command, args []string, autoApprove, forceD
 	opts := utils.ProcessOptions{
 		InitFunc: func(b *bundle.Bundle) {
 			// If `--force-lock` is specified, force acquisition of the deployment lock.
-			b.Config.Bundle.Deployment.Lock.Force = forceDestroy
+			utils.SetForceLock(cmd, b, forceDestroy)
 
 			// If `--auto-approve`` is specified, we skip confirmation checks
 			b.AutoApprove = autoApprove

--- a/cmd/bundle/utils/utils.go
+++ b/cmd/bundle/utils/utils.go
@@ -8,6 +8,23 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// SetForceLock applies the --force-lock flag to the bundle configuration.
+//
+// The flag must only override bundle.deployment.lock.force when the user passed
+// it explicitly. InitFunc runs after the configuration is loaded, so assigning
+// unconditionally would let the flag's default of false clobber a force: true
+// set in databricks.yml. Commands that share this code path without registering
+// the flag (bundle generate, which binds with forcing disabled) leave the
+// configured value untouched.
+func SetForceLock(cmd *cobra.Command, b *bundle.Bundle, forceLock bool) {
+	flag := cmd.Flags().Lookup("force-lock")
+	if flag == nil || !flag.Changed {
+		return
+	}
+
+	b.Config.Bundle.Deployment.Lock.Force = forceLock
+}
+
 func configureVariables(cmd *cobra.Command, b *bundle.Bundle, variables []string) {
 	bundle.ApplyFuncContext(cmd.Context(), b, func(ctx context.Context, b *bundle.Bundle) {
 		err := b.Config.InitializeVariables(variables)

--- a/cmd/bundle/utils/utils_test.go
+++ b/cmd/bundle/utils/utils_test.go
@@ -1,0 +1,71 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/databricks/cli/bundle"
+	"github.com/databricks/cli/bundle/config"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetForceLock(t *testing.T) {
+	tests := []struct {
+		name         string
+		args         []string
+		registerFlag bool
+		configured   bool
+		forceLock    bool
+		expected     bool
+	}{
+		{
+			name:         "flag set to true overrides configured false",
+			args:         []string{"--force-lock"},
+			registerFlag: true,
+			forceLock:    true,
+			expected:     true,
+		},
+		{
+			name:         "flag set to false overrides configured true",
+			args:         []string{"--force-lock=false"},
+			registerFlag: true,
+			configured:   true,
+			expected:     false,
+		},
+		{
+			name:         "unset flag preserves configured true",
+			registerFlag: true,
+			configured:   true,
+			expected:     true,
+		},
+		{
+			name:         "unset flag leaves configured false alone",
+			registerFlag: true,
+			expected:     false,
+		},
+		{
+			name:       "unregistered flag preserves configured true",
+			configured: true,
+			expected:   true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := &cobra.Command{Use: "deploy"}
+			var forceLock bool
+			if tc.registerFlag {
+				cmd.Flags().BoolVar(&forceLock, "force-lock", false, "")
+			}
+			require.NoError(t, cmd.ParseFlags(tc.args))
+
+			b := &bundle.Bundle{Config: config.Root{}}
+			b.Config.Bundle.Deployment.Lock.Force = tc.configured
+
+			SetForceLock(cmd, b, tc.forceLock)
+
+			assert.Equal(t, tc.expected, b.Config.Bundle.Deployment.Lock.Force)
+		})
+	}
+}

--- a/cmd/pipelines/deploy.go
+++ b/cmd/pipelines/deploy.go
@@ -38,7 +38,7 @@ func deployCommand() *cobra.Command {
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		b, err := utils.ProcessBundle(cmd, utils.ProcessOptions{
 			InitFunc: func(b *bundle.Bundle) {
-				b.Config.Bundle.Deployment.Lock.Force = forceLock
+				utils.SetForceLock(cmd, b, forceLock)
 				b.AutoApprove = autoApprove
 
 				if cmd.Flag("fail-on-active-runs").Changed {


### PR DESCRIPTION
## Changes

`bundle.deployment.lock.force` had no effect. Setting it in `databricks.yml` did not let a deploy break through a stale deployment lock — only the `--force-lock` flag worked.

The flag was assigned unconditionally inside `InitFunc`, which runs *after* the bundle configuration is loaded (`cmd/bundle/utils/process.go:138`). With the flag absent, its zero value `false` overwrote a `force: true` from config:

```go
b.Config.Bundle.Force = force
b.Config.Bundle.Deployment.Lock.Force = forceLock   // always overwrites config
```

Both halves of the lock override are then lost: `libs/locker/locker.go` only adds `filer.OverwriteIfExists` when forced, and `assertLockHeld` checks the `IsForced` field. Neither gets set, so the write fails against the existing lock exactly as if nothing had been passed.

The neighbouring flags in the very same closure were already guarded (`--cluster-id`, `--fail-on-active-runs`); `--force-lock` was the one that wasn't. In `cmd/apps/deploy_bundle.go` the enclosing function's own doc comment already stated the intended contract — "Flags that override bundle YAML are only applied when explicitly set by the user" — which `forceLock` did not honor.

This is a user-visible silent-ignore: the field is documented in `annotations.yml`, appears in the [public reference docs](https://docs.databricks.com/aws/en/dev-tools/bundles/reference), and passes schema validation, so users get no warning that it does nothing.

Fix: route all six sites through a new `utils.SetForceLock`, which applies the flag only when explicitly passed. It uses `Flags().Lookup` rather than `cmd.Flag(...).Changed` because `BindResource` is also reached from `bundle generate`, which never registers the flag and would panic on a nil return.

`cmd/apps/import.go` is intentionally unchanged: it forces `false` on a synthetic command with no flags.

### Scope note on `bundle.force`

`b.Config.Bundle.Force` is clobbered the same way but is *not* a bug, so it is deliberately left alone. It is tagged `bundle:"readonly"` and `libs/jsonschema/from_type.go` strips readonly fields from the generated schema. Confirmed against the generated schema:

```
Bundle: ['cluster_id', 'compute_id', 'databricks_cli_version', 'deployment', 'engine', 'git', 'name', 'uuid']
Lock:   ['enabled', 'force']
```

`bundle.force` is not a settable field, so a flag default cannot overwrite anything a user could have set. The public reference docs likewise document `deployment.lock.force` but have no entry for `bundle.force`. Every other `b.Config.*` assignment in the flag paths (`cluster_id`, `fail_on_active_runs`) is already `.Changed`-guarded; `AutoApprove`, `Select`, and `SkipLocalFileValidation` live on the `Bundle` struct rather than `Config` and are not YAML-settable. `lock.force` was the only field affected.

Out of scope but worth noting: `readonly` only strips a field from the schema, so `bundle.force: true` in YAML is still accepted by the loader and shows up in `bundle validate -o json` with no warning. That gap affects every readonly field and predates this change.

## Tests

New acceptance test `acceptance/bundle/deploy/force-lock-config/` seeds a real stale lock held by another user, then deploys with only `force: true` in `databricks.yml` — following the existing `acceptance/pipelines/deploy/force-lock/` pattern rather than asserting on request shape.

Verified it fails before the fix and passes after. Against the unfixed code it reproduces the reported error:

```
Error: Failed to acquire deployment lock: deploy lock acquired by user-with-lock@databricks.com at [TIMESTAMP] +0000 UTC.
Another deployment may be in progress. Use --force-lock to override, but this may
conflict with the other deployment if it is still active
```

With the fix the lock is overridden and the deploy completes.

`cmd/apps/deploy_bundle_test.go` had an assertion pinning the old behavior (`"force, forceLock, autoApprove always apply"`), now split into unset-flag and explicit-flag cases. The unset case pre-seeds `lock.force = true` via a new `configure` hook, since a zero-value bundle cannot detect a clobber. Also added a table-driven unit test for the helper in `cmd/bundle/utils/utils_test.go`.

`./cmd/...` 2379 passed; bundle deploy/destroy, deployment, help, pipelines and apps acceptance suites 450 passed; `./task fmt`, `./task lint-q`, `./task checks` clean.

This pull request and its description were written by Isaac, an AI coding agent.
