### PR TITLE
acc: always run acceptance tests locally

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -659,14 +659,10 @@ func validateTestPhase(phase int) error {
 func getSkipReason(config *internal.TestConfig, configPath, dir, skipLocalMode string, changedTests map[string][]string) string {
 	switch skipLocalMode {
 	case SkipLocalAll:
-		if isTruePtr(config.Local) {
-			return "Disabled via DATABRICKS_TEST_SKIPLOCAL=" + SkipLocalAll + " in " + configPath
-		}
+		return "Disabled via DATABRICKS_TEST_SKIPLOCAL=" + SkipLocalAll + " in " + configPath
 	case SkipLocalWithChanged:
-		if isTruePtr(config.Local) {
-			if _, ok := changedTests[dir]; !ok {
-				return "Disabled via DATABRICKS_TEST_SKIPLOCAL=" + SkipLocalWithChanged + " in " + configPath
-			}
+		if _, ok := changedTests[dir]; !ok {
+			return "Disabled via DATABRICKS_TEST_SKIPLOCAL=" + SkipLocalWithChanged + " in " + configPath
 		}
 	}
 
@@ -721,11 +717,6 @@ func getSkipReason(config *internal.TestConfig, configPath, dir, skipLocalMode s
 			return fmt.Sprintf("Disabled via RequiresCluster setting in %s (TEST_DEFAULT_CLUSTER_ID is empty)", configPath)
 		}
 
-	} else {
-		// Local run
-		if !isTruePtr(config.Local) {
-			return fmt.Sprintf("Disabled via Local setting in %s (CLOUD_ENV=%s)", configPath, cloudEnv)
-		}
 	}
 
 	return ""

--- a/acceptance/apps/deploy/bundle-no-args-with-flags/out.test.toml
+++ b/acceptance/apps/deploy/bundle-no-args-with-flags/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/apps/deploy/bundle-no-args-with-flags/test.toml
+++ b/acceptance/apps/deploy/bundle-no-args-with-flags/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 
 Ignore = [

--- a/acceptance/apps/deploy/bundle-no-args/out.test.toml
+++ b/acceptance/apps/deploy/bundle-no-args/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/apps/deploy/bundle-no-args/test.toml
+++ b/acceptance/apps/deploy/bundle-no-args/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 
 Ignore = [

--- a/acceptance/apps/deploy/bundle-with-appname/out.test.toml
+++ b/acceptance/apps/deploy/bundle-with-appname/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/apps/deploy/bundle-with-appname/test.toml
+++ b/acceptance/apps/deploy/bundle-with-appname/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 RecordRequests = true
 

--- a/acceptance/apps/deploy/no-bundle-no-args/out.test.toml
+++ b/acceptance/apps/deploy/no-bundle-no-args/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/apps/deploy/no-bundle-no-args/test.toml
+++ b/acceptance/apps/deploy/no-bundle-no-args/test.toml
@@ -1,1 +1,0 @@
-Cloud = false

--- a/acceptance/apps/deploy/no-bundle-no-args/test.toml
+++ b/acceptance/apps/deploy/no-bundle-no-args/test.toml
@@ -1,2 +1,1 @@
-Local = true
 Cloud = false

--- a/acceptance/apps/deploy/no-bundle-with-appname/out.test.toml
+++ b/acceptance/apps/deploy/no-bundle-with-appname/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/apps/deploy/no-bundle-with-appname/test.toml
+++ b/acceptance/apps/deploy/no-bundle-with-appname/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 RecordRequests = true
 

--- a/acceptance/auth/bundle_and_profile/out.test.toml
+++ b/acceptance/auth/bundle_and_profile/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/auth/bundle_default_profile/out.test.toml
+++ b/acceptance/auth/bundle_default_profile/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/auth/credentials/basic/out.test.toml
+++ b/acceptance/auth/credentials/basic/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/auth/credentials/oauth/out.test.toml
+++ b/acceptance/auth/credentials/oauth/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/auth/credentials/pat/out.test.toml
+++ b/acceptance/auth/credentials/pat/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/auth/host-metadata-cache/out.test.toml
+++ b/acceptance/auth/host-metadata-cache/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/ai_runtime_task/empty_code_source/out.test.toml
+++ b/acceptance/bundle/ai_runtime_task/empty_code_source/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/ai_runtime_task/local_code_source/out.test.toml
+++ b/acceptance/bundle/ai_runtime_task/local_code_source/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/apps/app_yaml/out.test.toml
+++ b/acceptance/bundle/apps/app_yaml/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/apps/artifact_and_app_same_path/out.test.toml
+++ b/acceptance/bundle/apps/artifact_and_app_same_path/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/apps/compute_size/out.test.toml
+++ b/acceptance/bundle/apps/compute_size/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/apps/compute_size/test.toml
+++ b/acceptance/bundle/apps/compute_size/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RecordRequests = false
 

--- a/acceptance/bundle/apps/delete_deleting/out.test.toml
+++ b/acceptance/bundle/apps/delete_deleting/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/apps/delete_deleting/test.toml
+++ b/acceptance/bundle/apps/delete_deleting/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 RecordRequests = false
 

--- a/acceptance/bundle/apps/git_source/out.test.toml
+++ b/acceptance/bundle/apps/git_source/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 RequiresWarehouse = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/apps/git_source/test.toml
+++ b/acceptance/bundle/apps/git_source/test.toml
@@ -1,5 +1,4 @@
 # Test that git_repository and git_source fields are properly configured for apps
-Local = true
 # Temporary disable cloud tests because it fails with "Git repository cannot be defined in this workspace. Please try again later."
 Cloud = false
 RecordRequests = false

--- a/acceptance/bundle/apps/job_permissions/out.test.toml
+++ b/acceptance/bundle/apps/job_permissions/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/apps/job_permissions_warning/out.test.toml
+++ b/acceptance/bundle/apps/job_permissions_warning/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/apps/value_from_warning/out.test.toml
+++ b/acceptance/bundle/apps/value_from_warning/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/ai_runtime_code_source/out.test.toml
+++ b/acceptance/bundle/artifacts/ai_runtime_code_source/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/artifacts/artifact_path_with_volume/test.toml
+++ b/acceptance/bundle/artifacts/artifact_path_with_volume/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 

--- a/acceptance/bundle/artifacts/artifact_path_with_volume/volume_doesnot_exist/out.test.toml
+++ b/acceptance/bundle/artifacts/artifact_path_with_volume/volume_doesnot_exist/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/artifact_path_with_volume/volume_not_deployed/out.test.toml
+++ b/acceptance/bundle/artifacts/artifact_path_with_volume/volume_not_deployed/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/artifact_upload_for_volumes/out.test.toml
+++ b/acceptance/bundle/artifacts/artifact_upload_for_volumes/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/artifact_upload_for_workspace/out.test.toml
+++ b/acceptance/bundle/artifacts/artifact_upload_for_workspace/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/artifact_upload_with_no_library_reference/out.test.toml
+++ b/acceptance/bundle/artifacts/artifact_upload_with_no_library_reference/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/artifacts_dynamic_version/out.test.toml
+++ b/acceptance/bundle/artifacts/artifacts_dynamic_version/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/build_and_files/out.test.toml
+++ b/acceptance/bundle/artifacts/build_and_files/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/build_and_files_whl/out.test.toml
+++ b/acceptance/bundle/artifacts/build_and_files_whl/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/glob_exact_whl/out.test.toml
+++ b/acceptance/bundle/artifacts/glob_exact_whl/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/globs_in_files/out.test.toml
+++ b/acceptance/bundle/artifacts/globs_in_files/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/globs_in_files_in_include/out.test.toml
+++ b/acceptance/bundle/artifacts/globs_in_files_in_include/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/globs_invalid/out.test.toml
+++ b/acceptance/bundle/artifacts/globs_invalid/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/issue_3109/out.test.toml
+++ b/acceptance/bundle/artifacts/issue_3109/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/nil_artifacts/out.test.toml
+++ b/acceptance/bundle/artifacts/nil_artifacts/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/same_name_libraries/out.test.toml
+++ b/acceptance/bundle/artifacts/same_name_libraries/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/shell/bash/out.test.toml
+++ b/acceptance/bundle/artifacts/shell/bash/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/shell/basic/out.test.toml
+++ b/acceptance/bundle/artifacts/shell/basic/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/shell/cmd/out.test.toml
+++ b/acceptance/bundle/artifacts/shell/cmd/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 GOOS.darwin = false
 GOOS.linux = false

--- a/acceptance/bundle/artifacts/shell/default/out.test.toml
+++ b/acceptance/bundle/artifacts/shell/default/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/shell/err-bash/out.test.toml
+++ b/acceptance/bundle/artifacts/shell/err-bash/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/shell/err-sh/out.test.toml
+++ b/acceptance/bundle/artifacts/shell/err-sh/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/shell/invalid/out.test.toml
+++ b/acceptance/bundle/artifacts/shell/invalid/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/shell/sh/out.test.toml
+++ b/acceptance/bundle/artifacts/shell/sh/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/shell/test.toml
+++ b/acceptance/bundle/artifacts/shell/test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 RecordRequests = false

--- a/acceptance/bundle/artifacts/unique_name_libraries/out.test.toml
+++ b/acceptance/bundle/artifacts/unique_name_libraries/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/upload_multiple_libraries/out.test.toml
+++ b/acceptance/bundle/artifacts/upload_multiple_libraries/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/whl_change_version/out.test.toml
+++ b/acceptance/bundle/artifacts/whl_change_version/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/whl_dbfs/out.test.toml
+++ b/acceptance/bundle/artifacts/whl_dbfs/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/whl_dynamic/out.test.toml
+++ b/acceptance/bundle/artifacts/whl_dynamic/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/whl_explicit/out.test.toml
+++ b/acceptance/bundle/artifacts/whl_explicit/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/whl_implicit/out.test.toml
+++ b/acceptance/bundle/artifacts/whl_implicit/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/whl_implicit_custom_path/out.test.toml
+++ b/acceptance/bundle/artifacts/whl_implicit_custom_path/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/whl_implicit_notebook/out.test.toml
+++ b/acceptance/bundle/artifacts/whl_implicit_notebook/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/whl_multiple/out.test.toml
+++ b/acceptance/bundle/artifacts/whl_multiple/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/whl_no_cleanup/out.test.toml
+++ b/acceptance/bundle/artifacts/whl_no_cleanup/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/whl_prebuilt_multiple/out.test.toml
+++ b/acceptance/bundle/artifacts/whl_prebuilt_multiple/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/whl_prebuilt_outside/out.test.toml
+++ b/acceptance/bundle/artifacts/whl_prebuilt_outside/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/whl_prebuilt_outside_dynamic/out.test.toml
+++ b/acceptance/bundle/artifacts/whl_prebuilt_outside_dynamic/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/whl_via_environment_key/out.test.toml
+++ b/acceptance/bundle/artifacts/whl_via_environment_key/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/benchmarks/deploy/out.test.toml
+++ b/acceptance/bundle/benchmarks/deploy/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/benchmarks/plan/out.test.toml
+++ b/acceptance/bundle/benchmarks/plan/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/benchmarks/validate/out.test.toml
+++ b/acceptance/bundle/benchmarks/validate/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/bundle_tag/id/out.test.toml
+++ b/acceptance/bundle/bundle_tag/id/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/bundle_tag/url/out.test.toml
+++ b/acceptance/bundle/bundle_tag/url/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/bundle_tag/url_ref/out.test.toml
+++ b/acceptance/bundle/bundle_tag/url_ref/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/config-remote-sync/cli_defaults/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/cli_defaults/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/config_edits/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/config_edits/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/dashboard_etag/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/dashboard_etag/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresWarehouse = true
 GOOS.windows = false

--- a/acceptance/bundle/config-remote-sync/flushed_cache/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/flushed_cache/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/formatting_preserved/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/formatting_preserved/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/job_fields/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/job_fields/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 GOOS.windows = false

--- a/acceptance/bundle/config-remote-sync/job_multiple_tasks/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/job_multiple_tasks/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/job_params_variables/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/job_params_variables/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 GOOS.windows = false

--- a/acceptance/bundle/config-remote-sync/job_pipeline_task/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/job_pipeline_task/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/multiple_files/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/multiple_files/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/multiple_resources/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/multiple_resources/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 GOOS.windows = false

--- a/acceptance/bundle/config-remote-sync/output_json/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/output_json/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/output_no_changes/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/output_no_changes/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/pipeline_fields/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/pipeline_fields/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 GOOS.windows = false

--- a/acceptance/bundle/config-remote-sync/policy_injected_cluster_fields/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/policy_injected_cluster_fields/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/resolve_variables/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/resolve_variables/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 GOOS.windows = false

--- a/acceptance/bundle/config-remote-sync/select_basic/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/select_basic/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/select_multiple/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/select_multiple/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/skip_permissions/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/skip_permissions/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/split/cli_default_split_element/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/split/cli_default_split_element/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/split/dotted_target/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/split/dotted_target/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/split/isolation/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/split/isolation/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/split/keyed_edit/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/split/keyed_edit/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/split/keyed_remove/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/split/keyed_remove/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/split/keyed_rename/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/split/keyed_rename/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/split/keyed_twoblock/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/split/keyed_twoblock/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/split/multifile/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/split/multifile/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/split/nested_add_split_parent/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/split/nested_add_split_parent/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/split/nested_sequence/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/split/nested_sequence/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/split/positional/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/split/positional/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/split/remove_field_both_blocks/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/split/remove_field_both_blocks/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/split/remove_with_unrelated_add/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/split/remove_with_unrelated_add/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/split/rename_ambiguous_pairing/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/split/rename_ambiguous_pairing/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/split/rename_ambiguous_single_block/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/split/rename_ambiguous_single_block/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/split/rename_two_removes_one_add/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/split/rename_two_removes_one_add/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/split/target_variable/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/split/target_variable/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/split/variable_file_order/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/split/variable_file_order/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/target_override/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/target_override/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/task_rename_revert/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/task_rename_revert/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/validation_errors/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/validation_errors/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/debug/list-targets/out.test.toml
+++ b/acceptance/bundle/debug/list-targets/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/debug/out.test.toml
+++ b/acceptance/bundle/debug/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deploy/empty-bundle/out.test.toml
+++ b/acceptance/bundle/deploy/empty-bundle/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 EnvMatrix.DATABRICKS_BUNDLE_ENABLE_EXPERIMENTAL_YAML_SYNC = ["", "true"]
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deploy/experimental-python/out.test.toml
+++ b/acceptance/bundle/deploy/experimental-python/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deploy/fail-on-active-runs/out.test.toml
+++ b/acceptance/bundle/deploy/fail-on-active-runs/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deploy/files/no-snapshot-sync/out.test.toml
+++ b/acceptance/bundle/deploy/files/no-snapshot-sync/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deploy/files/no-snapshot-sync/test.toml
+++ b/acceptance/bundle/deploy/files/no-snapshot-sync/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 
 Ignore = [

--- a/acceptance/bundle/deploy/files/out-of-band-delete/out.test.toml
+++ b/acceptance/bundle/deploy/files/out-of-band-delete/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deploy/force-lock-config/out.test.toml
+++ b/acceptance/bundle/deploy/force-lock-config/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deploy/force-lock-config/test.toml
+++ b/acceptance/bundle/deploy/force-lock-config/test.toml
@@ -1,1 +1,0 @@
-Cloud = false

--- a/acceptance/bundle/deploy/force-lock-config/test.toml
+++ b/acceptance/bundle/deploy/force-lock-config/test.toml
@@ -1,2 +1,1 @@
-Local = true
 Cloud = false

--- a/acceptance/bundle/deploy/immutable-no-artifacts/out.test.toml
+++ b/acceptance/bundle/deploy/immutable-no-artifacts/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/deploy/immutable-no-artifacts/test.toml
+++ b/acceptance/bundle/deploy/immutable-no-artifacts/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false # Temporary disable cloud tests until the API is fully available
 RecordRequests = true
 

--- a/acceptance/bundle/deploy/immutable-permissions-change/out.test.toml
+++ b/acceptance/bundle/deploy/immutable-permissions-change/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/deploy/immutable-permissions-change/test.toml
+++ b/acceptance/bundle/deploy/immutable-permissions-change/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false # Temporary disable cloud tests until the API is fully available
 
 # immutable_folder only works with the direct engine.

--- a/acceptance/bundle/deploy/immutable/out.test.toml
+++ b/acceptance/bundle/deploy/immutable/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/deploy/immutable/test.toml
+++ b/acceptance/bundle/deploy/immutable/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false # Temporary disable cloud tests until the API is fully available
 
 # immutable_folder only works with the direct engine.

--- a/acceptance/bundle/deploy/mlops-stacks/out.test.toml
+++ b/acceptance/bundle/deploy/mlops-stacks/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deploy/mlops-stacks/test.toml
+++ b/acceptance/bundle/deploy/mlops-stacks/test.toml
@@ -1,6 +1,4 @@
 Cloud=true
-Local=true
-
 # The MLOps Stacks template registers the model in Unity Catalog and runs its
 # jobs on serverless compute, so this test only works on a UC-enabled workspace
 # (which also has serverless jobs). Gate on UC so it skips on the non-UC cloud

--- a/acceptance/bundle/deploy/pipeline-config-dots/out.test.toml
+++ b/acceptance/bundle/deploy/pipeline-config-dots/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deploy/python-notebook/out.test.toml
+++ b/acceptance/bundle/deploy/python-notebook/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deploy/readplan/basic/out.test.toml
+++ b/acceptance/bundle/deploy/readplan/basic/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/deploy/readplan/cli-version-mismatch/out.test.toml
+++ b/acceptance/bundle/deploy/readplan/cli-version-mismatch/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/deploy/readplan/grants-remove-principal/out.test.toml
+++ b/acceptance/bundle/deploy/readplan/grants-remove-principal/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]
 EnvMatrix.READPLAN = ["", "1"]

--- a/acceptance/bundle/deploy/readplan/invalid-plan/out.test.toml
+++ b/acceptance/bundle/deploy/readplan/invalid-plan/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/deploy/readplan/lineage-mismatch/out.test.toml
+++ b/acceptance/bundle/deploy/readplan/lineage-mismatch/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/deploy/readplan/plan-not-found/out.test.toml
+++ b/acceptance/bundle/deploy/readplan/plan-not-found/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/deploy/readplan/plan-version-mismatch/out.test.toml
+++ b/acceptance/bundle/deploy/readplan/plan-version-mismatch/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/deploy/readplan/postgres_role/out.test.toml
+++ b/acceptance/bundle/deploy/readplan/postgres_role/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/deploy/readplan/serial-mismatch/out.test.toml
+++ b/acceptance/bundle/deploy/readplan/serial-mismatch/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/deploy/readplan/terraform-error/out.test.toml
+++ b/acceptance/bundle/deploy/readplan/terraform-error/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform"]

--- a/acceptance/bundle/deploy/readplan/unknown-field/out.test.toml
+++ b/acceptance/bundle/deploy/readplan/unknown-field/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/deploy/snapshot-comparison/out.test.toml
+++ b/acceptance/bundle/deploy/snapshot-comparison/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform"]

--- a/acceptance/bundle/deploy/spark-jar-task/out.test.toml
+++ b/acceptance/bundle/deploy/spark-jar-task/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deploy/spark-jar-task/test.toml
+++ b/acceptance/bundle/deploy/spark-jar-task/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
 

--- a/acceptance/bundle/deploy/wal/chain-3-jobs/out.test.toml
+++ b/acceptance/bundle/deploy/wal/chain-3-jobs/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/deploy/wal/corrupted-wal-entry/out.test.toml
+++ b/acceptance/bundle/deploy/wal/corrupted-wal-entry/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/deploy/wal/crash-after-create/out.test.toml
+++ b/acceptance/bundle/deploy/wal/crash-after-create/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 EnvMatrix.COMMAND = ["plan", "deploy --force-lock", "summary"]
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/deploy/wal/empty-wal/out.test.toml
+++ b/acceptance/bundle/deploy/wal/empty-wal/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/deploy/wal/failed-plan-no-wal/out.test.toml
+++ b/acceptance/bundle/deploy/wal/failed-plan-no-wal/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/deploy/wal/future-serial-wal/out.test.toml
+++ b/acceptance/bundle/deploy/wal/future-serial-wal/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/deploy/wal/header-only-wal/out.test.toml
+++ b/acceptance/bundle/deploy/wal/header-only-wal/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/deploy/wal/lineage-mismatch/out.test.toml
+++ b/acceptance/bundle/deploy/wal/lineage-mismatch/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 EnvMatrix.COMMAND = ["deploy", "plan", "summary"]
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/deploy/wal/stale-wal/out.test.toml
+++ b/acceptance/bundle/deploy/wal/stale-wal/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/deploy/wal/test.toml
+++ b/acceptance/bundle/deploy/wal/test.toml
@@ -2,7 +2,6 @@
 # These tests simulate process crashes using KillCaller and verify state recovery.
 # Only runs with direct engine since WAL is a direct-engine feature.
 
-Local = true
 Env.DATABRICKS_CLI_TEST_PID = "1"
 
 [EnvMatrix]

--- a/acceptance/bundle/deploy/wal/wal-with-delete/out.test.toml
+++ b/acceptance/bundle/deploy/wal/wal-with-delete/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/deploy/yaml-sync-empty-grants/out.test.toml
+++ b/acceptance/bundle/deploy/yaml-sync-empty-grants/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform"]

--- a/acceptance/bundle/deployment/bind/alert/out.test.toml
+++ b/acceptance/bundle/deployment/bind/alert/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/alert/test.toml
+++ b/acceptance/bundle/deployment/bind/alert/test.toml
@@ -1,6 +1,4 @@
 Cloud = true
-Local = true
-
 # Alert tests timeout during bundle deploy (hang at file upload for 50+ minutes).
 # Use aggressive 5-minute timeout until the issue is resolved.
 # See: https://github.com/databricks/cli/issues/4221

--- a/acceptance/bundle/deployment/bind/catalog/out.test.toml
+++ b/acceptance/bundle/deployment/bind/catalog/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/deployment/bind/catalog/test.toml
+++ b/acceptance/bundle/deployment/bind/catalog/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 

--- a/acceptance/bundle/deployment/bind/cluster/out.test.toml
+++ b/acceptance/bundle/deployment/bind/cluster/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresCluster = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/cluster/test.toml
+++ b/acceptance/bundle/deployment/bind/cluster/test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = true
 RequiresCluster = true

--- a/acceptance/bundle/deployment/bind/dashboard/out.test.toml
+++ b/acceptance/bundle/deployment/bind/dashboard/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresWarehouse = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/dashboard/recreation/out.test.toml
+++ b/acceptance/bundle/deployment/bind/dashboard/recreation/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresWarehouse = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/dashboard/test.toml
+++ b/acceptance/bundle/deployment/bind/dashboard/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresWarehouse = true
 

--- a/acceptance/bundle/deployment/bind/database_instance/out.test.toml
+++ b/acceptance/bundle/deployment/bind/database_instance/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/database_instance/test.toml
+++ b/acceptance/bundle/deployment/bind/database_instance/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 
 Ignore = [

--- a/acceptance/bundle/deployment/bind/experiment/out.test.toml
+++ b/acceptance/bundle/deployment/bind/experiment/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/experiment/test.toml
+++ b/acceptance/bundle/deployment/bind/experiment/test.toml
@@ -1,2 +1,1 @@
-Local = true
 Cloud = true

--- a/acceptance/bundle/deployment/bind/external_location/out.test.toml
+++ b/acceptance/bundle/deployment/bind/external_location/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/deployment/bind/external_location/test.toml
+++ b/acceptance/bundle/deployment/bind/external_location/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 
 Ignore = [

--- a/acceptance/bundle/deployment/bind/genie_space/out.test.toml
+++ b/acceptance/bundle/deployment/bind/genie_space/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/deployment/bind/genie_space/test.toml
+++ b/acceptance/bundle/deployment/bind/genie_space/test.toml
@@ -1,5 +1,3 @@
-Local = true
-
 # Genie spaces are only deployed via the direct deployment engine.
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]
 

--- a/acceptance/bundle/deployment/bind/job/already-managed-different/out.test.toml
+++ b/acceptance/bundle/deployment/bind/job/already-managed-different/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/job/already-managed-same/out.test.toml
+++ b/acceptance/bundle/deployment/bind/job/already-managed-same/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/job/engine-from-config/out.test.toml
+++ b/acceptance/bundle/deployment/bind/job/engine-from-config/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/deployment/bind/job/generate-and-bind/out.test.toml
+++ b/acceptance/bundle/deployment/bind/job/generate-and-bind/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/job/generate-and-bind/test.toml
+++ b/acceptance/bundle/deployment/bind/job/generate-and-bind/test.toml
@@ -1,7 +1,6 @@
 # This test uses the workspace import API to load a notebook file. The testserver
 # models the SOURCE import format (notebook with an explicit language), so it runs
 # locally in addition to cloud.
-Local = true
 Cloud = true
 
 Ignore = [

--- a/acceptance/bundle/deployment/bind/job/job-abort-bind/out.test.toml
+++ b/acceptance/bundle/deployment/bind/job/job-abort-bind/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/job/job-abort-bind/test.toml
+++ b/acceptance/bundle/deployment/bind/job/job-abort-bind/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 
 Ignore = [

--- a/acceptance/bundle/deployment/bind/job/job-spark-python-task/out.test.toml
+++ b/acceptance/bundle/deployment/bind/job/job-spark-python-task/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/job/job-spark-python-task/test.toml
+++ b/acceptance/bundle/deployment/bind/job/job-spark-python-task/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 
 Ignore = [

--- a/acceptance/bundle/deployment/bind/job/noop-job/out.test.toml
+++ b/acceptance/bundle/deployment/bind/job/noop-job/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/job/python-job/out.test.toml
+++ b/acceptance/bundle/deployment/bind/job/python-job/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/job/stale-state/out.test.toml
+++ b/acceptance/bundle/deployment/bind/job/stale-state/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/model-serving-endpoint/out.test.toml
+++ b/acceptance/bundle/deployment/bind/model-serving-endpoint/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/model-serving-endpoint/test.toml
+++ b/acceptance/bundle/deployment/bind/model-serving-endpoint/test.toml
@@ -1,2 +1,1 @@
-Local = true
 Cloud = true

--- a/acceptance/bundle/deployment/bind/pipelines/recreate/out.test.toml
+++ b/acceptance/bundle/deployment/bind/pipelines/recreate/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/pipelines/update/out.test.toml
+++ b/acceptance/bundle/deployment/bind/pipelines/update/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/postgres_database/out.test.toml
+++ b/acceptance/bundle/deployment/bind/postgres_database/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/postgres_database/test.toml
+++ b/acceptance/bundle/deployment/bind/postgres_database/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 
 Ignore = [

--- a/acceptance/bundle/deployment/bind/postgres_role/out.test.toml
+++ b/acceptance/bundle/deployment/bind/postgres_role/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/postgres_role/test.toml
+++ b/acceptance/bundle/deployment/bind/postgres_role/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 
 Ignore = [

--- a/acceptance/bundle/deployment/bind/quality-monitor/out.test.toml
+++ b/acceptance/bundle/deployment/bind/quality-monitor/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/quality-monitor/test.toml
+++ b/acceptance/bundle/deployment/bind/quality-monitor/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 
 [[Repls]]

--- a/acceptance/bundle/deployment/bind/registered-model/out.test.toml
+++ b/acceptance/bundle/deployment/bind/registered-model/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/registered-model/test.toml
+++ b/acceptance/bundle/deployment/bind/registered-model/test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true

--- a/acceptance/bundle/deployment/bind/schema/out.test.toml
+++ b/acceptance/bundle/deployment/bind/schema/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/schema/test.toml
+++ b/acceptance/bundle/deployment/bind/schema/test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true

--- a/acceptance/bundle/deployment/bind/secret-scope/out.test.toml
+++ b/acceptance/bundle/deployment/bind/secret-scope/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/secret-scope/test.toml
+++ b/acceptance/bundle/deployment/bind/secret-scope/test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true

--- a/acceptance/bundle/deployment/bind/sql_warehouse/out.test.toml
+++ b/acceptance/bundle/deployment/bind/sql_warehouse/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/sql_warehouse/test.toml
+++ b/acceptance/bundle/deployment/bind/sql_warehouse/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 
 Ignore = [

--- a/acceptance/bundle/deployment/bind/vector_search_endpoint/out.test.toml
+++ b/acceptance/bundle/deployment/bind/vector_search_endpoint/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/deployment/bind/vector_search_endpoint/test.toml
+++ b/acceptance/bundle/deployment/bind/vector_search_endpoint/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 

--- a/acceptance/bundle/deployment/bind/vector_search_index/out.test.toml
+++ b/acceptance/bundle/deployment/bind/vector_search_index/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 CloudSlow = true
 RequiresUnityCatalog = true

--- a/acceptance/bundle/deployment/bind/vector_search_index/test.toml
+++ b/acceptance/bundle/deployment/bind/vector_search_index/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 

--- a/acceptance/bundle/deployment/bind/volume/out.test.toml
+++ b/acceptance/bundle/deployment/bind/volume/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/volume/test.toml
+++ b/acceptance/bundle/deployment/bind/volume/test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true

--- a/acceptance/bundle/deployment/unbind/engine-from-config/out.test.toml
+++ b/acceptance/bundle/deployment/unbind/engine-from-config/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/deployment/unbind/grants/out.test.toml
+++ b/acceptance/bundle/deployment/unbind/grants/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/unbind/job/out.test.toml
+++ b/acceptance/bundle/deployment/unbind/job/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/unbind/permissions/out.test.toml
+++ b/acceptance/bundle/deployment/unbind/permissions/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/unbind/python-job/out.test.toml
+++ b/acceptance/bundle/deployment/unbind/python-job/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/destroy/all-resources/out.test.toml
+++ b/acceptance/bundle/destroy/all-resources/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/destroy/force-lock-node-limit/out.test.toml
+++ b/acceptance/bundle/destroy/force-lock-node-limit/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/destroy/jobs-and-pipeline/out.test.toml
+++ b/acceptance/bundle/destroy/jobs-and-pipeline/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/destroy/jobs-and-pipeline/test.toml
+++ b/acceptance/bundle/destroy/jobs-and-pipeline/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 
 Ignore = [

--- a/acceptance/bundle/empty_string_dropped/out.test.toml
+++ b/acceptance/bundle/empty_string_dropped/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/empty_string_dropped/test.toml
+++ b/acceptance/bundle/empty_string_dropped/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 RecordRequests = true
 

--- a/acceptance/bundle/empty_string_variable/out.test.toml
+++ b/acceptance/bundle/empty_string_variable/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/environments/dependencies/out.test.toml
+++ b/acceptance/bundle/environments/dependencies/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/experimental/skip_name_prefix_for_schema/out.test.toml
+++ b/acceptance/bundle/experimental/skip_name_prefix_for_schema/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/generate/alert/out.test.toml
+++ b/acceptance/bundle/generate/alert/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/generate/alert/test.toml
+++ b/acceptance/bundle/generate/alert/test.toml
@@ -1,6 +1,4 @@
 Cloud = true
-Local = true
-
 # Alert tests timeout during bundle deploy (hang at file upload for 50+ minutes).
 # Use aggressive 5-minute timeout until the issue is resolved.
 # See: https://github.com/databricks/cli/issues/4221

--- a/acceptance/bundle/generate/alert_existing_id_not_found/out.test.toml
+++ b/acceptance/bundle/generate/alert_existing_id_not_found/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/generate/app_not_yet_deployed/out.test.toml
+++ b/acceptance/bundle/generate/app_not_yet_deployed/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/generate/app_not_yet_deployed/test.toml
+++ b/acceptance/bundle/generate/app_not_yet_deployed/test.toml
@@ -1,1 +1,0 @@
-Cloud = false

--- a/acceptance/bundle/generate/app_not_yet_deployed/test.toml
+++ b/acceptance/bundle/generate/app_not_yet_deployed/test.toml
@@ -1,2 +1,1 @@
-Local = true
 Cloud = false

--- a/acceptance/bundle/generate/app_subfolders/out.test.toml
+++ b/acceptance/bundle/generate/app_subfolders/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/generate/auto-bind/out.test.toml
+++ b/acceptance/bundle/generate/auto-bind/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform"]

--- a/acceptance/bundle/generate/auto-bind/test.toml
+++ b/acceptance/bundle/generate/auto-bind/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 
 Ignore = [
@@ -10,7 +9,6 @@ Ignore = [
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform"]
-
 
 [Env]
 # MSYS2 automatically converts absolute paths like /Users/$username/$UNIQUE_NAME to

--- a/acceptance/bundle/generate/dashboard-inplace/out.test.toml
+++ b/acceptance/bundle/generate/dashboard-inplace/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/generate/dashboard/out.test.toml
+++ b/acceptance/bundle/generate/dashboard/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/generate/dashboard_existing_id_not_found/out.test.toml
+++ b/acceptance/bundle/generate/dashboard_existing_id_not_found/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/generate/dashboard_existing_path_nominal/out.test.toml
+++ b/acceptance/bundle/generate/dashboard_existing_path_nominal/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/generate/dashboard_existing_path_not_found/out.test.toml
+++ b/acceptance/bundle/generate/dashboard_existing_path_not_found/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/generate/designer_job/out.test.toml
+++ b/acceptance/bundle/generate/designer_job/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/generate/genie_space/out.test.toml
+++ b/acceptance/bundle/generate/genie_space/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/generate/genie_space_existing_id_not_found/out.test.toml
+++ b/acceptance/bundle/generate/genie_space_existing_id_not_found/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/generate/genie_space_inplace/out.test.toml
+++ b/acceptance/bundle/generate/genie_space_inplace/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/generate/git_job/out.test.toml
+++ b/acceptance/bundle/generate/git_job/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/generate/include_warning/out.test.toml
+++ b/acceptance/bundle/generate/include_warning/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/generate/ipynb_job/out.test.toml
+++ b/acceptance/bundle/generate/ipynb_job/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/generate/job_nested_notebooks/out.test.toml
+++ b/acceptance/bundle/generate/job_nested_notebooks/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/generate/lakeflow_pipelines/out.test.toml
+++ b/acceptance/bundle/generate/lakeflow_pipelines/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/generate/pipeline/out.test.toml
+++ b/acceptance/bundle/generate/pipeline/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/generate/pipeline_and_deploy/out.test.toml
+++ b/acceptance/bundle/generate/pipeline_and_deploy/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/generate/pipeline_and_deploy/test.toml
+++ b/acceptance/bundle/generate/pipeline_and_deploy/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 
 Ignore = [

--- a/acceptance/bundle/generate/pipeline_with_glob/out.test.toml
+++ b/acceptance/bundle/generate/pipeline_with_glob/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/generate/pipeline_with_sql/out.test.toml
+++ b/acceptance/bundle/generate/pipeline_with_sql/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/generate/python_job/out.test.toml
+++ b/acceptance/bundle/generate/python_job/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/generate/python_job_and_deploy/out.test.toml
+++ b/acceptance/bundle/generate/python_job_and_deploy/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/generate/python_job_and_deploy/test.toml
+++ b/acceptance/bundle/generate/python_job_and_deploy/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 
 Ignore = [

--- a/acceptance/bundle/generate/spark_python_task_job/out.test.toml
+++ b/acceptance/bundle/generate/spark_python_task_job/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/git-permerror/out.test.toml
+++ b/acceptance/bundle/git-permerror/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/help/bundle-deploy/out.test.toml
+++ b/acceptance/bundle/help/bundle-deploy/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/help/bundle-deployment-migrate/out.test.toml
+++ b/acceptance/bundle/help/bundle-deployment-migrate/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/help/bundle-deployment/out.test.toml
+++ b/acceptance/bundle/help/bundle-deployment/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/help/bundle-destroy/out.test.toml
+++ b/acceptance/bundle/help/bundle-destroy/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/help/bundle-generate-dashboard/out.test.toml
+++ b/acceptance/bundle/help/bundle-generate-dashboard/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/help/bundle-generate-job/out.test.toml
+++ b/acceptance/bundle/help/bundle-generate-job/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/help/bundle-generate-pipeline/out.test.toml
+++ b/acceptance/bundle/help/bundle-generate-pipeline/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/help/bundle-generate/out.test.toml
+++ b/acceptance/bundle/help/bundle-generate/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/help/bundle-init/out.test.toml
+++ b/acceptance/bundle/help/bundle-init/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/help/bundle-open/out.test.toml
+++ b/acceptance/bundle/help/bundle-open/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/help/bundle-run/out.test.toml
+++ b/acceptance/bundle/help/bundle-run/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/help/bundle-schema/out.test.toml
+++ b/acceptance/bundle/help/bundle-schema/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/help/bundle-summary/out.test.toml
+++ b/acceptance/bundle/help/bundle-summary/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/help/bundle-sync/out.test.toml
+++ b/acceptance/bundle/help/bundle-sync/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/help/bundle-validate/out.test.toml
+++ b/acceptance/bundle/help/bundle-validate/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/help/bundle/out.test.toml
+++ b/acceptance/bundle/help/bundle/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/includes/glob_in_root_path/out.test.toml
+++ b/acceptance/bundle/includes/glob_in_root_path/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/includes/include_outside_root/out.test.toml
+++ b/acceptance/bundle/includes/include_outside_root/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/includes/non_yaml_in_include/out.test.toml
+++ b/acceptance/bundle/includes/non_yaml_in_include/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/includes/yml_outside_root/out.test.toml
+++ b/acceptance/bundle/includes/yml_outside_root/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/integration_whl/base/out.test.toml
+++ b/acceptance/bundle/integration_whl/base/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 CloudSlow = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/integration_whl/custom_params/out.test.toml
+++ b/acceptance/bundle/integration_whl/custom_params/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 CloudSlow = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/integration_whl/interactive_cluster/out.test.toml
+++ b/acceptance/bundle/integration_whl/interactive_cluster/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 CloudSlow = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/integration_whl/interactive_cluster_dynamic_version/out.test.toml
+++ b/acceptance/bundle/integration_whl/interactive_cluster_dynamic_version/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 CloudSlow = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/integration_whl/interactive_single_user/out.test.toml
+++ b/acceptance/bundle/integration_whl/interactive_single_user/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 CloudSlow = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/integration_whl/interactive_single_user/test.toml
+++ b/acceptance/bundle/integration_whl/interactive_single_user/test.toml
@@ -1,1 +1,0 @@
-Local = true

--- a/acceptance/bundle/integration_whl/serverless/out.test.toml
+++ b/acceptance/bundle/integration_whl/serverless/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 CloudSlow = true
 RequiresUnityCatalog = true

--- a/acceptance/bundle/integration_whl/serverless/test.toml
+++ b/acceptance/bundle/integration_whl/serverless/test.toml
@@ -1,6 +1,4 @@
 CloudSlow = true
-Local = true
-
 # serverless is only enabled if UC is enabled
 RequiresUnityCatalog = true
 

--- a/acceptance/bundle/integration_whl/serverless_custom_params/out.test.toml
+++ b/acceptance/bundle/integration_whl/serverless_custom_params/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 CloudSlow = true
 RequiresUnityCatalog = true

--- a/acceptance/bundle/integration_whl/serverless_custom_params/test.toml
+++ b/acceptance/bundle/integration_whl/serverless_custom_params/test.toml
@@ -1,5 +1,3 @@
 Cloud = true
-Local = true
-
 # serverless is only enabled if UC is enabled
 RequiresUnityCatalog = true

--- a/acceptance/bundle/integration_whl/serverless_dynamic_version/out.test.toml
+++ b/acceptance/bundle/integration_whl/serverless_dynamic_version/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 CloudSlow = true
 RequiresUnityCatalog = true

--- a/acceptance/bundle/integration_whl/test.toml
+++ b/acceptance/bundle/integration_whl/test.toml
@@ -1,4 +1,3 @@
-Local = true
 CloudSlow = true
 
 # Workspace file system does not allow initializing python envs on it.

--- a/acceptance/bundle/integration_whl/wrapper/out.test.toml
+++ b/acceptance/bundle/integration_whl/wrapper/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 CloudSlow = true
 CloudEnvs.aws = false

--- a/acceptance/bundle/integration_whl/wrapper_custom_params/out.test.toml
+++ b/acceptance/bundle/integration_whl/wrapper_custom_params/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 CloudSlow = true
 CloudEnvs.aws = false

--- a/acceptance/bundle/invariant/continue_293/out.test.toml
+++ b/acceptance/bundle/invariant/continue_293/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/invariant/delete_idempotent/out.test.toml
+++ b/acceptance/bundle/invariant/delete_idempotent/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/invariant/destroy_idempotent/out.test.toml
+++ b/acceptance/bundle/invariant/destroy_idempotent/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/invariant/migrate/out.test.toml
+++ b/acceptance/bundle/invariant/migrate/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/invariant/no_drift/out.test.toml
+++ b/acceptance/bundle/invariant/no_drift/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/invariant/test.toml
+++ b/acceptance/bundle/invariant/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 Timeout = '10m'

--- a/acceptance/bundle/libraries/maven/out.test.toml
+++ b/acceptance/bundle/libraries/maven/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/libraries/outside_of_bundle_root/out.test.toml
+++ b/acceptance/bundle/libraries/outside_of_bundle_root/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/libraries/pypi/out.test.toml
+++ b/acceptance/bundle/libraries/pypi/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/lifecycle/prevent-destroy/out.test.toml
+++ b/acceptance/bundle/lifecycle/prevent-destroy/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/lifecycle/started-validation/out.test.toml
+++ b/acceptance/bundle/lifecycle/started-validation/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/lifecycle/started/out.test.toml
+++ b/acceptance/bundle/lifecycle/started/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/lifecycle/started/test.toml
+++ b/acceptance/bundle/lifecycle/started/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 
 Ignore = [".databricks"]

--- a/acceptance/bundle/lifecycle/test.toml
+++ b/acceptance/bundle/lifecycle/test.toml
@@ -1,1 +1,0 @@
-Cloud = false

--- a/acceptance/bundle/lifecycle/test.toml
+++ b/acceptance/bundle/lifecycle/test.toml
@@ -1,2 +1,1 @@
-Local = true
 Cloud = false

--- a/acceptance/bundle/local_state_staleness/out.test.toml
+++ b/acceptance/bundle/local_state_staleness/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/local_state_staleness/test.toml
+++ b/acceptance/bundle/local_state_staleness/test.toml
@@ -1,2 +1,1 @@
 Cloud = true
-Local = true

--- a/acceptance/bundle/migrate/added/out.test.toml
+++ b/acceptance/bundle/migrate/added/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/migrate/auto-migrate-clean/out.test.toml
+++ b/acceptance/bundle/migrate/auto-migrate-clean/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]
 EnvMatrix.READPLAN = ["", "1"]

--- a/acceptance/bundle/migrate/auto-migrate-empty-tfstate/out.test.toml
+++ b/acceptance/bundle/migrate/auto-migrate-empty-tfstate/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/migrate/auto-migrate-envvar/out.test.toml
+++ b/acceptance/bundle/migrate/auto-migrate-envvar/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/migrate/auto-migrate-push-failure/out.test.toml
+++ b/acceptance/bundle/migrate/auto-migrate-push-failure/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/migrate/auto-migrate-tfbackup-failure/out.test.toml
+++ b/acceptance/bundle/migrate/auto-migrate-tfbackup-failure/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/migrate/basic/out.test.toml
+++ b/acceptance/bundle/migrate/basic/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/migrate/dashboards/out.test.toml
+++ b/acceptance/bundle/migrate/dashboards/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/migrate/default-python/out.test.toml
+++ b/acceptance/bundle/migrate/default-python/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/migrate/engine-config-direct/out.test.toml
+++ b/acceptance/bundle/migrate/engine-config-direct/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/migrate/engine-config-terraform/out.test.toml
+++ b/acceptance/bundle/migrate/engine-config-terraform/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/migrate/grants/out.test.toml
+++ b/acceptance/bundle/migrate/grants/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/migrate/permissions/out.test.toml
+++ b/acceptance/bundle/migrate/permissions/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/migrate/profile_arg/out.test.toml
+++ b/acceptance/bundle/migrate/profile_arg/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/migrate/removed/out.test.toml
+++ b/acceptance/bundle/migrate/removed/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/migrate/runas/out.test.toml
+++ b/acceptance/bundle/migrate/runas/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/migrate/var_arg/out.test.toml
+++ b/acceptance/bundle/migrate/var_arg/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/multi_profile/auto_select/out.test.toml
+++ b/acceptance/bundle/multi_profile/auto_select/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/multi_profile/env_auth_skip/out.test.toml
+++ b/acceptance/bundle/multi_profile/env_auth_skip/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/multi_profile/no_workspace_profiles/out.test.toml
+++ b/acceptance/bundle/multi_profile/no_workspace_profiles/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/multi_profile/non_interactive_error/out.test.toml
+++ b/acceptance/bundle/multi_profile/non_interactive_error/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/multi_profile/test.toml
+++ b/acceptance/bundle/multi_profile/test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 Ignore = [".databricks"]

--- a/acceptance/bundle/open/out.test.toml
+++ b/acceptance/bundle/open/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/override/clusters/out.test.toml
+++ b/acceptance/bundle/override/clusters/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/override/job_cluster/out.test.toml
+++ b/acceptance/bundle/override/job_cluster/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/override/job_cluster_var/out.test.toml
+++ b/acceptance/bundle/override/job_cluster_var/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/override/job_tasks/out.test.toml
+++ b/acceptance/bundle/override/job_tasks/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/override/merge-string-map/out.test.toml
+++ b/acceptance/bundle/override/merge-string-map/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/override/pipeline_cluster/out.test.toml
+++ b/acceptance/bundle/override/pipeline_cluster/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/paths/designer_notebook/out.test.toml
+++ b/acceptance/bundle/paths/designer_notebook/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/paths/fallback/out.test.toml
+++ b/acceptance/bundle/paths/fallback/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/paths/git_source_jobs/out.test.toml
+++ b/acceptance/bundle/paths/git_source_jobs/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/paths/invalid_pipeline_globs/out.test.toml
+++ b/acceptance/bundle/paths/invalid_pipeline_globs/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/paths/nominal/out.test.toml
+++ b/acceptance/bundle/paths/nominal/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/paths/outside_root_no_sync/out.test.toml
+++ b/acceptance/bundle/paths/outside_root_no_sync/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/paths/pipeline_expected_file_got_notebook/out.test.toml
+++ b/acceptance/bundle/paths/pipeline_expected_file_got_notebook/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/paths/pipeline_globs/out.test.toml
+++ b/acceptance/bundle/paths/pipeline_globs/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/paths/pipeline_root_path_doesnotexist/out.test.toml
+++ b/acceptance/bundle/paths/pipeline_root_path_doesnotexist/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/paths/pipelines_glob_include_and_root_path/out.test.toml
+++ b/acceptance/bundle/paths/pipelines_glob_include_and_root_path/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/paths/pipelines_root_path_outside_sync_root/out.test.toml
+++ b/acceptance/bundle/paths/pipelines_root_path_outside_sync_root/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/paths/relative_path_outside_root/out.test.toml
+++ b/acceptance/bundle/paths/relative_path_outside_root/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/paths/relative_path_translation/out.test.toml
+++ b/acceptance/bundle/paths/relative_path_translation/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/plan/no_upload/out.test.toml
+++ b/acceptance/bundle/plan/no_upload/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/plan/no_upload/test.toml
+++ b/acceptance/bundle/plan/no_upload/test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 RecordRequests = true

--- a/acceptance/bundle/presets/preset_vs_dev_mode/out.test.toml
+++ b/acceptance/bundle/presets/preset_vs_dev_mode/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/python/experimental-compatibility-both-equal/out.test.toml
+++ b/acceptance/bundle/python/experimental-compatibility-both-equal/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
 EnvMatrix.PYDAB_VERSION = ["0.266.0", "current"]

--- a/acceptance/bundle/python/experimental-compatibility-both-error/out.test.toml
+++ b/acceptance/bundle/python/experimental-compatibility-both-error/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
 EnvMatrix.PYDAB_VERSION = ["0.266.0", "current"]

--- a/acceptance/bundle/python/experimental-compatibility/out.test.toml
+++ b/acceptance/bundle/python/experimental-compatibility/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
 EnvMatrix.PYDAB_VERSION = ["0.266.0", "current"]

--- a/acceptance/bundle/python/grants-aliases/out.test.toml
+++ b/acceptance/bundle/python/grants-aliases/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
 EnvMatrix.PYDAB_VERSION = ["current"]

--- a/acceptance/bundle/python/grants-aliases/test.toml
+++ b/acceptance/bundle/python/grants-aliases/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false # tests don't interact with APIs
 
 [EnvMatrix]

--- a/acceptance/bundle/python/mutator-ordering/out.test.toml
+++ b/acceptance/bundle/python/mutator-ordering/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
 EnvMatrix.PYDAB_VERSION = ["0.266.0", "current"]

--- a/acceptance/bundle/python/mutator-permissions-owner-5682/out.test.toml
+++ b/acceptance/bundle/python/mutator-permissions-owner-5682/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/python/pipelines-support/out.test.toml
+++ b/acceptance/bundle/python/pipelines-support/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
 EnvMatrix.PYDAB_VERSION = ["0.266.0", "current"]

--- a/acceptance/bundle/python/propagates-auth-env/out.test.toml
+++ b/acceptance/bundle/python/propagates-auth-env/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
 EnvMatrix.PYDAB_VERSION = ["0.266.0", "current"]

--- a/acceptance/bundle/python/resolve-variable/out.test.toml
+++ b/acceptance/bundle/python/resolve-variable/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
 EnvMatrix.PYDAB_VERSION = ["0.266.0", "current"]

--- a/acceptance/bundle/python/resource-loading/out.test.toml
+++ b/acceptance/bundle/python/resource-loading/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
 EnvMatrix.PYDAB_VERSION = ["0.266.0", "current"]

--- a/acceptance/bundle/python/restricted-execution/out.test.toml
+++ b/acceptance/bundle/python/restricted-execution/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
 EnvMatrix.PYDAB_VERSION = ["0.266.0", "current"]

--- a/acceptance/bundle/python/schemas-support/out.test.toml
+++ b/acceptance/bundle/python/schemas-support/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
 EnvMatrix.PYDAB_VERSION = ["current"]

--- a/acceptance/bundle/python/schemas-support/test.toml
+++ b/acceptance/bundle/python/schemas-support/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false # tests don't interact with APIs
 
 [EnvMatrix]

--- a/acceptance/bundle/python/unicode-support/out.test.toml
+++ b/acceptance/bundle/python/unicode-support/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
 EnvMatrix.PYDAB_VERSION = ["0.266.0", "current"]

--- a/acceptance/bundle/python/volumes-support/out.test.toml
+++ b/acceptance/bundle/python/volumes-support/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
 EnvMatrix.PYDAB_VERSION = ["0.266.0", "current"]

--- a/acceptance/bundle/python/volumes-support/test.toml
+++ b/acceptance/bundle/python/volumes-support/test.toml
@@ -1,2 +1,1 @@
-Local = true
 Cloud = false # tests don't interact with APIs

--- a/acceptance/bundle/quality_monitor/out.test.toml
+++ b/acceptance/bundle/quality_monitor/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/refschema/out.test.toml
+++ b/acceptance/bundle/refschema/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/refschema/test.toml
+++ b/acceptance/bundle/refschema/test.toml
@@ -1,1 +1,0 @@
-Cloud = false

--- a/acceptance/bundle/refschema/test.toml
+++ b/acceptance/bundle/refschema/test.toml
@@ -1,2 +1,1 @@
 Cloud = false
-Local = true

--- a/acceptance/bundle/resource_deps/bad_ref_string_to_int/out.test.toml
+++ b/acceptance/bundle/resource_deps/bad_ref_string_to_int/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/bad_syntax/out.test.toml
+++ b/acceptance/bundle/resource_deps/bad_syntax/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/computed_volume_path/out.test.toml
+++ b/acceptance/bundle/resource_deps/computed_volume_path/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/create_error/out.test.toml
+++ b/acceptance/bundle/resource_deps/create_error/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/duplicate_ref/out.test.toml
+++ b/acceptance/bundle/resource_deps/duplicate_ref/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/grant_ref/out.test.toml
+++ b/acceptance/bundle/resource_deps/grant_ref/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resource_deps/id_chain/out.test.toml
+++ b/acceptance/bundle/resource_deps/id_chain/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/id_star/out.test.toml
+++ b/acceptance/bundle/resource_deps/id_star/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/immutable_field_ref/out.test.toml
+++ b/acceptance/bundle/resource_deps/immutable_field_ref/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resource_deps/implicit_deps_model_serving_endpoint/out.test.toml
+++ b/acceptance/bundle/resource_deps/implicit_deps_model_serving_endpoint/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/implicit_deps_quality_monitor/out.test.toml
+++ b/acceptance/bundle/resource_deps/implicit_deps_quality_monitor/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/implicit_deps_registered_model/out.test.toml
+++ b/acceptance/bundle/resource_deps/implicit_deps_registered_model/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/implicit_deps_volume/out.test.toml
+++ b/acceptance/bundle/resource_deps/implicit_deps_volume/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/job_id/out.test.toml
+++ b/acceptance/bundle/resource_deps/job_id/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/job_id_big_graph/delete_all/out.test.toml
+++ b/acceptance/bundle/resource_deps/job_id_big_graph/delete_all/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/job_id_big_graph/destroy/out.test.toml
+++ b/acceptance/bundle/resource_deps/job_id_big_graph/destroy/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/job_id_delete_bar/out.test.toml
+++ b/acceptance/bundle/resource_deps/job_id_delete_bar/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/job_id_delete_foo/out.test.toml
+++ b/acceptance/bundle/resource_deps/job_id_delete_foo/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/job_tasks/out.test.toml
+++ b/acceptance/bundle/resource_deps/job_tasks/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/jobs_update/out.test.toml
+++ b/acceptance/bundle/resource_deps/jobs_update/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/jobs_update_remote/out.test.toml
+++ b/acceptance/bundle/resource_deps/jobs_update_remote/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/loop_jobs/out.test.toml
+++ b/acceptance/bundle/resource_deps/loop_jobs/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/loop_self/out.test.toml
+++ b/acceptance/bundle/resource_deps/loop_self/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/missing_ingestion_definition/out.test.toml
+++ b/acceptance/bundle/resource_deps/missing_ingestion_definition/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/missing_map_key/out.test.toml
+++ b/acceptance/bundle/resource_deps/missing_map_key/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/missing_string_field/out.test.toml
+++ b/acceptance/bundle/resource_deps/missing_string_field/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/model_id_ref/out.test.toml
+++ b/acceptance/bundle/resource_deps/model_id_ref/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/non_existent_field/out.test.toml
+++ b/acceptance/bundle/resource_deps/non_existent_field/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/permission_ref/out.test.toml
+++ b/acceptance/bundle/resource_deps/permission_ref/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resource_deps/pipelines_recreate/out.test.toml
+++ b/acceptance/bundle/resource_deps/pipelines_recreate/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/present_ingestion_definition/out.test.toml
+++ b/acceptance/bundle/resource_deps/present_ingestion_definition/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/remote_app_url/out.test.toml
+++ b/acceptance/bundle/resource_deps/remote_app_url/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/remote_field_storage_location/out.test.toml
+++ b/acceptance/bundle/resource_deps/remote_field_storage_location/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 CloudEnvs.azure = false

--- a/acceptance/bundle/resource_deps/remote_field_storage_location/test.toml
+++ b/acceptance/bundle/resource_deps/remote_field_storage_location/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 

--- a/acceptance/bundle/resource_deps/remote_pipeline/out.test.toml
+++ b/acceptance/bundle/resource_deps/remote_pipeline/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/resources_var/out.test.toml
+++ b/acceptance/bundle/resource_deps/resources_var/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/resources_var_presets/out.test.toml
+++ b/acceptance/bundle/resource_deps/resources_var_presets/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/resources_var_presets_implicit_deps/out.test.toml
+++ b/acceptance/bundle/resource_deps/resources_var_presets_implicit_deps/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/tf_path_only_error/out.test.toml
+++ b/acceptance/bundle/resource_deps/tf_path_only_error/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/tf_path_renames/out.test.toml
+++ b/acceptance/bundle/resource_deps/tf_path_renames/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/unicode_reference/out.test.toml
+++ b/acceptance/bundle/resource_deps/unicode_reference/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/volume_path_contains_id/out.test.toml
+++ b/acceptance/bundle/resource_deps/volume_path_contains_id/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/volume_path_job_ref/out.test.toml
+++ b/acceptance/bundle/resource_deps/volume_path_job_ref/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/alerts/basic/out.test.toml
+++ b/acceptance/bundle/resources/alerts/basic/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RunsOnDbr = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/alerts/basic/test.toml
+++ b/acceptance/bundle/resources/alerts/basic/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RecordRequests = false
 Ignore = [".databricks"]

--- a/acceptance/bundle/resources/alerts/with_file/out.test.toml
+++ b/acceptance/bundle/resources/alerts/with_file/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/alerts/with_file/test.toml
+++ b/acceptance/bundle/resources/alerts/with_file/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RecordRequests = false
 Ignore = [".databricks"]

--- a/acceptance/bundle/resources/alerts/with_file_not_allowed_field_error/out.test.toml
+++ b/acceptance/bundle/resources/alerts/with_file_not_allowed_field_error/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/alerts/with_file_not_allowed_field_error/test.toml
+++ b/acceptance/bundle/resources/alerts/with_file_not_allowed_field_error/test.toml
@@ -1,3 +1,2 @@
-Local = true
 RecordRequests = false
 Ignore = [".databricks"]

--- a/acceptance/bundle/resources/alerts/with_file_run_from_subdir/out.test.toml
+++ b/acceptance/bundle/resources/alerts/with_file_run_from_subdir/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/alerts/with_file_run_from_subdir/test.toml
+++ b/acceptance/bundle/resources/alerts/with_file_run_from_subdir/test.toml
@@ -1,3 +1,2 @@
-Local = true
 RecordRequests = false
 Ignore = [".databricks"]

--- a/acceptance/bundle/resources/alerts/with_file_variable_interpolation_error/out.test.toml
+++ b/acceptance/bundle/resources/alerts/with_file_variable_interpolation_error/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/alerts/with_file_variable_interpolation_error/test.toml
+++ b/acceptance/bundle/resources/alerts/with_file_variable_interpolation_error/test.toml
@@ -1,3 +1,2 @@
-Local = true
 RecordRequests = false
 Ignore = [".databricks"]

--- a/acceptance/bundle/resources/apps/config-drift-stopped/out.test.toml
+++ b/acceptance/bundle/resources/apps/config-drift-stopped/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/apps/config-drift-stopped/test.toml
+++ b/acceptance/bundle/resources/apps/config-drift-stopped/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 
 # Asserts plan classification, not requests; drop the inherited RecordRequests.

--- a/acceptance/bundle/resources/apps/config-drift/out.test.toml
+++ b/acceptance/bundle/resources/apps/config-drift/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/apps/config-drift/test.toml
+++ b/acceptance/bundle/resources/apps/config-drift/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false # This currently fails on Cloud due to incorrect API behaviour.
 RecordRequests = true
 

--- a/acceptance/bundle/resources/apps/config-no-deployment/out.test.toml
+++ b/acceptance/bundle/resources/apps/config-no-deployment/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/apps/config-no-deployment/test.toml
+++ b/acceptance/bundle/resources/apps/config-no-deployment/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 
 # Asserts plan classification, not requests; drop the inherited RecordRequests.

--- a/acceptance/bundle/resources/apps/create_already_exists/out.test.toml
+++ b/acceptance/bundle/resources/apps/create_already_exists/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/apps/create_already_exists/test.toml
+++ b/acceptance/bundle/resources/apps/create_already_exists/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 RecordRequests = false
 

--- a/acceptance/bundle/resources/apps/default_description/out.test.toml
+++ b/acceptance/bundle/resources/apps/default_description/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/apps/git-source-no-deployment/out.test.toml
+++ b/acceptance/bundle/resources/apps/git-source-no-deployment/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/apps/git-source-no-deployment/test.toml
+++ b/acceptance/bundle/resources/apps/git-source-no-deployment/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 
 # Asserts plan classification, not requests; drop the inherited RecordRequests.

--- a/acceptance/bundle/resources/apps/immutable/out.test.toml
+++ b/acceptance/bundle/resources/apps/immutable/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/apps/immutable/test.toml
+++ b/acceptance/bundle/resources/apps/immutable/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false # Temporary disable cloud tests until the API is fully available
 RecordRequests = true
 

--- a/acceptance/bundle/resources/apps/inline_config/out.test.toml
+++ b/acceptance/bundle/resources/apps/inline_config/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/apps/inline_config/test.toml
+++ b/acceptance/bundle/resources/apps/inline_config/test.toml
@@ -1,2 +1,1 @@
-Local = true
 Cloud = true

--- a/acceptance/bundle/resources/apps/lifecycle-started-omitted/out.test.toml
+++ b/acceptance/bundle/resources/apps/lifecycle-started-omitted/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/apps/lifecycle-started-omitted/test.toml
+++ b/acceptance/bundle/resources/apps/lifecycle-started-omitted/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RecordRequests = true
 

--- a/acceptance/bundle/resources/apps/lifecycle-started-terraform-error/out.test.toml
+++ b/acceptance/bundle/resources/apps/lifecycle-started-terraform-error/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform"]

--- a/acceptance/bundle/resources/apps/lifecycle-started-terraform-error/test.toml
+++ b/acceptance/bundle/resources/apps/lifecycle-started-terraform-error/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RecordRequests = false
 

--- a/acceptance/bundle/resources/apps/lifecycle-started-toggle/out.test.toml
+++ b/acceptance/bundle/resources/apps/lifecycle-started-toggle/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/apps/lifecycle-started-toggle/test.toml
+++ b/acceptance/bundle/resources/apps/lifecycle-started-toggle/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RecordRequests = true
 

--- a/acceptance/bundle/resources/apps/lifecycle-started/out.test.toml
+++ b/acceptance/bundle/resources/apps/lifecycle-started/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/apps/lifecycle-started/test.toml
+++ b/acceptance/bundle/resources/apps/lifecycle-started/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RecordRequests = true
 

--- a/acceptance/bundle/resources/apps/readplan-lifecycle/out.test.toml
+++ b/acceptance/bundle/resources/apps/readplan-lifecycle/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]
 EnvMatrix.READPLAN = ["", "1"]

--- a/acceptance/bundle/resources/apps/readplan-lifecycle/test.toml
+++ b/acceptance/bundle/resources/apps/readplan-lifecycle/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 Ignore = [".databricks", "tmp.plan.json"]
 

--- a/acceptance/bundle/resources/apps/resource-refs/out.test.toml
+++ b/acceptance/bundle/resources/apps/resource-refs/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/apps/resource-refs/test.toml
+++ b/acceptance/bundle/resources/apps/resource-refs/test.toml
@@ -1,1 +1,0 @@
-Cloud = false

--- a/acceptance/bundle/resources/apps/resource-refs/test.toml
+++ b/acceptance/bundle/resources/apps/resource-refs/test.toml
@@ -1,2 +1,1 @@
-Local = true
 Cloud = false

--- a/acceptance/bundle/resources/apps/update/out.test.toml
+++ b/acceptance/bundle/resources/apps/update/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/catalogs/auto-approve/out.test.toml
+++ b/acceptance/bundle/resources/catalogs/auto-approve/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/catalogs/auto-approve/test.toml
+++ b/acceptance/bundle/resources/catalogs/auto-approve/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RecordRequests = false
 RequiresUnityCatalog = true

--- a/acceptance/bundle/resources/catalogs/basic/out.test.toml
+++ b/acceptance/bundle/resources/catalogs/basic/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/catalogs/basic/test.toml
+++ b/acceptance/bundle/resources/catalogs/basic/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RecordRequests = false
 RequiresUnityCatalog = true

--- a/acceptance/bundle/resources/catalogs/drift/managed_properties/out.test.toml
+++ b/acceptance/bundle/resources/catalogs/drift/managed_properties/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/catalogs/empty-name/out.test.toml
+++ b/acceptance/bundle/resources/catalogs/empty-name/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/catalogs/empty-name/test.toml
+++ b/acceptance/bundle/resources/catalogs/empty-name/test.toml
@@ -1,4 +1,3 @@
-Local = true
 # The golden asserts UC's message verbatim, so run on cloud to catch it drifting.
 Cloud = true
 RequiresUnityCatalog = true

--- a/acceptance/bundle/resources/catalogs/with-schemas/out.test.toml
+++ b/acceptance/bundle/resources/catalogs/with-schemas/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/catalogs/with-schemas/test.toml
+++ b/acceptance/bundle/resources/catalogs/with-schemas/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RecordRequests = false
 RequiresUnityCatalog = true

--- a/acceptance/bundle/resources/clusters/deploy/data_security_mode/out.test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/data_security_mode/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RunsOnDbr = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/clusters/deploy/data_security_mode/test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/data_security_mode/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RecordRequests = false
 RunsOnDbr = true

--- a/acceptance/bundle/resources/clusters/deploy/instance_pool/out.test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/instance_pool/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/clusters/deploy/instance_pool/test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/instance_pool/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 RecordRequests = true
 

--- a/acceptance/bundle/resources/clusters/deploy/instance_pool_and_node_type/out.test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/instance_pool_and_node_type/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/clusters/deploy/instance_pool_and_node_type/test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/instance_pool_and_node_type/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 RecordRequests = true
 

--- a/acceptance/bundle/resources/clusters/deploy/local_ssd_count/out.test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/local_ssd_count/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 CloudEnvs.aws = false
 CloudEnvs.azure = false

--- a/acceptance/bundle/resources/clusters/deploy/local_ssd_count/test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/local_ssd_count/test.toml
@@ -1,5 +1,4 @@
 Badness = "In terraform, local_ssd_count field is not sent to backend"
-Local = true
 Cloud = true
 RecordRequests = true
 

--- a/acceptance/bundle/resources/clusters/deploy/num_workers_absent/out.test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/num_workers_absent/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/clusters/deploy/num_workers_absent/test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/num_workers_absent/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 RecordRequests = true
 

--- a/acceptance/bundle/resources/clusters/deploy/simple/out.test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/simple/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RunsOnDbr = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/clusters/deploy/simple/test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/simple/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RecordRequests = false
 RunsOnDbr = true

--- a/acceptance/bundle/resources/clusters/deploy/update-after-create/out.test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/update-after-create/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/clusters/deploy/update-after-create/test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/update-after-create/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RecordRequests = true
 

--- a/acceptance/bundle/resources/clusters/deploy/update-and-resize-autoscale/out.test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/update-and-resize-autoscale/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/clusters/deploy/update-and-resize-autoscale/test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/update-and-resize-autoscale/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 RecordRequests = true
 

--- a/acceptance/bundle/resources/clusters/deploy/update-and-resize/out.test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/update-and-resize/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/clusters/deploy/update-and-resize/test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/update-and-resize/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 RecordRequests = true
 

--- a/acceptance/bundle/resources/clusters/deploy/workload_type/out.test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/workload_type/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/clusters/deploy/workload_type/test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/workload_type/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 RecordRequests = true
 

--- a/acceptance/bundle/resources/clusters/lifecycle-started-terraform-error/out.test.toml
+++ b/acceptance/bundle/resources/clusters/lifecycle-started-terraform-error/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform"]

--- a/acceptance/bundle/resources/clusters/lifecycle-started-terraform-error/test.toml
+++ b/acceptance/bundle/resources/clusters/lifecycle-started-terraform-error/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RecordRequests = false
 

--- a/acceptance/bundle/resources/clusters/lifecycle-started-toggle/out.test.toml
+++ b/acceptance/bundle/resources/clusters/lifecycle-started-toggle/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/clusters/lifecycle-started-toggle/test.toml
+++ b/acceptance/bundle/resources/clusters/lifecycle-started-toggle/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RecordRequests = true
 

--- a/acceptance/bundle/resources/clusters/lifecycle-started/out.test.toml
+++ b/acceptance/bundle/resources/clusters/lifecycle-started/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/clusters/lifecycle-started/test.toml
+++ b/acceptance/bundle/resources/clusters/lifecycle-started/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RecordRequests = true
 

--- a/acceptance/bundle/resources/clusters/readplan-lifecycle/out.test.toml
+++ b/acceptance/bundle/resources/clusters/readplan-lifecycle/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]
 EnvMatrix.READPLAN = ["", "1"]

--- a/acceptance/bundle/resources/clusters/readplan-lifecycle/test.toml
+++ b/acceptance/bundle/resources/clusters/readplan-lifecycle/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 Ignore = [".databricks", "tmp.plan.json"]
 

--- a/acceptance/bundle/resources/clusters/resize-terminated-fallback/out.test.toml
+++ b/acceptance/bundle/resources/clusters/resize-terminated-fallback/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/clusters/resize-terminated-fallback/test.toml
+++ b/acceptance/bundle/resources/clusters/resize-terminated-fallback/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RecordRequests = true
 

--- a/acceptance/bundle/resources/clusters/run/spark_python_task/out.test.toml
+++ b/acceptance/bundle/resources/clusters/run/spark_python_task/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 CloudSlow = true
 RunsOnDbr = true

--- a/acceptance/bundle/resources/clusters/run/spark_python_task/test.toml
+++ b/acceptance/bundle/resources/clusters/run/spark_python_task/test.toml
@@ -1,4 +1,3 @@
-Local = true
 CloudSlow = true
 RecordRequests = false
 RunsOnDbr = true

--- a/acceptance/bundle/resources/dashboards/change-embed-credentials/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/change-embed-credentials/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresWarehouse = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/change-name/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/change-name/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresWarehouse = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/change-parent-path/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/change-parent-path/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresWarehouse = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/change-serialized-dashboard/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/change-serialized-dashboard/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresWarehouse = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/dataset-catalog-schema/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/dataset-catalog-schema/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresWarehouse = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/resources/dashboards/dataset-catalog-schema/test.toml
+++ b/acceptance/bundle/resources/dashboards/dataset-catalog-schema/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresWarehouse = true
 RecordRequests = true

--- a/acceptance/bundle/resources/dashboards/delete-trashed-out-of-band/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/delete-trashed-out-of-band/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresWarehouse = true
 RunsOnDbr = true

--- a/acceptance/bundle/resources/dashboards/delete-trashed-out-of-band/test.toml
+++ b/acceptance/bundle/resources/dashboards/delete-trashed-out-of-band/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresWarehouse = true
 RecordRequests = false

--- a/acceptance/bundle/resources/dashboards/destroy/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/destroy/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresWarehouse = true
 RunsOnDbr = true

--- a/acceptance/bundle/resources/dashboards/destroy/test.toml
+++ b/acceptance/bundle/resources/dashboards/destroy/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresWarehouse = true
 RecordRequests = false

--- a/acceptance/bundle/resources/dashboards/detect-change/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/detect-change/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresWarehouse = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/detect-change/test.toml
+++ b/acceptance/bundle/resources/dashboards/detect-change/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 
 Ignore = [

--- a/acceptance/bundle/resources/dashboards/generate_inplace/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/generate_inplace/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresWarehouse = true
 RunsOnDbr = true

--- a/acceptance/bundle/resources/dashboards/generate_inplace/test.toml
+++ b/acceptance/bundle/resources/dashboards/generate_inplace/test.toml
@@ -1,5 +1,4 @@
 Cloud = true
-Local = true
 RecordRequests = false
 RunsOnDbr = true
 

--- a/acceptance/bundle/resources/dashboards/nested-folders/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/nested-folders/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresWarehouse = true
 RunsOnDbr = true

--- a/acceptance/bundle/resources/dashboards/nested-folders/test.toml
+++ b/acceptance/bundle/resources/dashboards/nested-folders/test.toml
@@ -1,5 +1,4 @@
 Badness = "Cannot read dashboard, expecting deployment to succeed"
-Local = true
 Cloud = true
 RequiresWarehouse = true
 RecordRequests = false
@@ -14,7 +13,6 @@ Ignore = [
 # Deploying a saved plan must send the same full serialized_dashboard, which the
 # lakeview get in the script reads back.
 EnvMatrix.READPLAN = ["", "1"]
-
 
 [[Repls]]
 # Windows:

--- a/acceptance/bundle/resources/dashboards/publish-failure-cleans-up-dashboard/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/publish-failure-cleans-up-dashboard/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 RequiresWarehouse = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/publish-failure-cleans-up-dashboard/test.toml
+++ b/acceptance/bundle/resources/dashboards/publish-failure-cleans-up-dashboard/test.toml
@@ -1,5 +1,4 @@
 Cloud = false
-Local = true
 RecordRequests = true
 
 Ignore = ["tmp.plan.json"]

--- a/acceptance/bundle/resources/dashboards/publish-failure-stale-content/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/publish-failure-stale-content/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 RequiresWarehouse = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/dashboards/publish-failure-stale-content/test.toml
+++ b/acceptance/bundle/resources/dashboards/publish-failure-stale-content/test.toml
@@ -1,6 +1,5 @@
 Badness = "after publish failure, re-deploy fails with 'modified remotely' instead of republishing; --force is required as a workaround"
 Cloud = false
-Local = true
 RecordRequests = true
 
 Ignore = [

--- a/acceptance/bundle/resources/dashboards/republish-after-draft-update/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/republish-after-draft-update/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 RequiresWarehouse = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/dashboards/republish-after-draft-update/test.toml
+++ b/acceptance/bundle/resources/dashboards/republish-after-draft-update/test.toml
@@ -1,7 +1,6 @@
 # Regression test for stale-publish detection. The dashboard "published" state is a
 # direct-engine concept derived from the publish/update timestamps, so run direct only.
 Cloud = false
-Local = true
 RequiresWarehouse = true
 # This test asserts plan output, not the recorded request sequence, so keep request
 # recording off (inherited as true from the parent) to avoid flaky ordering.

--- a/acceptance/bundle/resources/dashboards/simple/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/simple/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresWarehouse = true
 RunsOnDbr = true

--- a/acceptance/bundle/resources/dashboards/simple/test.toml
+++ b/acceptance/bundle/resources/dashboards/simple/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresWarehouse = true
 RecordRequests = false

--- a/acceptance/bundle/resources/dashboards/simple_outside_bundle_root/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/simple_outside_bundle_root/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresWarehouse = true
 RunsOnDbr = true

--- a/acceptance/bundle/resources/dashboards/simple_outside_bundle_root/test.toml
+++ b/acceptance/bundle/resources/dashboards/simple_outside_bundle_root/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresWarehouse = true
 RecordRequests = false
@@ -8,7 +7,6 @@ Ignore = [
     "databricks.yml",
     "sample-dashboard.lvdash.json",
 ]
-
 
 [[Repls]]
 # Windows:

--- a/acceptance/bundle/resources/dashboards/simple_syncroot/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/simple_syncroot/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresWarehouse = true
 RunsOnDbr = true

--- a/acceptance/bundle/resources/dashboards/simple_syncroot/test.toml
+++ b/acceptance/bundle/resources/dashboards/simple_syncroot/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresWarehouse = true
 RecordRequests = false
@@ -8,7 +7,6 @@ Ignore = [
     "databricks.yml",
     "sample-dashboard.lvdash.json",
 ]
-
 
 [[Repls]]
 # Windows:

--- a/acceptance/bundle/resources/dashboards/test.toml
+++ b/acceptance/bundle/resources/dashboards/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresWarehouse = true
 

--- a/acceptance/bundle/resources/dashboards/unpublish-out-of-band/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/unpublish-out-of-band/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresWarehouse = true
 RunsOnDbr = true

--- a/acceptance/bundle/resources/dashboards/unpublish-out-of-band/test.toml
+++ b/acceptance/bundle/resources/dashboards/unpublish-out-of-band/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresWarehouse = true
 RecordRequests = false

--- a/acceptance/bundle/resources/database_catalogs/basic/out.test.toml
+++ b/acceptance/bundle/resources/database_catalogs/basic/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 CloudSlow = true
 RequiresUnityCatalog = true

--- a/acceptance/bundle/resources/database_catalogs/basic/test.toml
+++ b/acceptance/bundle/resources/database_catalogs/basic/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 
 # Mitigates running into quota limits in workspaces

--- a/acceptance/bundle/resources/database_catalogs/recreate/out.test.toml
+++ b/acceptance/bundle/resources/database_catalogs/recreate/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 RequiresUnityCatalog = true
 CloudEnvs.gcp = false

--- a/acceptance/bundle/resources/database_instances/recreate/out.test.toml
+++ b/acceptance/bundle/resources/database_instances/recreate/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 RequiresUnityCatalog = true
 CloudEnvs.gcp = false

--- a/acceptance/bundle/resources/database_instances/single-instance/out.test.toml
+++ b/acceptance/bundle/resources/database_instances/single-instance/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 CloudSlow = true
 RequiresUnityCatalog = true

--- a/acceptance/bundle/resources/database_instances/single-instance/test.toml
+++ b/acceptance/bundle/resources/database_instances/single-instance/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 
 # Mitigates running into quota limits in workspaces

--- a/acceptance/bundle/resources/experiments/basic/out.test.toml
+++ b/acceptance/bundle/resources/experiments/basic/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RunsOnDbr = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/experiments/basic/test.toml
+++ b/acceptance/bundle/resources/experiments/basic/test.toml
@@ -1,5 +1,4 @@
 Cloud = true
-Local = true
 RecordRequests = false
 RunsOnDbr = true
 

--- a/acceptance/bundle/resources/external_locations/out.test.toml
+++ b/acceptance/bundle/resources/external_locations/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 RequiresUnityCatalog = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/external_locations/test.toml
+++ b/acceptance/bundle/resources/external_locations/test.toml
@@ -1,4 +1,3 @@
-Local = true
 # External locations require actual storage credentials with cloud IAM setup
 # which are environment-specific, so we only test locally with the mock server
 Cloud = false

--- a/acceptance/bundle/resources/genie_spaces/delete_warning/out.test.toml
+++ b/acceptance/bundle/resources/genie_spaces/delete_warning/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 RequiresWarehouse = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/genie_spaces/delete_warning/test.toml
+++ b/acceptance/bundle/resources/genie_spaces/delete_warning/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 RecordRequests = false
 

--- a/acceptance/bundle/resources/genie_spaces/inline/out.test.toml
+++ b/acceptance/bundle/resources/genie_spaces/inline/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 RequiresWarehouse = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/genie_spaces/inline/test.toml
+++ b/acceptance/bundle/resources/genie_spaces/inline/test.toml
@@ -1,4 +1,3 @@
-Local = true
 # Local-only: the inline serialized_space references tables (main.sales.orders)
 # that do not exist on a real workspace, so the backend rejects the create (403).
 Cloud = false

--- a/acceptance/bundle/resources/genie_spaces/parent_path_update/out.test.toml
+++ b/acceptance/bundle/resources/genie_spaces/parent_path_update/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresWarehouse = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/genie_spaces/parent_path_update/test.toml
+++ b/acceptance/bundle/resources/genie_spaces/parent_path_update/test.toml
@@ -1,4 +1,3 @@
-Local = true
 RecordRequests = false
 
 Ignore = [

--- a/acceptance/bundle/resources/genie_spaces/recreate_when_gone/out.test.toml
+++ b/acceptance/bundle/resources/genie_spaces/recreate_when_gone/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresWarehouse = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/genie_spaces/recreate_when_gone/test.toml
+++ b/acceptance/bundle/resources/genie_spaces/recreate_when_gone/test.toml
@@ -1,4 +1,3 @@
-Local = true
 RecordRequests = false
 
 Ignore = [

--- a/acceptance/bundle/resources/genie_spaces/serialized_space/out.test.toml
+++ b/acceptance/bundle/resources/genie_spaces/serialized_space/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 RequiresWarehouse = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/genie_spaces/serialized_space/test.toml
+++ b/acceptance/bundle/resources/genie_spaces/serialized_space/test.toml
@@ -1,4 +1,3 @@
-Local = true
 # Local-only: asserts on the recorded create-request payloads, which only the
 # local testserver captures (RecordRequests).
 Cloud = false

--- a/acceptance/bundle/resources/genie_spaces/simple/out.test.toml
+++ b/acceptance/bundle/resources/genie_spaces/simple/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresWarehouse = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/genie_spaces/simple/test.toml
+++ b/acceptance/bundle/resources/genie_spaces/simple/test.toml
@@ -1,4 +1,3 @@
-Local = true
 RecordRequests = false
 
 Ignore = [

--- a/acceptance/bundle/resources/genie_spaces/version_migration/out.test.toml
+++ b/acceptance/bundle/resources/genie_spaces/version_migration/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresWarehouse = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/genie_spaces/version_migration/test.toml
+++ b/acceptance/bundle/resources/genie_spaces/version_migration/test.toml
@@ -1,4 +1,3 @@
-Local = true
 RecordRequests = false
 
 Ignore = [

--- a/acceptance/bundle/resources/grants/catalogs/out.test.toml
+++ b/acceptance/bundle/resources/grants/catalogs/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/grants/registered_models/out.test.toml
+++ b/acceptance/bundle/resources/grants/registered_models/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/grants/schemas/all_privileges/out.test.toml
+++ b/acceptance/bundle/resources/grants/schemas/all_privileges/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/grants/schemas/all_privileges_coexist/out.test.toml
+++ b/acceptance/bundle/resources/grants/schemas/all_privileges_coexist/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/grants/schemas/change_privilege/out.test.toml
+++ b/acceptance/bundle/resources/grants/schemas/change_privilege/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/grants/schemas/duplicate_principals/out.test.toml
+++ b/acceptance/bundle/resources/grants/schemas/duplicate_principals/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/grants/schemas/duplicate_privileges/out.test.toml
+++ b/acceptance/bundle/resources/grants/schemas/duplicate_privileges/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/grants/schemas/empty_array/out.test.toml
+++ b/acceptance/bundle/resources/grants/schemas/empty_array/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/grants/schemas/out_of_band_principal/out.test.toml
+++ b/acceptance/bundle/resources/grants/schemas/out_of_band_principal/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/grants/schemas/remove_all/out.test.toml
+++ b/acceptance/bundle/resources/grants/schemas/remove_all/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/grants/schemas/remove_principal/out.test.toml
+++ b/acceptance/bundle/resources/grants/schemas/remove_principal/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/grants/volumes/out.test.toml
+++ b/acceptance/bundle/resources/grants/volumes/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/independent/out.test.toml
+++ b/acceptance/bundle/resources/independent/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/instance_pools/out.test.toml
+++ b/acceptance/bundle/resources/instance_pools/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/instance_pools/test.toml
+++ b/acceptance/bundle/resources/instance_pools/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]
 

--- a/acceptance/bundle/resources/job_runs/basic/out.test.toml
+++ b/acceptance/bundle/resources/job_runs/basic/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/job_runs/job_parameters/out.test.toml
+++ b/acceptance/bundle/resources/job_runs/job_parameters/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/job_runs/redeploy/out.test.toml
+++ b/acceptance/bundle/resources/job_runs/redeploy/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/jobs/alert-task/out.test.toml
+++ b/acceptance/bundle/resources/jobs/alert-task/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/alert-task/test.toml
+++ b/acceptance/bundle/resources/jobs/alert-task/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RecordRequests = false
 Ignore = ["databricks.yml", ".databricks"]

--- a/acceptance/bundle/resources/jobs/big_id/out.test.toml
+++ b/acceptance/bundle/resources/jobs/big_id/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]
 EnvMatrix.READPLAN = ["", "1"]

--- a/acceptance/bundle/resources/jobs/check-metadata/out.test.toml
+++ b/acceptance/bundle/resources/jobs/check-metadata/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/check-metadata/test.toml
+++ b/acceptance/bundle/resources/jobs/check-metadata/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RecordRequests = false
 

--- a/acceptance/bundle/resources/jobs/create-error/out.test.toml
+++ b/acceptance/bundle/resources/jobs/create-error/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/jobs/delete_job/out.test.toml
+++ b/acceptance/bundle/resources/jobs/delete_job/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/delete_task/out.test.toml
+++ b/acceptance/bundle/resources/jobs/delete_task/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
 EnvMatrix.READPLAN = ["", "1"]

--- a/acceptance/bundle/resources/jobs/double-underscore-keys/out.test.toml
+++ b/acceptance/bundle/resources/jobs/double-underscore-keys/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RunsOnDbr = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/double-underscore-keys/test.toml
+++ b/acceptance/bundle/resources/jobs/double-underscore-keys/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RecordRequests = false
 RunsOnDbr = true

--- a/acceptance/bundle/resources/jobs/fail-on-active-runs/out.test.toml
+++ b/acceptance/bundle/resources/jobs/fail-on-active-runs/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RunsOnDbr = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/fail-on-active-runs/test.toml
+++ b/acceptance/bundle/resources/jobs/fail-on-active-runs/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RecordRequests = false
 RunsOnDbr = true

--- a/acceptance/bundle/resources/jobs/instance_pool_and_node_type/out.test.toml
+++ b/acceptance/bundle/resources/jobs/instance_pool_and_node_type/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/no-git-provider/out.test.toml
+++ b/acceptance/bundle/resources/jobs/no-git-provider/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RunsOnDbr = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/no-git-provider/test.toml
+++ b/acceptance/bundle/resources/jobs/no-git-provider/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 
 RecordRequests = false

--- a/acceptance/bundle/resources/jobs/num_workers/out.test.toml
+++ b/acceptance/bundle/resources/jobs/num_workers/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/on_failure_empty_slice/out.test.toml
+++ b/acceptance/bundle/resources/jobs/on_failure_empty_slice/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/remote_add_tag/out.test.toml
+++ b/acceptance/bundle/resources/jobs/remote_add_tag/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/remote_delete/deploy/out.test.toml
+++ b/acceptance/bundle/resources/jobs/remote_delete/deploy/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
 EnvMatrix.READPLAN = ["", "1"]

--- a/acceptance/bundle/resources/jobs/remote_delete/destroy/out.test.toml
+++ b/acceptance/bundle/resources/jobs/remote_delete/destroy/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/remote_delete/removed_from_config/out.test.toml
+++ b/acceptance/bundle/resources/jobs/remote_delete/removed_from_config/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/remote_matches_config/out.test.toml
+++ b/acceptance/bundle/resources/jobs/remote_matches_config/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/shared-root-path/out.test.toml
+++ b/acceptance/bundle/resources/jobs/shared-root-path/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RunsOnDbr = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/shared-root-path/test.toml
+++ b/acceptance/bundle/resources/jobs/shared-root-path/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RecordRequests = false
 RunsOnDbr = true

--- a/acceptance/bundle/resources/jobs/tags_empty_map/out.test.toml
+++ b/acceptance/bundle/resources/jobs/tags_empty_map/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/task-source/out.test.toml
+++ b/acceptance/bundle/resources/jobs/task-source/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/task-source/test.toml
+++ b/acceptance/bundle/resources/jobs/task-source/test.toml
@@ -1,3 +1,2 @@
 Cloud = false
-Local = true
 RecordRequests = true

--- a/acceptance/bundle/resources/jobs/tasks-reorder-locally/out.test.toml
+++ b/acceptance/bundle/resources/jobs/tasks-reorder-locally/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/unknown-terraform-field/out.test.toml
+++ b/acceptance/bundle/resources/jobs/unknown-terraform-field/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform"]

--- a/acceptance/bundle/resources/jobs/update/out.test.toml
+++ b/acceptance/bundle/resources/jobs/update/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
 EnvMatrix.READPLAN = ["", "1"]

--- a/acceptance/bundle/resources/jobs/update_single_node/out.test.toml
+++ b/acceptance/bundle/resources/jobs/update_single_node/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/webhook-reorder-remote/out.test.toml
+++ b/acceptance/bundle/resources/jobs/webhook-reorder-remote/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/basic/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/basic/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/basic/test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/basic/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RecordRequests = true
 RequiresUnityCatalog = true

--- a/acceptance/bundle/resources/model_serving_endpoints/drift/write_only/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/drift/write_only/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/recreate/catalog-name/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/recreate/catalog-name/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/recreate/name-change/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/recreate/name-change/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/recreate/route-optimized/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/recreate/route-optimized/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/recreate/schema-name/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/recreate/schema-name/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/recreate/table-prefix/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/recreate/table-prefix/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/recreate/test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/recreate/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 RecordRequests = true
 

--- a/acceptance/bundle/resources/model_serving_endpoints/running-endpoint/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/running-endpoint/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 CloudSlow = true
 RequiresUnityCatalog = true

--- a/acceptance/bundle/resources/model_serving_endpoints/running-endpoint/test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/running-endpoint/test.toml
@@ -1,6 +1,5 @@
 Timeout = '30m'
 Cloud = true
-Local = true
 CloudSlow = true
 RequiresUnityCatalog = true
 

--- a/acceptance/bundle/resources/model_serving_endpoints/update/ai-gateway/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/update/ai-gateway/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/update/both_gateway_and_tags/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/update/both_gateway_and_tags/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/update/config/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/update/config/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/update/email-notifications/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/update/email-notifications/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/update/tags/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/update/tags/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/update/test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/update/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 RecordRequests = true
 

--- a/acceptance/bundle/resources/models/basic/out.test.toml
+++ b/acceptance/bundle/resources/models/basic/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RunsOnDbr = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/models/basic/test.toml
+++ b/acceptance/bundle/resources/models/basic/test.toml
@@ -1,4 +1,3 @@
 Cloud = true
-Local = true
 RecordRequests = false
 RunsOnDbr = true

--- a/acceptance/bundle/resources/models/empty-name/out.test.toml
+++ b/acceptance/bundle/resources/models/empty-name/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/models/empty-name/test.toml
+++ b/acceptance/bundle/resources/models/empty-name/test.toml
@@ -1,4 +1,3 @@
-Local = true
 # The golden asserts MLflow's message verbatim, so run on cloud to catch it drifting.
 Cloud = true
 RecordRequests = false

--- a/acceptance/bundle/resources/models/readplan-permissions/out.test.toml
+++ b/acceptance/bundle/resources/models/readplan-permissions/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]
 EnvMatrix.READPLAN = ["", "1"]

--- a/acceptance/bundle/resources/models/readplan-permissions/test.toml
+++ b/acceptance/bundle/resources/models/readplan-permissions/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 Ignore = [".databricks", "tmp.plan.json"]
 

--- a/acceptance/bundle/resources/permissions/apps/current_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/apps/current_can_manage/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/apps/other_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/apps/other_can_manage/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/clusters/current_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/clusters/current_can_manage/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/clusters/target/out.test.toml
+++ b/acceptance/bundle/resources/permissions/clusters/target/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/dashboards/create/out.test.toml
+++ b/acceptance/bundle/resources/permissions/dashboards/create/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresWarehouse = true
 CloudEnvs.gcp = false

--- a/acceptance/bundle/resources/permissions/dashboards/create/test.toml
+++ b/acceptance/bundle/resources/permissions/dashboards/create/test.toml
@@ -1,4 +1,3 @@
-Local = true
 RequiresWarehouse = true
 Cloud = true
 

--- a/acceptance/bundle/resources/permissions/database_instances/current_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/database_instances/current_can_manage/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/experiments/current_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/experiments/current_can_manage/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/factcheck/out.test.toml
+++ b/acceptance/bundle/resources/permissions/factcheck/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 CloudSlow = true
 RunsOnDbr = true

--- a/acceptance/bundle/resources/permissions/factcheck/test.toml
+++ b/acceptance/bundle/resources/permissions/factcheck/test.toml
@@ -1,4 +1,3 @@
-Local = true
 CloudSlow = true
 RecordRequests = false
 RunsOnDbr = true

--- a/acceptance/bundle/resources/permissions/genie_spaces/current_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/genie_spaces/current_can_manage/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/permissions/genie_spaces/out_of_band_deletion/out.test.toml
+++ b/acceptance/bundle/resources/permissions/genie_spaces/out_of_band_deletion/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/permissions/jobs/added_remotely/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/added_remotely/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/current_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/current_can_manage/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/current_can_manage_run/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/current_can_manage_run/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/current_can_manage_run/test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/current_can_manage_run/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 IsServicePrincipal = true
 

--- a/acceptance/bundle/resources/permissions/jobs/current_is_owner/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/current_is_owner/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/delete_one/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/delete_one/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/delete_one/test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/delete_one/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 IsServicePrincipal = true
 RequiresUnityCatalog = true

--- a/acceptance/bundle/resources/permissions/jobs/deleted_remotely/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/deleted_remotely/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/destroy_without_mgmtperms/with_permissions/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/destroy_without_mgmtperms/with_permissions/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RunsOnDbr = false
 CloudEnvs.azure = false

--- a/acceptance/bundle/resources/permissions/jobs/destroy_without_mgmtperms/with_permissions/test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/destroy_without_mgmtperms/with_permissions/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RecordRequests = false
 CloudEnvs.gcp = false

--- a/acceptance/bundle/resources/permissions/jobs/destroy_without_mgmtperms/without_permissions/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/destroy_without_mgmtperms/without_permissions/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RunsOnDbr = false
 CloudEnvs.azure = false

--- a/acceptance/bundle/resources/permissions/jobs/destroy_without_mgmtperms/without_permissions/test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/destroy_without_mgmtperms/without_permissions/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RecordRequests = false
 CloudEnvs.gcp = false

--- a/acceptance/bundle/resources/permissions/jobs/empty_list/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/empty_list/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/other_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/other_can_manage/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/other_can_manage_run/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/other_can_manage_run/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/other_can_manage_run/test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/other_can_manage_run/test.toml
@@ -1,1 +1,0 @@
-Local = true

--- a/acceptance/bundle/resources/permissions/jobs/other_is_owner/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/other_is_owner/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/reorder_locally/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/reorder_locally/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/reorder_remotely/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/reorder_remotely/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/update/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/update/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/viewers/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/viewers/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/models/current_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/models/current_can_manage/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/out.test.toml
+++ b/acceptance/bundle/resources/permissions/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 Phase = 1
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/pipelines/504/create/out.test.toml
+++ b/acceptance/bundle/resources/permissions/pipelines/504/create/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]
 EnvMatrix.READPLAN = []

--- a/acceptance/bundle/resources/permissions/pipelines/504/plan/out.test.toml
+++ b/acceptance/bundle/resources/permissions/pipelines/504/plan/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]
 EnvMatrix.READPLAN = []

--- a/acceptance/bundle/resources/permissions/pipelines/504/update/out.test.toml
+++ b/acceptance/bundle/resources/permissions/pipelines/504/update/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]
 EnvMatrix.READPLAN = []

--- a/acceptance/bundle/resources/permissions/pipelines/current_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/pipelines/current_can_manage/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/pipelines/current_is_owner/out.test.toml
+++ b/acceptance/bundle/resources/permissions/pipelines/current_is_owner/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/pipelines/empty_list/out.test.toml
+++ b/acceptance/bundle/resources/permissions/pipelines/empty_list/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/pipelines/other_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/pipelines/other_can_manage/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/pipelines/other_is_owner/out.test.toml
+++ b/acceptance/bundle/resources/permissions/pipelines/other_is_owner/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/pipelines/update/out.test.toml
+++ b/acceptance/bundle/resources/permissions/pipelines/update/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/postgres_projects/current_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/postgres_projects/current_can_manage/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/sql_warehouses/current_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/sql_warehouses/current_can_manage/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/target_permissions/out.test.toml
+++ b/acceptance/bundle/resources/permissions/target_permissions/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/vector_search_endpoints/current_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/vector_search_endpoints/current_can_manage/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/pipelines/allow-duplicate-names/out.test.toml
+++ b/acceptance/bundle/resources/pipelines/allow-duplicate-names/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/pipelines/auto-approve/out.test.toml
+++ b/acceptance/bundle/resources/pipelines/auto-approve/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RunsOnDbr = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/pipelines/auto-approve/test.toml
+++ b/acceptance/bundle/resources/pipelines/auto-approve/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RecordRequests = false
 RunsOnDbr = true

--- a/acceptance/bundle/resources/pipelines/drift/parameters/out.test.toml
+++ b/acceptance/bundle/resources/pipelines/drift/parameters/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/pipelines/lakeflow-pipeline/out.test.toml
+++ b/acceptance/bundle/resources/pipelines/lakeflow-pipeline/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/pipelines/lakeflow-pipeline/test.toml
+++ b/acceptance/bundle/resources/pipelines/lakeflow-pipeline/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RecordRequests = true
 

--- a/acceptance/bundle/resources/pipelines/num-workers-zero/out.test.toml
+++ b/acceptance/bundle/resources/pipelines/num-workers-zero/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/pipelines/num-workers-zero/test.toml
+++ b/acceptance/bundle/resources/pipelines/num-workers-zero/test.toml
@@ -1,5 +1,4 @@
 Badness = "num_workers value 0 is not sent in the direct deployment"
-Local = true
 Cloud = false
 RecordRequests = true
 

--- a/acceptance/bundle/resources/pipelines/photon-true/out.test.toml
+++ b/acceptance/bundle/resources/pipelines/photon-true/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/pipelines/photon-true/test.toml
+++ b/acceptance/bundle/resources/pipelines/photon-true/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 RecordRequests = true
 

--- a/acceptance/bundle/resources/pipelines/recreate-keys/change-ingestion-definition/out.test.toml
+++ b/acceptance/bundle/resources/pipelines/recreate-keys/change-ingestion-definition/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/pipelines/recreate-keys/change-storage/out.test.toml
+++ b/acceptance/bundle/resources/pipelines/recreate-keys/change-storage/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/pipelines/recreate/out.test.toml
+++ b/acceptance/bundle/resources/pipelines/recreate/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 RunsOnDbr = true

--- a/acceptance/bundle/resources/pipelines/recreate/test.toml
+++ b/acceptance/bundle/resources/pipelines/recreate/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RecordRequests = false
 RunsOnDbr = true

--- a/acceptance/bundle/resources/pipelines/remote_matches_config/out.test.toml
+++ b/acceptance/bundle/resources/pipelines/remote_matches_config/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/pipelines/update/out.test.toml
+++ b/acceptance/bundle/resources/pipelines/update/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/pipelines/zero-value-fields/out.test.toml
+++ b/acceptance/bundle/resources/pipelines/zero-value-fields/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/pipelines/zero-value-fields/test.toml
+++ b/acceptance/bundle/resources/pipelines/zero-value-fields/test.toml
@@ -1,5 +1,4 @@
 Badness = "zero-value bool fields (photon, serverless, continuous, development) are not sent in the terraform deployment"
-Local = true
 Cloud = false
 RecordRequests = true
 

--- a/acceptance/bundle/resources/postgres_branches/basic/out.test.toml
+++ b/acceptance/bundle/resources/postgres_branches/basic/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 CloudEnvs.azure = false

--- a/acceptance/bundle/resources/postgres_branches/purge_on_delete/out.test.toml
+++ b/acceptance/bundle/resources/postgres_branches/purge_on_delete/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 CloudEnvs.azure = false

--- a/acceptance/bundle/resources/postgres_branches/purge_on_delete_transitions/out.test.toml
+++ b/acceptance/bundle/resources/postgres_branches/purge_on_delete_transitions/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 CloudEnvs.azure = false

--- a/acceptance/bundle/resources/postgres_branches/recreate/out.test.toml
+++ b/acceptance/bundle/resources/postgres_branches/recreate/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 CloudEnvs.azure = false

--- a/acceptance/bundle/resources/postgres_branches/replace_existing/out.test.toml
+++ b/acceptance/bundle/resources/postgres_branches/replace_existing/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 CloudEnvs.azure = false

--- a/acceptance/bundle/resources/postgres_branches/test.toml
+++ b/acceptance/bundle/resources/postgres_branches/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 

--- a/acceptance/bundle/resources/postgres_branches/update_protected/out.test.toml
+++ b/acceptance/bundle/resources/postgres_branches/update_protected/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 CloudEnvs.azure = false

--- a/acceptance/bundle/resources/postgres_branches/without_branch_id/out.test.toml
+++ b/acceptance/bundle/resources/postgres_branches/without_branch_id/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 CloudEnvs.azure = false

--- a/acceptance/bundle/resources/postgres_catalogs/basic/out.test.toml
+++ b/acceptance/bundle/resources/postgres_catalogs/basic/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 CloudEnvs.azure = false

--- a/acceptance/bundle/resources/postgres_catalogs/recreate/out.test.toml
+++ b/acceptance/bundle/resources/postgres_catalogs/recreate/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 CloudEnvs.azure = false

--- a/acceptance/bundle/resources/postgres_catalogs/test.toml
+++ b/acceptance/bundle/resources/postgres_catalogs/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 

--- a/acceptance/bundle/resources/postgres_databases/basic/out.test.toml
+++ b/acceptance/bundle/resources/postgres_databases/basic/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 CloudEnvs.azure = false

--- a/acceptance/bundle/resources/postgres_databases/live_errors/bad_database_id/out.test.toml
+++ b/acceptance/bundle/resources/postgres_databases/live_errors/bad_database_id/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 CloudEnvs.azure = false

--- a/acceptance/bundle/resources/postgres_databases/live_errors/bad_role_ref/out.test.toml
+++ b/acceptance/bundle/resources/postgres_databases/live_errors/bad_role_ref/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 CloudEnvs.azure = false

--- a/acceptance/bundle/resources/postgres_databases/live_errors/test.toml
+++ b/acceptance/bundle/resources/postgres_databases/live_errors/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 

--- a/acceptance/bundle/resources/postgres_databases/recreate/out.test.toml
+++ b/acceptance/bundle/resources/postgres_databases/recreate/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 CloudEnvs.azure = false

--- a/acceptance/bundle/resources/postgres_databases/replace_existing/out.test.toml
+++ b/acceptance/bundle/resources/postgres_databases/replace_existing/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 CloudEnvs.azure = false

--- a/acceptance/bundle/resources/postgres_databases/test.toml
+++ b/acceptance/bundle/resources/postgres_databases/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 

--- a/acceptance/bundle/resources/postgres_databases/update/out.test.toml
+++ b/acceptance/bundle/resources/postgres_databases/update/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 CloudEnvs.azure = false

--- a/acceptance/bundle/resources/postgres_endpoints/basic/out.test.toml
+++ b/acceptance/bundle/resources/postgres_endpoints/basic/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 CloudEnvs.azure = false

--- a/acceptance/bundle/resources/postgres_endpoints/recreate/out.test.toml
+++ b/acceptance/bundle/resources/postgres_endpoints/recreate/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 CloudEnvs.azure = false

--- a/acceptance/bundle/resources/postgres_endpoints/replace_existing/out.test.toml
+++ b/acceptance/bundle/resources/postgres_endpoints/replace_existing/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 CloudEnvs.azure = false

--- a/acceptance/bundle/resources/postgres_endpoints/test.toml
+++ b/acceptance/bundle/resources/postgres_endpoints/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 

--- a/acceptance/bundle/resources/postgres_endpoints/update_autoscaling/out.test.toml
+++ b/acceptance/bundle/resources/postgres_endpoints/update_autoscaling/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 CloudEnvs.azure = false

--- a/acceptance/bundle/resources/postgres_endpoints/without_endpoint_id/out.test.toml
+++ b/acceptance/bundle/resources/postgres_endpoints/without_endpoint_id/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 CloudEnvs.azure = false

--- a/acceptance/bundle/resources/postgres_projects/basic/out.test.toml
+++ b/acceptance/bundle/resources/postgres_projects/basic/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 CloudEnvs.azure = false

--- a/acceptance/bundle/resources/postgres_projects/purge_on_delete/out.test.toml
+++ b/acceptance/bundle/resources/postgres_projects/purge_on_delete/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 CloudEnvs.azure = false

--- a/acceptance/bundle/resources/postgres_projects/purge_on_delete_transitions/out.test.toml
+++ b/acceptance/bundle/resources/postgres_projects/purge_on_delete_transitions/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 CloudEnvs.azure = false

--- a/acceptance/bundle/resources/postgres_projects/recreate/out.test.toml
+++ b/acceptance/bundle/resources/postgres_projects/recreate/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 CloudEnvs.azure = false

--- a/acceptance/bundle/resources/postgres_projects/test.toml
+++ b/acceptance/bundle/resources/postgres_projects/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 

--- a/acceptance/bundle/resources/postgres_projects/update_display_name/out.test.toml
+++ b/acceptance/bundle/resources/postgres_projects/update_display_name/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 CloudEnvs.azure = false

--- a/acceptance/bundle/resources/postgres_projects/without_project_id/out.test.toml
+++ b/acceptance/bundle/resources/postgres_projects/without_project_id/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 CloudEnvs.azure = false

--- a/acceptance/bundle/resources/postgres_roles/basic/out.test.toml
+++ b/acceptance/bundle/resources/postgres_roles/basic/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 CloudEnvs.azure = false

--- a/acceptance/bundle/resources/postgres_roles/inherited-role-bind/out.test.toml
+++ b/acceptance/bundle/resources/postgres_roles/inherited-role-bind/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 RequiresUnityCatalog = true
 CloudEnvs.azure = false

--- a/acceptance/bundle/resources/postgres_roles/inherited-role-conflict/out.test.toml
+++ b/acceptance/bundle/resources/postgres_roles/inherited-role-conflict/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 RequiresUnityCatalog = true
 CloudEnvs.azure = false

--- a/acceptance/bundle/resources/postgres_roles/recreate-postgres-role/out.test.toml
+++ b/acceptance/bundle/resources/postgres_roles/recreate-postgres-role/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 CloudEnvs.azure = false

--- a/acceptance/bundle/resources/postgres_roles/recreate/out.test.toml
+++ b/acceptance/bundle/resources/postgres_roles/recreate/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 CloudEnvs.azure = false

--- a/acceptance/bundle/resources/postgres_roles/replace_existing/out.test.toml
+++ b/acceptance/bundle/resources/postgres_roles/replace_existing/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 CloudEnvs.azure = false

--- a/acceptance/bundle/resources/postgres_roles/test.toml
+++ b/acceptance/bundle/resources/postgres_roles/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 

--- a/acceptance/bundle/resources/postgres_roles/update/out.test.toml
+++ b/acceptance/bundle/resources/postgres_roles/update/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 CloudEnvs.azure = false

--- a/acceptance/bundle/resources/postgres_synced_tables/basic/out.test.toml
+++ b/acceptance/bundle/resources/postgres_synced_tables/basic/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 CloudEnvs.azure = false

--- a/acceptance/bundle/resources/postgres_synced_tables/recreate/out.test.toml
+++ b/acceptance/bundle/resources/postgres_synced_tables/recreate/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 CloudEnvs.azure = false

--- a/acceptance/bundle/resources/postgres_synced_tables/test.toml
+++ b/acceptance/bundle/resources/postgres_synced_tables/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 

--- a/acceptance/bundle/resources/quality_monitors/change_assets_dir/out.test.toml
+++ b/acceptance/bundle/resources/quality_monitors/change_assets_dir/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/quality_monitors/change_output_schema_name/out.test.toml
+++ b/acceptance/bundle/resources/quality_monitors/change_output_schema_name/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/quality_monitors/change_table_name/out.test.toml
+++ b/acceptance/bundle/resources/quality_monitors/change_table_name/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/quality_monitors/create/out.test.toml
+++ b/acceptance/bundle/resources/quality_monitors/create/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/quality_monitors/test.toml
+++ b/acceptance/bundle/resources/quality_monitors/test.toml
@@ -1,6 +1,5 @@
 # Test quality monitor output_schema_name updates
 Cloud = true
-Local = true
 RequiresUnityCatalog = true
 RecordRequests = true
 
@@ -10,7 +9,6 @@ EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
 [[Server]]
 Pattern = "POST /api/2.0/sql/statements/"
 Response.Body = '{"status": {"state": "SUCCEEDED"}, "manifest": {"schema": {"columns": []}}}'
-
 
 [[Repls]]
 Old = '"dashboard_id":\s*"[0-9a-f]+",'

--- a/acceptance/bundle/resources/registered_models/aliases_converge/out.test.toml
+++ b/acceptance/bundle/resources/registered_models/aliases_converge/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/registered_models/basic/out.test.toml
+++ b/acceptance/bundle/resources/registered_models/basic/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 RunsOnDbr = true

--- a/acceptance/bundle/resources/registered_models/basic/test.toml
+++ b/acceptance/bundle/resources/registered_models/basic/test.toml
@@ -1,5 +1,4 @@
 Cloud = true
-Local = true
 RecordRequests = false
 RunsOnDbr = true
 RequiresUnityCatalog = true

--- a/acceptance/bundle/resources/registered_models/drift/browse_only/out.test.toml
+++ b/acceptance/bundle/resources/registered_models/drift/browse_only/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/schemas/auto-approve/out.test.toml
+++ b/acceptance/bundle/resources/schemas/auto-approve/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 RunsOnDbr = true

--- a/acceptance/bundle/resources/schemas/auto-approve/test.toml
+++ b/acceptance/bundle/resources/schemas/auto-approve/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RecordRequests = false
 RunsOnDbr = true

--- a/acceptance/bundle/resources/schemas/drift/managed_properties/out.test.toml
+++ b/acceptance/bundle/resources/schemas/drift/managed_properties/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/schemas/recreate/out.test.toml
+++ b/acceptance/bundle/resources/schemas/recreate/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/schemas/update/out.test.toml
+++ b/acceptance/bundle/resources/schemas/update/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/secret_scopes/backend-type/out.test.toml
+++ b/acceptance/bundle/resources/secret_scopes/backend-type/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/secret_scopes/backend-type/test.toml
+++ b/acceptance/bundle/resources/secret_scopes/backend-type/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 
 RecordRequests = true

--- a/acceptance/bundle/resources/secret_scopes/basic/out.test.toml
+++ b/acceptance/bundle/resources/secret_scopes/basic/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/secret_scopes/basic/test.toml
+++ b/acceptance/bundle/resources/secret_scopes/basic/test.toml
@@ -1,4 +1,3 @@
 Cloud = true
-Local = true
 RecordRequests = true
 IsServicePrincipal = true

--- a/acceptance/bundle/resources/secret_scopes/delete_scope/out.test.toml
+++ b/acceptance/bundle/resources/secret_scopes/delete_scope/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/secret_scopes/delete_scope/test.toml
+++ b/acceptance/bundle/resources/secret_scopes/delete_scope/test.toml
@@ -1,3 +1,2 @@
 Cloud = true
-Local = true
 RecordRequests = true

--- a/acceptance/bundle/resources/secret_scopes/permissions-collapse/out.test.toml
+++ b/acceptance/bundle/resources/secret_scopes/permissions-collapse/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RunsOnDbr = true
 CloudEnvs.gcp = false

--- a/acceptance/bundle/resources/secret_scopes/permissions-collapse/test.toml
+++ b/acceptance/bundle/resources/secret_scopes/permissions-collapse/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RecordRequests = false
 RunsOnDbr = true

--- a/acceptance/bundle/resources/secret_scopes/permissions/out.test.toml
+++ b/acceptance/bundle/resources/secret_scopes/permissions/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RunsOnDbr = true
 CloudEnvs.gcp = false

--- a/acceptance/bundle/resources/secret_scopes/permissions/test.toml
+++ b/acceptance/bundle/resources/secret_scopes/permissions/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RecordRequests = false
 RunsOnDbr = true

--- a/acceptance/bundle/resources/secrets/basic/out.test.toml
+++ b/acceptance/bundle/resources/secrets/basic/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/secrets/basic/test.toml
+++ b/acceptance/bundle/resources/secrets/basic/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RecordRequests = true
 RequiresUnityCatalog = true

--- a/acceptance/bundle/resources/secrets/direct-only/out.test.toml
+++ b/acceptance/bundle/resources/secrets/direct-only/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform"]

--- a/acceptance/bundle/resources/secrets/direct-only/test.toml
+++ b/acceptance/bundle/resources/secrets/direct-only/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 RecordRequests = false
 

--- a/acceptance/bundle/resources/secrets/update-value/out.test.toml
+++ b/acceptance/bundle/resources/secrets/update-value/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/secrets/update-value/test.toml
+++ b/acceptance/bundle/resources/secrets/update-value/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 RecordRequests = true
 

--- a/acceptance/bundle/resources/secrets/validate-no-plain-text-default/out.test.toml
+++ b/acceptance/bundle/resources/secrets/validate-no-plain-text-default/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/secrets/validate-no-plain-text-default/test.toml
+++ b/acceptance/bundle/resources/secrets/validate-no-plain-text-default/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 RecordRequests = false
 

--- a/acceptance/bundle/resources/secrets/validate-no-plain-text/out.test.toml
+++ b/acceptance/bundle/resources/secrets/validate-no-plain-text/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/secrets/validate-no-plain-text/test.toml
+++ b/acceptance/bundle/resources/secrets/validate-no-plain-text/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 RecordRequests = false
 

--- a/acceptance/bundle/resources/sql_warehouses/lifecycle-started-edit/out.test.toml
+++ b/acceptance/bundle/resources/sql_warehouses/lifecycle-started-edit/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 CloudSlow = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/sql_warehouses/lifecycle-started-edit/test.toml
+++ b/acceptance/bundle/resources/sql_warehouses/lifecycle-started-edit/test.toml
@@ -1,4 +1,3 @@
-Local = true
 RecordRequests = true
 
 # Starting warehouses is slow, so run on cloud nightly (CloudSlow) instead of every PR

--- a/acceptance/bundle/resources/sql_warehouses/lifecycle-started-terraform-error/out.test.toml
+++ b/acceptance/bundle/resources/sql_warehouses/lifecycle-started-terraform-error/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 CloudSlow = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform"]

--- a/acceptance/bundle/resources/sql_warehouses/lifecycle-started-terraform-error/test.toml
+++ b/acceptance/bundle/resources/sql_warehouses/lifecycle-started-terraform-error/test.toml
@@ -1,4 +1,3 @@
-Local = true
 RecordRequests = false
 
 # This test performs static validation; no need to run on cloud.

--- a/acceptance/bundle/resources/sql_warehouses/lifecycle-started-toggle/out.test.toml
+++ b/acceptance/bundle/resources/sql_warehouses/lifecycle-started-toggle/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 CloudSlow = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/sql_warehouses/lifecycle-started-toggle/test.toml
+++ b/acceptance/bundle/resources/sql_warehouses/lifecycle-started-toggle/test.toml
@@ -1,4 +1,3 @@
-Local = true
 RecordRequests = true
 
 # Starting warehouses can take a while on infra under load.

--- a/acceptance/bundle/resources/sql_warehouses/lifecycle-started/out.test.toml
+++ b/acceptance/bundle/resources/sql_warehouses/lifecycle-started/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 CloudSlow = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/sql_warehouses/lifecycle-started/test.toml
+++ b/acceptance/bundle/resources/sql_warehouses/lifecycle-started/test.toml
@@ -1,4 +1,3 @@
-Local = true
 RecordRequests = true
 
 # Starting warehouses can take a while on infra under load.

--- a/acceptance/bundle/resources/sql_warehouses/out.test.toml
+++ b/acceptance/bundle/resources/sql_warehouses/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 CloudSlow = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/sql_warehouses/test.toml
+++ b/acceptance/bundle/resources/sql_warehouses/test.toml
@@ -1,5 +1,4 @@
 Cloud = false
-Local = true
 CloudSlow = false
 RecordRequests = true
 

--- a/acceptance/bundle/resources/synced_database_tables/basic/out.test.toml
+++ b/acceptance/bundle/resources/synced_database_tables/basic/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 RunsOnDbr = false

--- a/acceptance/bundle/resources/synced_database_tables/basic/test.toml
+++ b/acceptance/bundle/resources/synced_database_tables/basic/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 Badness = "post deployment, bundle summary should print actual name that is fully resolved"
 

--- a/acceptance/bundle/resources/synced_database_tables/recreate/out.test.toml
+++ b/acceptance/bundle/resources/synced_database_tables/recreate/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 RequiresUnityCatalog = true
 CloudEnvs.gcp = false

--- a/acceptance/bundle/resources/vector_search_endpoints/basic/out.test.toml
+++ b/acceptance/bundle/resources/vector_search_endpoints/basic/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/vector_search_endpoints/drift/budget_policy/out.test.toml
+++ b/acceptance/bundle/resources/vector_search_endpoints/drift/budget_policy/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 RequiresUnityCatalog = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/vector_search_endpoints/drift/recreated_same_name/out.test.toml
+++ b/acceptance/bundle/resources/vector_search_endpoints/drift/recreated_same_name/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/vector_search_endpoints/drift/target_qps/out.test.toml
+++ b/acceptance/bundle/resources/vector_search_endpoints/drift/target_qps/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 RequiresUnityCatalog = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/vector_search_endpoints/recreate/create-fails/out.test.toml
+++ b/acceptance/bundle/resources/vector_search_endpoints/recreate/create-fails/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 RequiresUnityCatalog = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/vector_search_endpoints/recreate/endpoint_type/out.test.toml
+++ b/acceptance/bundle/resources/vector_search_endpoints/recreate/endpoint_type/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 RequiresUnityCatalog = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/vector_search_endpoints/test.toml
+++ b/acceptance/bundle/resources/vector_search_endpoints/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 

--- a/acceptance/bundle/resources/vector_search_endpoints/update/budget_policy/out.test.toml
+++ b/acceptance/bundle/resources/vector_search_endpoints/update/budget_policy/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 RequiresUnityCatalog = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/vector_search_endpoints/update/target_qps/out.test.toml
+++ b/acceptance/bundle/resources/vector_search_endpoints/update/target_qps/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 RequiresUnityCatalog = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/vector_search_indexes/basic/out.test.toml
+++ b/acceptance/bundle/resources/vector_search_indexes/basic/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 CloudSlow = true
 RequiresUnityCatalog = true

--- a/acceptance/bundle/resources/vector_search_indexes/drift/deleted_remotely/out.test.toml
+++ b/acceptance/bundle/resources/vector_search_indexes/drift/deleted_remotely/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 CloudSlow = false
 RequiresUnityCatalog = true

--- a/acceptance/bundle/resources/vector_search_indexes/drift/orphaned_endpoint/out.test.toml
+++ b/acceptance/bundle/resources/vector_search_indexes/drift/orphaned_endpoint/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 CloudSlow = false
 RequiresUnityCatalog = true

--- a/acceptance/bundle/resources/vector_search_indexes/grants/select/out.test.toml
+++ b/acceptance/bundle/resources/vector_search_indexes/grants/select/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 CloudSlow = true
 RequiresUnityCatalog = true

--- a/acceptance/bundle/resources/vector_search_indexes/recreate/embedding_dimension/out.test.toml
+++ b/acceptance/bundle/resources/vector_search_indexes/recreate/embedding_dimension/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 CloudSlow = true
 RequiresUnityCatalog = true

--- a/acceptance/bundle/resources/vector_search_indexes/recreate/pending_deletion/out.test.toml
+++ b/acceptance/bundle/resources/vector_search_indexes/recreate/pending_deletion/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 CloudSlow = false
 RequiresUnityCatalog = true

--- a/acceptance/bundle/resources/vector_search_indexes/recreate/with_endpoint/out.test.toml
+++ b/acceptance/bundle/resources/vector_search_indexes/recreate/with_endpoint/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 CloudSlow = false
 RequiresUnityCatalog = true

--- a/acceptance/bundle/resources/vector_search_indexes/schema_normalization/out.test.toml
+++ b/acceptance/bundle/resources/vector_search_indexes/schema_normalization/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 CloudSlow = true
 RequiresUnityCatalog = true

--- a/acceptance/bundle/resources/vector_search_indexes/test.toml
+++ b/acceptance/bundle/resources/vector_search_indexes/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 

--- a/acceptance/bundle/resources/volumes/catalog-var-ref/out.test.toml
+++ b/acceptance/bundle/resources/volumes/catalog-var-ref/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/volumes/catalog-var-ref/test.toml
+++ b/acceptance/bundle/resources/volumes/catalog-var-ref/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 RecordRequests = false
 

--- a/acceptance/bundle/resources/volumes/change-comment/out.test.toml
+++ b/acceptance/bundle/resources/volumes/change-comment/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/volumes/change-name/out.test.toml
+++ b/acceptance/bundle/resources/volumes/change-name/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/volumes/change-schema-name/out.test.toml
+++ b/acceptance/bundle/resources/volumes/change-schema-name/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/volumes/recreate/out.test.toml
+++ b/acceptance/bundle/resources/volumes/recreate/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 RunsOnDbr = true

--- a/acceptance/bundle/resources/volumes/recreate/test.toml
+++ b/acceptance/bundle/resources/volumes/recreate/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RecordRequests = false
 RunsOnDbr = true

--- a/acceptance/bundle/resources/volumes/remote-change-name/out.test.toml
+++ b/acceptance/bundle/resources/volumes/remote-change-name/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/volumes/remote-delete/out.test.toml
+++ b/acceptance/bundle/resources/volumes/remote-delete/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/volumes/set-storage-location/out.test.toml
+++ b/acceptance/bundle/resources/volumes/set-storage-location/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 CloudEnvs.azure = false

--- a/acceptance/bundle/resources/volumes/set-storage-location/test.toml
+++ b/acceptance/bundle/resources/volumes/set-storage-location/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 CloudEnvs.gcp = false

--- a/acceptance/bundle/resources/volumes/set-volume-path/out.test.toml
+++ b/acceptance/bundle/resources/volumes/set-volume-path/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/volumes/set-volume-path/test.toml
+++ b/acceptance/bundle/resources/volumes/set-volume-path/test.toml
@@ -1,1 +1,0 @@
-Cloud = false

--- a/acceptance/bundle/resources/volumes/set-volume-path/test.toml
+++ b/acceptance/bundle/resources/volumes/set-volume-path/test.toml
@@ -1,2 +1,1 @@
-Local = true
 Cloud = false

--- a/acceptance/bundle/resources/volumes/uppercase-name/out.test.toml
+++ b/acceptance/bundle/resources/volumes/uppercase-name/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/root/env-not-a-directory/out.test.toml
+++ b/acceptance/bundle/root/env-not-a-directory/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/root/env-not-found/out.test.toml
+++ b/acceptance/bundle/root/env-not-found/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/root/not-found/out.test.toml
+++ b/acceptance/bundle/root/not-found/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/root/real-empty-dir/out.test.toml
+++ b/acceptance/bundle/root/real-empty-dir/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/root/test.toml
+++ b/acceptance/bundle/root/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 
 # These errors originate in bundle/root.go before any engine is selected,

--- a/acceptance/bundle/run/app-with-job/out.test.toml
+++ b/acceptance/bundle/run/app-with-job/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 CloudSlow = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run/app-with-job/test.toml
+++ b/acceptance/bundle/run/app-with-job/test.toml
@@ -1,5 +1,3 @@
-Local = true
-
 #
 # On June 18 2025 it was taking:
 # - 160-180 seconds to start an application in this test

--- a/acceptance/bundle/run/basic/out.test.toml
+++ b/acceptance/bundle/run/basic/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run/diagnostics/out.test.toml
+++ b/acceptance/bundle/run/diagnostics/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run/inline-script/basic/out.test.toml
+++ b/acceptance/bundle/run/inline-script/basic/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run/inline-script/cwd/out.test.toml
+++ b/acceptance/bundle/run/inline-script/cwd/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run/inline-script/databricks-cli/profile-is-passed/from_flag/out.test.toml
+++ b/acceptance/bundle/run/inline-script/databricks-cli/profile-is-passed/from_flag/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run/inline-script/databricks-cli/target-is-passed/default/out.test.toml
+++ b/acceptance/bundle/run/inline-script/databricks-cli/target-is-passed/default/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run/inline-script/databricks-cli/target-is-passed/from_flag/out.test.toml
+++ b/acceptance/bundle/run/inline-script/databricks-cli/target-is-passed/from_flag/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run/inline-script/no-auth/out.test.toml
+++ b/acceptance/bundle/run/inline-script/no-auth/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run/inline-script/no-bundle/out.test.toml
+++ b/acceptance/bundle/run/inline-script/no-bundle/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run/inline-script/no-separator/out.test.toml
+++ b/acceptance/bundle/run/inline-script/no-separator/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run/inline-script/test.toml
+++ b/acceptance/bundle/run/inline-script/test.toml
@@ -1,1 +1,0 @@
-Cloud = false

--- a/acceptance/bundle/run/inline-script/test.toml
+++ b/acceptance/bundle/run/inline-script/test.toml
@@ -1,2 +1,1 @@
 Cloud = false
-Local = true

--- a/acceptance/bundle/run/jobs/partial_run/out.test.toml
+++ b/acceptance/bundle/run/jobs/partial_run/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run/jobs/partial_run/test.toml
+++ b/acceptance/bundle/run/jobs/partial_run/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 
 RecordRequests = true

--- a/acceptance/bundle/run/no-state/out.test.toml
+++ b/acceptance/bundle/run/no-state/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run/refresh-flags/out.test.toml
+++ b/acceptance/bundle/run/refresh-flags/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run/scripts/basic/out.test.toml
+++ b/acceptance/bundle/run/scripts/basic/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run/scripts/cwd/out.test.toml
+++ b/acceptance/bundle/run/scripts/cwd/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run/scripts/databricks-cli/profile-is-passed/from_flag/out.test.toml
+++ b/acceptance/bundle/run/scripts/databricks-cli/profile-is-passed/from_flag/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run/scripts/databricks-cli/target-is-passed/default/out.test.toml
+++ b/acceptance/bundle/run/scripts/databricks-cli/target-is-passed/default/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run/scripts/databricks-cli/target-is-passed/from_flag/out.test.toml
+++ b/acceptance/bundle/run/scripts/databricks-cli/target-is-passed/from_flag/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run/scripts/env-bad-prefix/out.test.toml
+++ b/acceptance/bundle/run/scripts/env-bad-prefix/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run/scripts/env-bad-prefix/test.toml
+++ b/acceptance/bundle/run/scripts/env-bad-prefix/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 
 [EnvMatrix]

--- a/acceptance/bundle/run/scripts/env-precedence/out.test.toml
+++ b/acceptance/bundle/run/scripts/env-precedence/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run/scripts/env-precedence/test.toml
+++ b/acceptance/bundle/run/scripts/env-precedence/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 
 [EnvMatrix]

--- a/acceptance/bundle/run/scripts/env-section/out.test.toml
+++ b/acceptance/bundle/run/scripts/env-section/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run/scripts/env-section/test.toml
+++ b/acceptance/bundle/run/scripts/env-section/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 
 [EnvMatrix]

--- a/acceptance/bundle/run/scripts/exit_code/out.test.toml
+++ b/acceptance/bundle/run/scripts/exit_code/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run/scripts/io/out.test.toml
+++ b/acceptance/bundle/run/scripts/io/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run/scripts/no-auth/out.test.toml
+++ b/acceptance/bundle/run/scripts/no-auth/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run/scripts/no-interpolation/out.test.toml
+++ b/acceptance/bundle/run/scripts/no-interpolation/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run/scripts/no_content/out.test.toml
+++ b/acceptance/bundle/run/scripts/no_content/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run/scripts/shell/envvar/out.test.toml
+++ b/acceptance/bundle/run/scripts/shell/envvar/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run/scripts/shell/math/out.test.toml
+++ b/acceptance/bundle/run/scripts/shell/math/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run/scripts/unique_keys/duplicate_resource_and_script_name_root/out.test.toml
+++ b/acceptance/bundle/run/scripts/unique_keys/duplicate_resource_and_script_name_root/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run/scripts/unique_keys/duplicate_resource_and_script_subconfigurations/out.test.toml
+++ b/acceptance/bundle/run/scripts/unique_keys/duplicate_resource_and_script_subconfigurations/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run/scripts/unique_keys/duplicate_script_names_in_subconfiguration/out.test.toml
+++ b/acceptance/bundle/run/scripts/unique_keys/duplicate_script_names_in_subconfiguration/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run/state-wiped/out.test.toml
+++ b/acceptance/bundle/run/state-wiped/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/allowed/regular_user/out.test.toml
+++ b/acceptance/bundle/run_as/allowed/regular_user/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/allowed/service_principal/out.test.toml
+++ b/acceptance/bundle/run_as/allowed/service_principal/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/dashboard_embed/out.test.toml
+++ b/acceptance/bundle/run_as/dashboard_embed/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/empty_override/out.test.toml
+++ b/acceptance/bundle/run_as/empty_override/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/empty_run_as/out.test.toml
+++ b/acceptance/bundle/run_as/empty_run_as/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/empty_run_as_dict/out.test.toml
+++ b/acceptance/bundle/run_as/empty_run_as_dict/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/empty_sp/out.test.toml
+++ b/acceptance/bundle/run_as/empty_sp/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/empty_user/out.test.toml
+++ b/acceptance/bundle/run_as/empty_user/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/empty_user_and_sp/out.test.toml
+++ b/acceptance/bundle/run_as/empty_user_and_sp/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/invalid_both_sp_and_user/out.test.toml
+++ b/acceptance/bundle/run_as/invalid_both_sp_and_user/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/job_default/out.test.toml
+++ b/acceptance/bundle/run_as/job_default/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/run_as/job_default/test.toml
+++ b/acceptance/bundle/run_as/job_default/test.toml
@@ -1,7 +1,6 @@
 Badness = "run_as is still set even though it's not in bundle and not in reset request"
 Ignore = [".databricks/.gitignore"]
 
-Local = true
 Cloud = true
 RecordRequests = true
 

--- a/acceptance/bundle/run_as/model_serving_different/out.test.toml
+++ b/acceptance/bundle/run_as/model_serving_different/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/model_serving_matching/out.test.toml
+++ b/acceptance/bundle/run_as/model_serving_matching/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/out.test.toml
+++ b/acceptance/bundle/run_as/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/pipelines/regular_user/out.test.toml
+++ b/acceptance/bundle/run_as/pipelines/regular_user/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/pipelines/service_principal/out.test.toml
+++ b/acceptance/bundle/run_as/pipelines/service_principal/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/pipelines_legacy/out.test.toml
+++ b/acceptance/bundle/run_as/pipelines_legacy/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/scripts/no-trailing-newline/out.test.toml
+++ b/acceptance/bundle/scripts/no-trailing-newline/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/scripts/out.test.toml
+++ b/acceptance/bundle/scripts/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/scripts/restricted-execution/out.test.toml
+++ b/acceptance/bundle/scripts/restricted-execution/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/select/ambiguous/out.test.toml
+++ b/acceptance/bundle/select/ambiguous/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/select/basic/out.test.toml
+++ b/acceptance/bundle/select/basic/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]
 EnvMatrix.READPLAN = ["", "1"]

--- a/acceptance/bundle/select/basic/test.toml
+++ b/acceptance/bundle/select/basic/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RecordRequests = true
 # --select is only supported by the direct engine, so this happy-path test runs on

--- a/acceptance/bundle/select/grants_permissions/out.test.toml
+++ b/acceptance/bundle/select/grants_permissions/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 RequiresUnityCatalog = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/select/grants_permissions/test.toml
+++ b/acceptance/bundle/select/grants_permissions/test.toml
@@ -6,7 +6,6 @@
 # would otherwise also match the bundle's own file-upload paths. (We can't set
 # MSYS_NO_PATHCONV to keep the "//" intact, because that breaks the python helper's
 # own path resolution -- see the env -u workaround in acceptance/script.prepare.)
-Local = true
 Cloud = false
 RecordRequests = true
 RequiresUnityCatalog = true

--- a/acceptance/bundle/select/missing/out.test.toml
+++ b/acceptance/bundle/select/missing/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/select/rejected/out.test.toml
+++ b/acceptance/bundle/select/rejected/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform"]

--- a/acceptance/bundle/select/test.toml
+++ b/acceptance/bundle/select/test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 Ignore = [".databricks", ".gitignore"]

--- a/acceptance/bundle/state/bad_env/out.test.toml
+++ b/acceptance/bundle/state/bad_env/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/state/bad_json_local/out.test.toml
+++ b/acceptance/bundle/state/bad_json_local/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/state/basic/out.test.toml
+++ b/acceptance/bundle/state/basic/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/state/engine_default/out.test.toml
+++ b/acceptance/bundle/state/engine_default/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/state/engine_mismatch/out.test.toml
+++ b/acceptance/bundle/state/engine_mismatch/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/state/feature_flags/out.test.toml
+++ b/acceptance/bundle/state/feature_flags/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/state/force_pull_commands/out.test.toml
+++ b/acceptance/bundle/state/force_pull_commands/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/state/force_pull_commands/test.toml
+++ b/acceptance/bundle/state/force_pull_commands/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 RecordRequests = true
 

--- a/acceptance/bundle/state/future_version/out.test.toml
+++ b/acceptance/bundle/state/future_version/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/state/lineage_different/out.test.toml
+++ b/acceptance/bundle/state/lineage_different/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/state/permission_level_migration/out.test.toml
+++ b/acceptance/bundle/state/permission_level_migration/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/state/same_serial/out.test.toml
+++ b/acceptance/bundle/state/same_serial/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/state/state_present/out.test.toml
+++ b/acceptance/bundle/state/state_present/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/summary/missing-libraries-file-path/out.test.toml
+++ b/acceptance/bundle/summary/missing-libraries-file-path/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/summary/modified_status/out.test.toml
+++ b/acceptance/bundle/summary/modified_status/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
 EnvMatrix.VARIANT = ["empty_resources.yml", "no_resources.yml"]

--- a/acceptance/bundle/sync/dryrun/out.test.toml
+++ b/acceptance/bundle/sync/dryrun/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/sync/out.test.toml
+++ b/acceptance/bundle/sync/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/syncroot/dotdot-git/out.test.toml
+++ b/acceptance/bundle/syncroot/dotdot-git/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/syncroot/dotdot-nogit/out.test.toml
+++ b/acceptance/bundle/syncroot/dotdot-nogit/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/telemetry/config-remote-sync-error/out.test.toml
+++ b/acceptance/bundle/telemetry/config-remote-sync-error/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform"]

--- a/acceptance/bundle/telemetry/config-remote-sync-recreate/out.test.toml
+++ b/acceptance/bundle/telemetry/config-remote-sync-recreate/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/telemetry/config-remote-sync-save/out.test.toml
+++ b/acceptance/bundle/telemetry/config-remote-sync-save/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/telemetry/config-remote-sync/out.test.toml
+++ b/acceptance/bundle/telemetry/config-remote-sync/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/telemetry/deploy-app-lifecycle-started/out.test.toml
+++ b/acceptance/bundle/telemetry/deploy-app-lifecycle-started/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/telemetry/deploy-artifact-path-type/out.test.toml
+++ b/acceptance/bundle/telemetry/deploy-artifact-path-type/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/telemetry/deploy-artifacts-variables/out.test.toml
+++ b/acceptance/bundle/telemetry/deploy-artifacts-variables/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/telemetry/deploy-compute-type/out.test.toml
+++ b/acceptance/bundle/telemetry/deploy-compute-type/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/telemetry/deploy-config-file-count/out.test.toml
+++ b/acceptance/bundle/telemetry/deploy-config-file-count/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/telemetry/deploy-error-message/out.test.toml
+++ b/acceptance/bundle/telemetry/deploy-error-message/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/telemetry/deploy-error/out.test.toml
+++ b/acceptance/bundle/telemetry/deploy-error/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/telemetry/deploy-experimental/out.test.toml
+++ b/acceptance/bundle/telemetry/deploy-experimental/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/telemetry/deploy-mode/out.test.toml
+++ b/acceptance/bundle/telemetry/deploy-mode/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/telemetry/deploy-name-prefix/custom/out.test.toml
+++ b/acceptance/bundle/telemetry/deploy-name-prefix/custom/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/telemetry/deploy-name-prefix/mode-development/out.test.toml
+++ b/acceptance/bundle/telemetry/deploy-name-prefix/mode-development/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/telemetry/deploy-no-uuid/out.test.toml
+++ b/acceptance/bundle/telemetry/deploy-no-uuid/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/telemetry/deploy-run-as/out.test.toml
+++ b/acceptance/bundle/telemetry/deploy-run-as/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/telemetry/deploy-run-as/test.toml
+++ b/acceptance/bundle/telemetry/deploy-run-as/test.toml
@@ -1,1 +1,0 @@
-Cloud = false

--- a/acceptance/bundle/telemetry/deploy-run-as/test.toml
+++ b/acceptance/bundle/telemetry/deploy-run-as/test.toml
@@ -1,2 +1,1 @@
-Local = true
 Cloud = false

--- a/acceptance/bundle/telemetry/deploy-target-count/out.test.toml
+++ b/acceptance/bundle/telemetry/deploy-target-count/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/telemetry/deploy-variable-count/out.test.toml
+++ b/acceptance/bundle/telemetry/deploy-variable-count/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/telemetry/deploy-whl-artifacts/out.test.toml
+++ b/acceptance/bundle/telemetry/deploy-whl-artifacts/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/telemetry/deploy-workspace-folder-permissions/out.test.toml
+++ b/acceptance/bundle/telemetry/deploy-workspace-folder-permissions/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/telemetry/deploy/out.test.toml
+++ b/acceptance/bundle/telemetry/deploy/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/templates-machinery/helper_upper_lower/out.test.toml
+++ b/acceptance/bundle/templates-machinery/helper_upper_lower/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/templates-machinery/helper_username/out.test.toml
+++ b/acceptance/bundle/templates-machinery/helper_username/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/templates-machinery/helpers-error/out.test.toml
+++ b/acceptance/bundle/templates-machinery/helpers-error/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/templates-machinery/number-precision/out.test.toml
+++ b/acceptance/bundle/templates-machinery/number-precision/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/templates-machinery/supported-url/out.test.toml
+++ b/acceptance/bundle/templates-machinery/supported-url/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/templates-machinery/unsupported-url/out.test.toml
+++ b/acceptance/bundle/templates-machinery/unsupported-url/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/templates-machinery/wrong-path/out.test.toml
+++ b/acceptance/bundle/templates-machinery/wrong-path/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/templates-machinery/wrong-url/out.test.toml
+++ b/acceptance/bundle/templates-machinery/wrong-url/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/templates/dbt-sql/out.test.toml
+++ b/acceptance/bundle/templates/dbt-sql/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/templates/default-minimal/python/out.test.toml
+++ b/acceptance/bundle/templates/default-minimal/python/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/templates/default-minimal/skip/out.test.toml
+++ b/acceptance/bundle/templates/default-minimal/skip/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/templates/default-minimal/sql/out.test.toml
+++ b/acceptance/bundle/templates/default-minimal/sql/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/templates/default-python/azure-government/out.test.toml
+++ b/acceptance/bundle/templates/default-python/azure-government/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/templates/default-python/classic/out.test.toml
+++ b/acceptance/bundle/templates/default-python/classic/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 Phase = 1
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/templates/default-python/combinations/classic/out.test.toml
+++ b/acceptance/bundle/templates/default-python/combinations/classic/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
 EnvMatrix.DLT = ["yes", "no"]

--- a/acceptance/bundle/templates/default-python/combinations/serverless/out.test.toml
+++ b/acceptance/bundle/templates/default-python/combinations/serverless/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
 EnvMatrix.DLT = ["yes", "no"]

--- a/acceptance/bundle/templates/default-python/fail-missing-uv/out.test.toml
+++ b/acceptance/bundle/templates/default-python/fail-missing-uv/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/templates/default-python/fail-missing-uv/test.toml
+++ b/acceptance/bundle/templates/default-python/fail-missing-uv/test.toml
@@ -1,6 +1,5 @@
 Badness = "The error message is not ideal: it reports a generic build failure or 'command not found' instead of a clear message that 'uv' is missing from the environment."
 
-Local = true
 Cloud = false
 
 # Replace the uv not found error for portability

--- a/acceptance/bundle/templates/default-python/integration_classic/out.test.toml
+++ b/acceptance/bundle/templates/default-python/integration_classic/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
 EnvMatrix.UV_PYTHON = [

--- a/acceptance/bundle/templates/default-python/no-uc/out.test.toml
+++ b/acceptance/bundle/templates/default-python/no-uc/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/templates/default-python/serverless-customcatalog/out.test.toml
+++ b/acceptance/bundle/templates/default-python/serverless-customcatalog/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 Phase = 1
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/templates/default-python/serverless/out.test.toml
+++ b/acceptance/bundle/templates/default-python/serverless/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/templates/default-scala/out.test.toml
+++ b/acceptance/bundle/templates/default-scala/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/templates/default-sql/out.test.toml
+++ b/acceptance/bundle/templates/default-sql/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/templates/lakeflow-integrations/out.test.toml
+++ b/acceptance/bundle/templates/lakeflow-integrations/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/templates/lakeflow-integrations/test.toml
+++ b/acceptance/bundle/templates/lakeflow-integrations/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 
 # databricks-lakeflow-integrations requires Python 3.12+.

--- a/acceptance/bundle/templates/lakeflow-pipelines/python/out.test.toml
+++ b/acceptance/bundle/templates/lakeflow-pipelines/python/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/templates/lakeflow-pipelines/sql/out.test.toml
+++ b/acceptance/bundle/templates/lakeflow-pipelines/sql/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/templates/nested-output/out.test.toml
+++ b/acceptance/bundle/templates/nested-output/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/templates/pydabs/check-consistency/out.test.toml
+++ b/acceptance/bundle/templates/pydabs/check-consistency/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
 EnvMatrix.INCLUDE_JOB = ["yes", "no"]

--- a/acceptance/bundle/templates/pydabs/check-formatting/out.test.toml
+++ b/acceptance/bundle/templates/pydabs/check-formatting/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
 EnvMatrix.INCLUDE_JOB = ["yes", "no"]

--- a/acceptance/bundle/templates/pydabs/deploy-classic/out.test.toml
+++ b/acceptance/bundle/templates/pydabs/deploy-classic/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/templates/pydabs/init-classic/out.test.toml
+++ b/acceptance/bundle/templates/pydabs/init-classic/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/templates/pydabs/test.toml
+++ b/acceptance/bundle/templates/pydabs/test.toml
@@ -1,7 +1,6 @@
 Timeout = '40s'
 TimeoutWindows = '120s'
 
-Local = true
 Cloud = false
 
 # Mask the real databricks-bundles version so the golden pyproject.toml does not

--- a/acceptance/bundle/templates/telemetry/custom-template/out.test.toml
+++ b/acceptance/bundle/templates/telemetry/custom-template/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/templates/telemetry/dbt-sql/out.test.toml
+++ b/acceptance/bundle/templates/telemetry/dbt-sql/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/templates/telemetry/default-python/out.test.toml
+++ b/acceptance/bundle/templates/telemetry/default-python/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/templates/telemetry/default-sql/out.test.toml
+++ b/acceptance/bundle/templates/telemetry/default-sql/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/trampoline/warning_message/out.test.toml
+++ b/acceptance/bundle/trampoline/warning_message/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/trampoline/warning_message_with_new_spark/out.test.toml
+++ b/acceptance/bundle/trampoline/warning_message_with_new_spark/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/trampoline/warning_message_with_old_spark/out.test.toml
+++ b/acceptance/bundle/trampoline/warning_message_with_old_spark/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/undefined_resources/out.test.toml
+++ b/acceptance/bundle/undefined_resources/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/upload/internal_server_error/out.test.toml
+++ b/acceptance/bundle/upload/internal_server_error/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/upload/timeout/out.test.toml
+++ b/acceptance/bundle/upload/timeout/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/user_agent/out.test.toml
+++ b/acceptance/bundle/user_agent/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 Phase = 1
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/user_agent/simple/out.test.toml
+++ b/acceptance/bundle/user_agent/simple/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/user_agent/simple/test.toml
+++ b/acceptance/bundle/user_agent/simple/test.toml
@@ -1,5 +1,4 @@
 RecordRequests = true
-Local = true
 IncludeRequestHeaders = ["User-Agent"]
 Ignore = [".databricks"]
 

--- a/acceptance/bundle/user_agent/test.toml
+++ b/acceptance/bundle/user_agent/test.toml
@@ -1,6 +1,5 @@
 Phase = 1
 RecordRequests = true
-Local = true
 IncludeRequestHeaders = ["User-Agent"]
 
 [Env]

--- a/acceptance/bundle/validate/anchor_containers/out.test.toml
+++ b/acceptance/bundle/validate/anchor_containers/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/catalog_requires_direct_mode/out.test.toml
+++ b/acceptance/bundle/validate/catalog_requires_direct_mode/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform"]

--- a/acceptance/bundle/validate/catalog_requires_direct_mode/test.toml
+++ b/acceptance/bundle/validate/catalog_requires_direct_mode/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 
 Ignore = [".databricks"]

--- a/acceptance/bundle/validate/dashboard_defaults/out.test.toml
+++ b/acceptance/bundle/validate/dashboard_defaults/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/dashboard_required_name/out.test.toml
+++ b/acceptance/bundle/validate/dashboard_required_name/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/dashboard_required_warehouse_id/out.test.toml
+++ b/acceptance/bundle/validate/dashboard_required_warehouse_id/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/definitions_yaml_anchors/out.test.toml
+++ b/acceptance/bundle/validate/definitions_yaml_anchors/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/duplicate_yaml_merge_key/out.test.toml
+++ b/acceptance/bundle/validate/duplicate_yaml_merge_key/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/empty_resources/empty_def/out.test.toml
+++ b/acceptance/bundle/validate/empty_resources/empty_def/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/empty_resources/empty_dict/out.test.toml
+++ b/acceptance/bundle/validate/empty_resources/empty_dict/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/empty_resources/null/out.test.toml
+++ b/acceptance/bundle/validate/empty_resources/null/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/empty_resources/with_grants/out.test.toml
+++ b/acceptance/bundle/validate/empty_resources/with_grants/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/empty_resources/with_permissions/out.test.toml
+++ b/acceptance/bundle/validate/empty_resources/with_permissions/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/empty_tasks/out.test.toml
+++ b/acceptance/bundle/validate/empty_tasks/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/engine-config-valid/out.test.toml
+++ b/acceptance/bundle/validate/engine-config-valid/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/enum/out.test.toml
+++ b/acceptance/bundle/validate/enum/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/enum_resource_refs/out.test.toml
+++ b/acceptance/bundle/validate/enum_resource_refs/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/genie_space_complex/out.test.toml
+++ b/acceptance/bundle/validate/genie_space_complex/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/genie_space_defaults/out.test.toml
+++ b/acceptance/bundle/validate/genie_space_defaults/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/genie_space_file_path_and_inline/out.test.toml
+++ b/acceptance/bundle/validate/genie_space_file_path_and_inline/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/genie_space_file_path_and_inline/test.toml
+++ b/acceptance/bundle/validate/genie_space_file_path_and_inline/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 
 # Genie spaces only support direct deployment engine.

--- a/acceptance/bundle/validate/grants_required_principal/out.test.toml
+++ b/acceptance/bundle/validate/grants_required_principal/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/validate/immutable_workspace_paths/out.test.toml
+++ b/acceptance/bundle/validate/immutable_workspace_paths/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/immutable_workspace_paths/test.toml
+++ b/acceptance/bundle/validate/immutable_workspace_paths/test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 Ignore = [".databricks"]

--- a/acceptance/bundle/validate/include_locations/out.test.toml
+++ b/acceptance/bundle/validate/include_locations/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/invalid-engine-bundle/out.test.toml
+++ b/acceptance/bundle/validate/invalid-engine-bundle/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/invalid-engine-target/out.test.toml
+++ b/acceptance/bundle/validate/invalid-engine-target/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/job-references/out.test.toml
+++ b/acceptance/bundle/validate/job-references/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/model_serving_both_fields_error/out.test.toml
+++ b/acceptance/bundle/validate/model_serving_both_fields_error/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/model_serving_conversion/out.test.toml
+++ b/acceptance/bundle/validate/model_serving_conversion/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/models/missing_name/out.test.toml
+++ b/acceptance/bundle/validate/models/missing_name/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/models/user_id/out.test.toml
+++ b/acceptance/bundle/validate/models/user_id/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/no_dashboard_etag/out.test.toml
+++ b/acceptance/bundle/validate/no_dashboard_etag/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/no_genie_space_etag/out.test.toml
+++ b/acceptance/bundle/validate/no_genie_space_etag/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/validate/permissions/out.test.toml
+++ b/acceptance/bundle/validate/permissions/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/permissions_overlap/out.test.toml
+++ b/acceptance/bundle/validate/permissions_overlap/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/presets_max_concurrent_runs/out.test.toml
+++ b/acceptance/bundle/validate/presets_max_concurrent_runs/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/presets_name_prefix/out.test.toml
+++ b/acceptance/bundle/validate/presets_name_prefix/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/presets_name_prefix_dev/out.test.toml
+++ b/acceptance/bundle/validate/presets_name_prefix_dev/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/validate/presets_tags/out.test.toml
+++ b/acceptance/bundle/validate/presets_tags/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/required/out.test.toml
+++ b/acceptance/bundle/validate/required/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/reserved_deployment_fields/out.test.toml
+++ b/acceptance/bundle/validate/reserved_deployment_fields/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/sql_warehouse_required_name/out.test.toml
+++ b/acceptance/bundle/validate/sql_warehouse_required_name/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/strict/out.test.toml
+++ b/acceptance/bundle/validate/strict/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/sync_patterns/out.test.toml
+++ b/acceptance/bundle/validate/sync_patterns/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/var_in_bundle_name/out.test.toml
+++ b/acceptance/bundle/validate/var_in_bundle_name/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/volume_defaults/out.test.toml
+++ b/acceptance/bundle/validate/volume_defaults/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/arg-repeat/out.test.toml
+++ b/acceptance/bundle/variables/arg-repeat/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/complex-cross-ref/out.test.toml
+++ b/acceptance/bundle/variables/complex-cross-ref/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/complex-cycle-self/out.test.toml
+++ b/acceptance/bundle/variables/complex-cycle-self/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/complex-cycle/out.test.toml
+++ b/acceptance/bundle/variables/complex-cycle/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/complex-simple/out.test.toml
+++ b/acceptance/bundle/variables/complex-simple/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/complex-transitive-deep/out.test.toml
+++ b/acceptance/bundle/variables/complex-transitive-deep/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/complex-transitive-deeper/out.test.toml
+++ b/acceptance/bundle/variables/complex-transitive-deeper/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/complex-transitive/out.test.toml
+++ b/acceptance/bundle/variables/complex-transitive/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/complex-with-var-reference/out.test.toml
+++ b/acceptance/bundle/variables/complex-with-var-reference/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/complex-within-complex/out.test.toml
+++ b/acceptance/bundle/variables/complex-within-complex/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/complex/out.test.toml
+++ b/acceptance/bundle/variables/complex/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/complex_multiple_files/out.test.toml
+++ b/acceptance/bundle/variables/complex_multiple_files/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/cycle/out.test.toml
+++ b/acceptance/bundle/variables/cycle/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/double_underscore/out.test.toml
+++ b/acceptance/bundle/variables/double_underscore/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/empty/out.test.toml
+++ b/acceptance/bundle/variables/empty/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/env_overrides/out.test.toml
+++ b/acceptance/bundle/variables/env_overrides/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/file-defaults/out.test.toml
+++ b/acceptance/bundle/variables/file-defaults/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/git-branch/out.test.toml
+++ b/acceptance/bundle/variables/git-branch/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/host/out.test.toml
+++ b/acceptance/bundle/variables/host/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/int/out.test.toml
+++ b/acceptance/bundle/variables/int/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/issue_2436/out.test.toml
+++ b/acceptance/bundle/variables/issue_2436/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/issue_3039_lookup_with_ref/out.test.toml
+++ b/acceptance/bundle/variables/issue_3039_lookup_with_ref/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/lookup/out.test.toml
+++ b/acceptance/bundle/variables/lookup/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/lookup/test.toml
+++ b/acceptance/bundle/variables/lookup/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 
 Ignore = [

--- a/acceptance/bundle/variables/prepend-workspace-var/out.test.toml
+++ b/acceptance/bundle/variables/prepend-workspace-var/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/resolve-builtin/out.test.toml
+++ b/acceptance/bundle/variables/resolve-builtin/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/resolve-empty/out.test.toml
+++ b/acceptance/bundle/variables/resolve-empty/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/resolve-field-within-complex/out.test.toml
+++ b/acceptance/bundle/variables/resolve-field-within-complex/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/resolve-nonstrings/out.test.toml
+++ b/acceptance/bundle/variables/resolve-nonstrings/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/resolve-resources-fields/out.test.toml
+++ b/acceptance/bundle/variables/resolve-resources-fields/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/resolve-vars-in-root-path/out.test.toml
+++ b/acceptance/bundle/variables/resolve-vars-in-root-path/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/unicode_reference/out.test.toml
+++ b/acceptance/bundle/variables/unicode_reference/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/vanilla/out.test.toml
+++ b/acceptance/bundle/variables/vanilla/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/var_in_var/out.test.toml
+++ b/acceptance/bundle/variables/var_in_var/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/variable_in_resource_key/out.test.toml
+++ b/acceptance/bundle/variables/variable_in_resource_key/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/variable_overrides_in_target/out.test.toml
+++ b/acceptance/bundle/variables/variable_overrides_in_target/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/without_definition/out.test.toml
+++ b/acceptance/bundle/variables/without_definition/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/volume_path/invalid_file/out.test.toml
+++ b/acceptance/bundle/volume_path/invalid_file/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/volume_path/invalid_resource/out.test.toml
+++ b/acceptance/bundle/volume_path/invalid_resource/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/volume_path/invalid_root/out.test.toml
+++ b/acceptance/bundle/volume_path/invalid_root/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/volume_path/invalid_state/out.test.toml
+++ b/acceptance/bundle/volume_path/invalid_state/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/volume_path/valid/out.test.toml
+++ b/acceptance/bundle/volume_path/valid/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cache/clear/out.test.toml
+++ b/acceptance/cache/clear/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cache/clear/test.toml
+++ b/acceptance/cache/clear/test.toml
@@ -1,6 +1,4 @@
 Cloud = false
-Local = true
-
 # Redact structured logging fields from debug output
 [[Repls]]
 Old = ' pid=[0-9]+'

--- a/acceptance/cache/simple/out.test.toml
+++ b/acceptance/cache/simple/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cache/simple/test.toml
+++ b/acceptance/cache/simple/test.toml
@@ -1,6 +1,4 @@
 Cloud = false
-Local = true
-
 RecordRequests = true
 
 # Redact structured logging fields from debug output

--- a/acceptance/cmd/account/account-help/out.test.toml
+++ b/acceptance/cmd/account/account-help/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/api/account-flag/out.test.toml
+++ b/acceptance/cmd/api/account-flag/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/api/account-path/out.test.toml
+++ b/acceptance/cmd/api/account-path/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/api/default-profile-vs-env/out.test.toml
+++ b/acceptance/cmd/api/default-profile-vs-env/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/api/default-profile/out.test.toml
+++ b/acceptance/cmd/api/default-profile/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/api/profile-overrides-env/out.test.toml
+++ b/acceptance/cmd/api/profile-overrides-env/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/api/workspace-id-flag/out.test.toml
+++ b/acceptance/cmd/api/workspace-id-flag/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/api/workspace-id-from-query/out.test.toml
+++ b/acceptance/cmd/api/workspace-id-from-query/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/api/workspace-id-from-w-query/out.test.toml
+++ b/acceptance/cmd/api/workspace-id-from-w-query/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/api/workspace-id-none/out.test.toml
+++ b/acceptance/cmd/api/workspace-id-none/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/api/workspace-path/out.test.toml
+++ b/acceptance/cmd/api/workspace-path/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/api/workspace-proxy-regression/out.test.toml
+++ b/acceptance/cmd/api/workspace-proxy-regression/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/describe/account-host-with-workspace-id/out.test.toml
+++ b/acceptance/cmd/auth/describe/account-host-with-workspace-id/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/describe/bundle-profile-env/out.test.toml
+++ b/acceptance/cmd/auth/describe/bundle-profile-env/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/describe/default-profile/out.test.toml
+++ b/acceptance/cmd/auth/describe/default-profile/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/describe/profile-overrides-env/out.test.toml
+++ b/acceptance/cmd/auth/describe/profile-overrides-env/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/describe/u2m-json-output/out.test.toml
+++ b/acceptance/cmd/auth/describe/u2m-json-output/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/describe/u2m-plaintext-config/out.test.toml
+++ b/acceptance/cmd/auth/describe/u2m-plaintext-config/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/describe/u2m-plaintext-env/out.test.toml
+++ b/acceptance/cmd/auth/describe/u2m-plaintext-env/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/describe/u2m-secure-default/out.test.toml
+++ b/acceptance/cmd/auth/describe/u2m-secure-default/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/login/configure-serverless/out.test.toml
+++ b/acceptance/cmd/auth/login/configure-serverless/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/login/custom-config-file/out.test.toml
+++ b/acceptance/cmd/auth/login/custom-config-file/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/login/discovery/out.test.toml
+++ b/acceptance/cmd/auth/login/discovery/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/login/host-arg-overrides-profile/out.test.toml
+++ b/acceptance/cmd/auth/login/host-arg-overrides-profile/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/login/host-from-profile/out.test.toml
+++ b/acceptance/cmd/auth/login/host-from-profile/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/login/nominal/out.test.toml
+++ b/acceptance/cmd/auth/login/nominal/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/login/preserve-fields/out.test.toml
+++ b/acceptance/cmd/auth/login/preserve-fields/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/login/with-scopes/out.test.toml
+++ b/acceptance/cmd/auth/login/with-scopes/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/logout/default-profile/out.test.toml
+++ b/acceptance/cmd/auth/logout/default-profile/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/logout/delete-clears-default/out.test.toml
+++ b/acceptance/cmd/auth/logout/delete-clears-default/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/logout/delete-pat-token-profile/out.test.toml
+++ b/acceptance/cmd/auth/logout/delete-pat-token-profile/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/logout/error-cases/out.test.toml
+++ b/acceptance/cmd/auth/logout/error-cases/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/logout/last-non-default/out.test.toml
+++ b/acceptance/cmd/auth/logout/last-non-default/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/logout/ordering-preserved/out.test.toml
+++ b/acceptance/cmd/auth/logout/ordering-preserved/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/logout/stale-account-id-workspace-host/out.test.toml
+++ b/acceptance/cmd/auth/logout/stale-account-id-workspace-host/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/logout/token-only-shared-host/out.test.toml
+++ b/acceptance/cmd/auth/logout/token-only-shared-host/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/logout/token-only/out.test.toml
+++ b/acceptance/cmd/auth/logout/token-only/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/profiles/out.test.toml
+++ b/acceptance/cmd/auth/profiles/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/profiles/spog-account/out.test.toml
+++ b/acceptance/cmd/auth/profiles/spog-account/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/storage-modes/env-overrides-config/out.test.toml
+++ b/acceptance/cmd/auth/storage-modes/env-overrides-config/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/storage-modes/invalid-config/out.test.toml
+++ b/acceptance/cmd/auth/storage-modes/invalid-config/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/storage-modes/invalid-env/out.test.toml
+++ b/acceptance/cmd/auth/storage-modes/invalid-env/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/storage-modes/plaintext-env-default/out.test.toml
+++ b/acceptance/cmd/auth/storage-modes/plaintext-env-default/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/switch/nominal/out.test.toml
+++ b/acceptance/cmd/auth/switch/nominal/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/token/default-profile/out.test.toml
+++ b/acceptance/cmd/auth/token/default-profile/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/token/force-refresh-invalid-refresh-token/out.test.toml
+++ b/acceptance/cmd/auth/token/force-refresh-invalid-refresh-token/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/token/force-refresh-no-cache/out.test.toml
+++ b/acceptance/cmd/auth/token/force-refresh-no-cache/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/token/force-refresh-success/out.test.toml
+++ b/acceptance/cmd/auth/token/force-refresh-success/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/token/no-args-no-profiles/out.test.toml
+++ b/acceptance/cmd/auth/token/no-args-no-profiles/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/token/no-args-with-profiles/out.test.toml
+++ b/acceptance/cmd/auth/token/no-args-with-profiles/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/token/out.test.toml
+++ b/acceptance/cmd/auth/token/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/bundle/dms-read-only/out.test.toml
+++ b/acceptance/cmd/bundle/dms-read-only/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/cmd/bundle/dms-read-only/test.toml
+++ b/acceptance/cmd/bundle/dms-read-only/test.toml
@@ -6,7 +6,6 @@
 # The deployment/version stubs include git_info: it is the field of interest
 # for this service and is silently dropped by older CLI releases whose SDK
 # model predates it, so we assert it round-trips through the generated command.
-Local = true
 Cloud = false
 
 # bundle-deployments is a workspace-service command independent of the bundle

--- a/acceptance/cmd/completion/out.test.toml
+++ b/acceptance/cmd/completion/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform"]

--- a/acceptance/cmd/completion/test.toml
+++ b/acceptance/cmd/completion/test.toml
@@ -2,7 +2,6 @@ Ignore = [
     "home",
 ]
 
-Local = true
 Cloud = false
 
 # Completion tests don't involve bundles, skip the engine matrix.

--- a/acceptance/cmd/configure/clears-oauth-on-pat/out.test.toml
+++ b/acceptance/cmd/configure/clears-oauth-on-pat/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/configure/clears-serverless-when-cluster-from-env/out.test.toml
+++ b/acceptance/cmd/configure/clears-serverless-when-cluster-from-env/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/fs/cp/dir-to-dir/out.test.toml
+++ b/acceptance/cmd/fs/cp/dir-to-dir/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/fs/cp/dir-to-dir/test.toml
+++ b/acceptance/cmd/fs/cp/dir-to-dir/test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true

--- a/acceptance/cmd/fs/cp/file-to-dir/out.test.toml
+++ b/acceptance/cmd/fs/cp/file-to-dir/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/fs/cp/file-to-dir/test.toml
+++ b/acceptance/cmd/fs/cp/file-to-dir/test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true

--- a/acceptance/cmd/fs/cp/file-to-file/out.test.toml
+++ b/acceptance/cmd/fs/cp/file-to-file/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/fs/cp/file-to-file/test.toml
+++ b/acceptance/cmd/fs/cp/file-to-file/test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true

--- a/acceptance/cmd/fs/cp/file-to-skill/out.test.toml
+++ b/acceptance/cmd/fs/cp/file-to-skill/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/fs/cp/file-to-skill/test.toml
+++ b/acceptance/cmd/fs/cp/file-to-skill/test.toml
@@ -1,3 +1,0 @@
-# Local only: the UC Skills Files API path is gated by a server-side feature flag
-# that has not rolled out, so a real workspace rejects these writes.
-Cloud = false

--- a/acceptance/cmd/fs/cp/file-to-skill/test.toml
+++ b/acceptance/cmd/fs/cp/file-to-skill/test.toml
@@ -1,4 +1,3 @@
 # Local only: the UC Skills Files API path is gated by a server-side feature flag
 # that has not rolled out, so a real workspace rejects these writes.
-Local = true
 Cloud = false

--- a/acceptance/cmd/fs/cp/input-validation/out.test.toml
+++ b/acceptance/cmd/fs/cp/input-validation/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/fs/cp/input-validation/test.toml
+++ b/acceptance/cmd/fs/cp/input-validation/test.toml
@@ -1,1 +1,0 @@
-Cloud = false

--- a/acceptance/cmd/fs/cp/input-validation/test.toml
+++ b/acceptance/cmd/fs/cp/input-validation/test.toml
@@ -1,2 +1,1 @@
-Local = true
 Cloud = false

--- a/acceptance/cmd/patchwhl/out.test.toml
+++ b/acceptance/cmd/patchwhl/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/psql/argument-errors/out.test.toml
+++ b/acceptance/cmd/psql/argument-errors/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/psql/completions/out.test.toml
+++ b/acceptance/cmd/psql/completions/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/psql/failing-connection/out.test.toml
+++ b/acceptance/cmd/psql/failing-connection/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/psql/not-available/out.test.toml
+++ b/acceptance/cmd/psql/not-available/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/psql/postgres/out.test.toml
+++ b/acceptance/cmd/psql/postgres/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/psql/simple/out.test.toml
+++ b/acceptance/cmd/psql/simple/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/sandbox/config/idle-timeout-bounds/out.test.toml
+++ b/acceptance/cmd/sandbox/config/idle-timeout-bounds/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/cmd/sandbox/config/no-flags/out.test.toml
+++ b/acceptance/cmd/sandbox/config/no-flags/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/cmd/sandbox/config/update-name/out.test.toml
+++ b/acceptance/cmd/sandbox/config/update-name/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/cmd/sandbox/create/with-name/out.test.toml
+++ b/acceptance/cmd/sandbox/create/with-name/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/cmd/sandbox/default/not-found/out.test.toml
+++ b/acceptance/cmd/sandbox/default/not-found/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/cmd/sandbox/default/set/out.test.toml
+++ b/acceptance/cmd/sandbox/default/set/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/cmd/sandbox/delete/no-tty-no-auto-approve/out.test.toml
+++ b/acceptance/cmd/sandbox/delete/no-tty-no-auto-approve/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/cmd/sandbox/delete/not-found/out.test.toml
+++ b/acceptance/cmd/sandbox/delete/not-found/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/cmd/sandbox/delete/success/out.test.toml
+++ b/acceptance/cmd/sandbox/delete/success/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/cmd/sandbox/list/empty/out.test.toml
+++ b/acceptance/cmd/sandbox/list/empty/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/cmd/sandbox/list/json/out.test.toml
+++ b/acceptance/cmd/sandbox/list/json/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/cmd/sandbox/list/region-unavailable/out.test.toml
+++ b/acceptance/cmd/sandbox/list/region-unavailable/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/cmd/sandbox/list/with-entries/out.test.toml
+++ b/acceptance/cmd/sandbox/list/with-entries/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/cmd/sandbox/register/success/out.test.toml
+++ b/acceptance/cmd/sandbox/register/success/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/cmd/sandbox/ssh-key/delete/success/out.test.toml
+++ b/acceptance/cmd/sandbox/ssh-key/delete/success/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/cmd/sandbox/ssh-key/list/empty/out.test.toml
+++ b/acceptance/cmd/sandbox/ssh-key/list/empty/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/cmd/sandbox/ssh-key/list/with-entries/out.test.toml
+++ b/acceptance/cmd/sandbox/ssh-key/list/with-entries/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/cmd/sandbox/start/already-running/out.test.toml
+++ b/acceptance/cmd/sandbox/start/already-running/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/cmd/sandbox/status/json/out.test.toml
+++ b/acceptance/cmd/sandbox/status/json/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/cmd/sandbox/status/not-found/out.test.toml
+++ b/acceptance/cmd/sandbox/status/not-found/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/cmd/sandbox/status/running/out.test.toml
+++ b/acceptance/cmd/sandbox/status/running/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/cmd/sandbox/stop/success/out.test.toml
+++ b/acceptance/cmd/sandbox/stop/success/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/cmd/sync-from-file/out.test.toml
+++ b/acceptance/cmd/sync-from-file/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/sync-without-args/out.test.toml
+++ b/acceptance/cmd/sync-without-args/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/sync/dryrun-missing-remote/out.test.toml
+++ b/acceptance/cmd/sync/dryrun-missing-remote/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/sync/dryrun/out.test.toml
+++ b/acceptance/cmd/sync/dryrun/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/sync/out.test.toml
+++ b/acceptance/cmd/sync/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/unknown-subcommand/out.test.toml
+++ b/acceptance/cmd/unknown-subcommand/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/unknown-subcommand/test.toml
+++ b/acceptance/cmd/unknown-subcommand/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 
 [[Server]]

--- a/acceptance/cmd/version/out.test.toml
+++ b/acceptance/cmd/version/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/cmd/workspace/apps/out.test.toml
+++ b/acceptance/cmd/workspace/apps/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/workspace/apps/run-local-node/out.test.toml
+++ b/acceptance/cmd/workspace/apps/run-local-node/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/cmd/workspace/apps/run-local-node/test.toml
+++ b/acceptance/cmd/workspace/apps/run-local-node/test.toml
@@ -1,5 +1,4 @@
 Cloud = false
-Local = true
 RecordRequests = false
 
 # npm install writes package-lock.json even with nothing to install, and older npm versions

--- a/acceptance/cmd/workspace/apps/run-local/out.test.toml
+++ b/acceptance/cmd/workspace/apps/run-local/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/cmd/workspace/apps/run-local/test.toml
+++ b/acceptance/cmd/workspace/apps/run-local/test.toml
@@ -1,5 +1,4 @@
 Cloud = false
-Local = true
 RecordRequests = false
 
 # The command is unrelated to bundle deployment, so run it once rather than per engine.

--- a/acceptance/cmd/workspace/create-scope/out.test.toml
+++ b/acceptance/cmd/workspace/create-scope/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/workspace/create-scope/test.toml
+++ b/acceptance/cmd/workspace/create-scope/test.toml
@@ -1,1 +1,0 @@
-Cloud = false

--- a/acceptance/cmd/workspace/create-scope/test.toml
+++ b/acceptance/cmd/workspace/create-scope/test.toml
@@ -1,2 +1,1 @@
-Local = true
 Cloud = false

--- a/acceptance/cmd/workspace/database/update-database-instance/out.test.toml
+++ b/acceptance/cmd/workspace/database/update-database-instance/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/workspace/database/update-database-instance/test.toml
+++ b/acceptance/cmd/workspace/database/update-database-instance/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 
 [[Server]]

--- a/acceptance/cmd/workspace/export-dir-file-size-limit/out.test.toml
+++ b/acceptance/cmd/workspace/export-dir-file-size-limit/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/workspace/export-dir-file-size-limit/test.toml
+++ b/acceptance/cmd/workspace/export-dir-file-size-limit/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 
 [Env]

--- a/acceptance/cmd/workspace/export-dir-illegal-filename/posix/out.test.toml
+++ b/acceptance/cmd/workspace/export-dir-illegal-filename/posix/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/workspace/export-dir-illegal-filename/test.toml
+++ b/acceptance/cmd/workspace/export-dir-illegal-filename/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 
 # This reproduces databricks/cli#5171. The behaviour is OS-specific (see _script),

--- a/acceptance/cmd/workspace/export-dir-illegal-filename/windows/out.test.toml
+++ b/acceptance/cmd/workspace/export-dir-illegal-filename/windows/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 GOOS.darwin = false
 GOOS.linux = false

--- a/acceptance/cmd/workspace/export-dir-skip-experiments/out.test.toml
+++ b/acceptance/cmd/workspace/export-dir-skip-experiments/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/workspace/export-dir-skip-experiments/test.toml
+++ b/acceptance/cmd/workspace/export-dir-skip-experiments/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 
 [Env]

--- a/acceptance/cmd/workspace/jobs/runs-submit/out.test.toml
+++ b/acceptance/cmd/workspace/jobs/runs-submit/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/cmd/workspace/jobs/runs-submit/test.toml
+++ b/acceptance/cmd/workspace/jobs/runs-submit/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 
 RecordRequests = true

--- a/acceptance/cmd/workspace/queries/out.test.toml
+++ b/acceptance/cmd/workspace/queries/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/workspace/query-history/out.test.toml
+++ b/acceptance/cmd/workspace/query-history/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/workspace/secrets/out.test.toml
+++ b/acceptance/cmd/workspace/secrets/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/experimental/air/cancel/out.test.toml
+++ b/acceptance/experimental/air/cancel/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/experimental/air/convert-to-dabs/out.test.toml
+++ b/acceptance/experimental/air/convert-to-dabs/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/experimental/air/get-ai-runtime/out.test.toml
+++ b/acceptance/experimental/air/get-ai-runtime/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/experimental/air/get/out.test.toml
+++ b/acceptance/experimental/air/get/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/experimental/air/help/out.test.toml
+++ b/acceptance/experimental/air/help/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/experimental/air/list/out.test.toml
+++ b/acceptance/experimental/air/list/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/experimental/air/logs-download/out.test.toml
+++ b/acceptance/experimental/air/logs-download/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/experimental/air/logs-mlflow-fallback/out.test.toml
+++ b/acceptance/experimental/air/logs-mlflow-fallback/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/experimental/air/logs/out.test.toml
+++ b/acceptance/experimental/air/logs/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/experimental/air/register-image-no-secret-permission/out.test.toml
+++ b/acceptance/experimental/air/register-image-no-secret-permission/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/experimental/air/register-image/out.test.toml
+++ b/acceptance/experimental/air/register-image/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/experimental/air/run-submit-deps/out.test.toml
+++ b/acceptance/experimental/air/run-submit-deps/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/experimental/air/run-submit/out.test.toml
+++ b/acceptance/experimental/air/run-submit/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/experimental/air/run/out.test.toml
+++ b/acceptance/experimental/air/run/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/experimental/aitools/skills/install-experimental-empty/out.test.toml
+++ b/acceptance/experimental/aitools/skills/install-experimental-empty/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/experimental/aitools/skills/install-specific/out.test.toml
+++ b/acceptance/experimental/aitools/skills/install-specific/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/experimental/aitools/skills/install/out.test.toml
+++ b/acceptance/experimental/aitools/skills/install/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/experimental/aitools/skills/path-dump/out.test.toml
+++ b/acceptance/experimental/aitools/skills/path-dump/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/experimental/aitools/skills/update-prune/out.test.toml
+++ b/acceptance/experimental/aitools/skills/update-prune/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/experimental/genie/ask-deprecated/out.test.toml
+++ b/acceptance/experimental/genie/ask-deprecated/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/experimental/open/out.test.toml
+++ b/acceptance/experimental/open/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/genie/ask-endpoint-gone/out.test.toml
+++ b/acceptance/genie/ask-endpoint-gone/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/genie/ask-protocol-drift/out.test.toml
+++ b/acceptance/genie/ask-protocol-drift/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/genie/ask-request-drift/out.test.toml
+++ b/acceptance/genie/ask-request-drift/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/genie/ask/out.test.toml
+++ b/acceptance/genie/ask/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/help/out.test.toml
+++ b/acceptance/help/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/internal/config.go
+++ b/acceptance/internal/config.go
@@ -42,9 +42,6 @@ type TestConfig struct {
 	// Only checked if CLOUD_ENV is not empty.
 	CloudEnvs map[string]bool
 
-	// If true, run this test when running locally with a testserver
-	Local *bool
-
 	// If true, run this test when running with cloud env configured
 	Cloud *bool
 

--- a/acceptance/internal/config_test.go
+++ b/acceptance/internal/config_test.go
@@ -263,7 +263,7 @@ func TestLoadConfigPhaseIsNotInherited(t *testing.T) {
 			name: "leaf config without phase resets inherited value",
 			files: map[string]string{
 				"test.toml":            "Phase = 3\n",
-				"suite/test/test.toml": "Local = true\n",
+				"suite/test/test.toml": "Cloud = false\n",
 			},
 			dir:        "suite/test",
 			wantPhase:  0,
@@ -273,7 +273,7 @@ func TestLoadConfigPhaseIsNotInherited(t *testing.T) {
 			name: "leaf phase wins",
 			files: map[string]string{
 				"test.toml":            "Phase = 3\n",
-				"suite/test/test.toml": "Local = true\nPhase = 1\n",
+				"suite/test/test.toml": "Cloud = false\nPhase = 1\n",
 			},
 			dir:        "suite/test",
 			wantPhase:  1,

--- a/acceptance/internal/materialized_config.go
+++ b/acceptance/internal/materialized_config.go
@@ -40,7 +40,6 @@ const MaterializedConfigFile = "out.test.toml"
 func GenerateMaterializedConfig(config *TestConfig) string {
 	var buf strings.Builder
 
-	writeBool(&buf, "Local", config.Local)
 	writeBool(&buf, "Cloud", config.Cloud)
 	writeBool(&buf, "CloudSlow", config.CloudSlow)
 	writeBool(&buf, "RequiresUnityCatalog", config.RequiresUnityCatalog)

--- a/acceptance/localenv/cluster-name-ambiguous-json/out.test.toml
+++ b/acceptance/localenv/cluster-name-ambiguous-json/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/localenv/cluster-name-ambiguous/out.test.toml
+++ b/acceptance/localenv/cluster-name-ambiguous/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/localenv/cluster-name-check/out.test.toml
+++ b/acceptance/localenv/cluster-name-check/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/localenv/cluster-name-unknown/out.test.toml
+++ b/acceptance/localenv/cluster-name-unknown/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/localenv/constraints-only/out.test.toml
+++ b/acceptance/localenv/constraints-only/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/localenv/env-unsupported/out.test.toml
+++ b/acceptance/localenv/env-unsupported/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/localenv/flag-conflict-json/out.test.toml
+++ b/acceptance/localenv/flag-conflict-json/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/localenv/flag-conflict/out.test.toml
+++ b/acceptance/localenv/flag-conflict/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/localenv/help/out.test.toml
+++ b/acceptance/localenv/help/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/localenv/job-classic-check/out.test.toml
+++ b/acceptance/localenv/job-classic-check/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/localenv/job-serverless-check/out.test.toml
+++ b/acceptance/localenv/job-serverless-check/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/localenv/job-task-foreach/out.test.toml
+++ b/acceptance/localenv/job-task-foreach/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/localenv/job-task-jobcluster/out.test.toml
+++ b/acceptance/localenv/job-task-jobcluster/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/localenv/job-task-missing-key/out.test.toml
+++ b/acceptance/localenv/job-task-missing-key/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/localenv/job-task-unknown/out.test.toml
+++ b/acceptance/localenv/job-task-unknown/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/localenv/job-task-unpinned/out.test.toml
+++ b/acceptance/localenv/job-task-unpinned/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/localenv/json-error/out.test.toml
+++ b/acceptance/localenv/json-error/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/localenv/manager-unsupported/out.test.toml
+++ b/acceptance/localenv/manager-unsupported/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/localenv/no-target/out.test.toml
+++ b/acceptance/localenv/no-target/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/localenv/serverless-check/out.test.toml
+++ b/acceptance/localenv/serverless-check/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/localenv/serverless-json/out.test.toml
+++ b/acceptance/localenv/serverless-json/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/panic/out.test.toml
+++ b/acceptance/panic/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/pipelines/databricks-cli-help/out.test.toml
+++ b/acceptance/pipelines/databricks-cli-help/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/pipelines/deploy/auto-approve/out.test.toml
+++ b/acceptance/pipelines/deploy/auto-approve/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/pipelines/deploy/create-pipeline/out.test.toml
+++ b/acceptance/pipelines/deploy/create-pipeline/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/pipelines/deploy/fail-on-active-runs/out.test.toml
+++ b/acceptance/pipelines/deploy/fail-on-active-runs/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/pipelines/deploy/force-lock/out.test.toml
+++ b/acceptance/pipelines/deploy/force-lock/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/pipelines/deploy/oss-spark-error/out.test.toml
+++ b/acceptance/pipelines/deploy/oss-spark-error/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/pipelines/deploy/render-diagnostics-warning/out.test.toml
+++ b/acceptance/pipelines/deploy/render-diagnostics-warning/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/pipelines/deploy/var-flag/out.test.toml
+++ b/acceptance/pipelines/deploy/var-flag/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/pipelines/destroy/auto-approve/out.test.toml
+++ b/acceptance/pipelines/destroy/auto-approve/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/pipelines/destroy/destroy-pipeline/out.test.toml
+++ b/acceptance/pipelines/destroy/destroy-pipeline/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/pipelines/destroy/force-lock/out.test.toml
+++ b/acceptance/pipelines/destroy/force-lock/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/pipelines/dry-run/dry-run-pipeline/out.test.toml
+++ b/acceptance/pipelines/dry-run/dry-run-pipeline/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/pipelines/dry-run/no-wait/out.test.toml
+++ b/acceptance/pipelines/dry-run/no-wait/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/pipelines/dry-run/restart/out.test.toml
+++ b/acceptance/pipelines/dry-run/restart/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/pipelines/e2e/out.test.toml
+++ b/acceptance/pipelines/e2e/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/pipelines/generate/bad-path/out.test.toml
+++ b/acceptance/pipelines/generate/bad-path/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/pipelines/generate/discover-spark-pipeline-yml/out.test.toml
+++ b/acceptance/pipelines/generate/discover-spark-pipeline-yml/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/pipelines/generate/fail-overwrite/out.test.toml
+++ b/acceptance/pipelines/generate/fail-overwrite/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/pipelines/generate/simple/out.test.toml
+++ b/acceptance/pipelines/generate/simple/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/pipelines/generate/unknown-attribute/out.test.toml
+++ b/acceptance/pipelines/generate/unknown-attribute/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/pipelines/init/error-cases/out.test.toml
+++ b/acceptance/pipelines/init/error-cases/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/pipelines/init/python/out.test.toml
+++ b/acceptance/pipelines/init/python/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/pipelines/init/sql/out.test.toml
+++ b/acceptance/pipelines/init/sql/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/pipelines/open/completion/out.test.toml
+++ b/acceptance/pipelines/open/completion/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/pipelines/open/open-after-deployment/out.test.toml
+++ b/acceptance/pipelines/open/open-after-deployment/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 GOOS.linux = false
 GOOS.windows = false

--- a/acceptance/pipelines/run/completion/out.test.toml
+++ b/acceptance/pipelines/run/completion/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/pipelines/run/no-wait/out.test.toml
+++ b/acceptance/pipelines/run/no-wait/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/pipelines/run/refresh-flags/out.test.toml
+++ b/acceptance/pipelines/run/refresh-flags/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/pipelines/run/restart/out.test.toml
+++ b/acceptance/pipelines/run/restart/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/pipelines/run/run-info/out.test.toml
+++ b/acceptance/pipelines/run/run-info/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/pipelines/run/run-info/test.toml
+++ b/acceptance/pipelines/run/run-info/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 
 [[Server]]

--- a/acceptance/pipelines/run/run-pipeline/out.test.toml
+++ b/acceptance/pipelines/run/run-pipeline/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/pipelines/show/basic/out.test.toml
+++ b/acceptance/pipelines/show/basic/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/pipelines/show/help/out.test.toml
+++ b/acceptance/pipelines/show/help/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/pipelines/show/rendering/out.test.toml
+++ b/acceptance/pipelines/show/rendering/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/pipelines/stop/out.test.toml
+++ b/acceptance/pipelines/stop/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/pipelines/test.toml
+++ b/acceptance/pipelines/test.toml
@@ -1,3 +1,2 @@
 # All pipelines tests are local only
-Local = true
 Cloud = false

--- a/acceptance/pipelines/test.toml
+++ b/acceptance/pipelines/test.toml
@@ -1,2 +1,0 @@
-# All pipelines tests are local only
-Cloud = false

--- a/acceptance/quickstart/out.test.toml
+++ b/acceptance/quickstart/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/selftest/IsServicePrincipal/out.test.toml
+++ b/acceptance/selftest/IsServicePrincipal/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/selftest/acc_repls/out.test.toml
+++ b/acceptance/selftest/acc_repls/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/selftest/add_repl/out.test.toml
+++ b/acceptance/selftest/add_repl/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/selftest/basic/out.test.toml
+++ b/acceptance/selftest/basic/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/selftest/benchmark/out.test.toml
+++ b/acceptance/selftest/benchmark/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/selftest/contains/out.test.toml
+++ b/acceptance/selftest/contains/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/selftest/diff/out.test.toml
+++ b/acceptance/selftest/diff/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/selftest/envmatrix/inner/out.test.toml
+++ b/acceptance/selftest/envmatrix/inner/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 EnvMatrix.B_REGULAR_VAR = ["hello"]
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/selftest/envmatrix/out.test.toml
+++ b/acceptance/selftest/envmatrix/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
 EnvMatrix.FIRST = ["overriden-in-inner"]

--- a/acceptance/selftest/envmatrix_empty/out.test.toml
+++ b/acceptance/selftest/envmatrix_empty/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = []

--- a/acceptance/selftest/envmatrix_empty/test.toml
+++ b/acceptance/selftest/envmatrix_empty/test.toml
@@ -1,4 +1,2 @@
-Local = true
-
 [EnvMatrix]
 DATABRICKS_BUNDLE_ENGINE = []

--- a/acceptance/selftest/envmatrix_mixed/out.test.toml
+++ b/acceptance/selftest/envmatrix_mixed/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = []
 EnvMatrix.FIRST = ["alpha", "beta"]

--- a/acceptance/selftest/envmatrix_mixed/test.toml
+++ b/acceptance/selftest/envmatrix_mixed/test.toml
@@ -1,5 +1,3 @@
-Local = true
-
 [EnvMatrix]
 DATABRICKS_BUNDLE_ENGINE = []
 FIRST = ["alpha", "beta"]

--- a/acceptance/selftest/envoutput/out.test.toml
+++ b/acceptance/selftest/envoutput/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/selftest/gen_config/out.test.toml
+++ b/acceptance/selftest/gen_config/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/selftest/inject_error/out.test.toml
+++ b/acceptance/selftest/inject_error/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/selftest/kill_caller/currentuser/out.test.toml
+++ b/acceptance/selftest/kill_caller/currentuser/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/selftest/kill_caller/multi_pattern/out.test.toml
+++ b/acceptance/selftest/kill_caller/multi_pattern/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/selftest/kill_caller/multiple/out.test.toml
+++ b/acceptance/selftest/kill_caller/multiple/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/selftest/kill_caller/offset/out.test.toml
+++ b/acceptance/selftest/kill_caller/offset/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/selftest/kill_caller/test.toml
+++ b/acceptance/selftest/kill_caller/test.toml
@@ -2,7 +2,6 @@
 # This enables testing crash recovery scenarios, e.g., "bundle deploy" fails on first attempt
 # but succeeds on retry. Each subdirectory tests a different endpoint or retry count.
 
-Local = true
 Env.DATABRICKS_CLI_TEST_PID = "1"
 
 [[Repls]]

--- a/acceptance/selftest/kill_caller/workspace/out.test.toml
+++ b/acceptance/selftest/kill_caller/workspace/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/selftest/log/out.test.toml
+++ b/acceptance/selftest/log/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/selftest/record_cloud/basic/out.test.toml
+++ b/acceptance/selftest/record_cloud/basic/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/selftest/record_cloud/error/out.test.toml
+++ b/acceptance/selftest/record_cloud/error/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/selftest/record_cloud/pipeline-crud/out.test.toml
+++ b/acceptance/selftest/record_cloud/pipeline-crud/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/selftest/record_cloud/test.toml
+++ b/acceptance/selftest/record_cloud/test.toml
@@ -1,5 +1,4 @@
 Cloud = true
-Local = true
 RecordRequests = true
 
 # Local runs go through the proxy too, so one set of goldens covers it against both

--- a/acceptance/selftest/record_cloud/volume-io/out.test.toml
+++ b/acceptance/selftest/record_cloud/volume-io/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = true
 RequiresUnityCatalog = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/selftest/record_cloud/workspace-file-io/out.test.toml
+++ b/acceptance/selftest/record_cloud/workspace-file-io/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/selftest/server/out.test.toml
+++ b/acceptance/selftest/server/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
 EnvMatrix.VARIABLE_A = ["one", "two"]

--- a/acceptance/selftest/skip/out.test.toml
+++ b/acceptance/selftest/skip/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/selftest/subset_ancestor_engine/child/out.test.toml
+++ b/acceptance/selftest/subset_ancestor_engine/child/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/selftest/testlog/out.test.toml
+++ b/acceptance/selftest/testlog/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/selftest/timeout/out.test.toml
+++ b/acceptance/selftest/timeout/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/selftest/timestamp/out.test.toml
+++ b/acceptance/selftest/timestamp/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/selftest/trap/out.test.toml
+++ b/acceptance/selftest/trap/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/skiplocal_test.go
+++ b/acceptance/skiplocal_test.go
@@ -9,15 +9,17 @@ import (
 	"testing"
 )
 
-// DATABRICKS_TEST_SKIPLOCAL controls skipping of Local acceptance tests.
+// DATABRICKS_TEST_SKIPLOCAL skips acceptance tests on cloud runs that already have
+// testserver coverage. Every acceptance test runs locally, so this skips them all
+// unless withchanged re-enables tests touched on the branch.
 const (
 	SkipLocalEnvVar = "DATABRICKS_TEST_SKIPLOCAL"
 
-	// SkipLocalAll skips every test with Local = true.
+	// SkipLocalAll skips every acceptance test.
 	SkipLocalAll = "true"
-	// SkipLocalWithChanged skips Local tests except those added or changed on this
-	// branch (relative to the merge base with origin/main), so a cloud run still
-	// exercises the tests this branch touches.
+	// SkipLocalWithChanged skips acceptance tests except those added or changed on
+	// this branch (relative to the merge base with origin/main), so a cloud run
+	// still exercises the tests this branch touches.
 	SkipLocalWithChanged = "withchanged"
 
 	// maxChangedLocalTests caps how many changed tests SkipLocalWithChanged re-enables,

--- a/acceptance/skiplocal_test.go
+++ b/acceptance/skiplocal_test.go
@@ -9,17 +9,15 @@ import (
 	"testing"
 )
 
-// DATABRICKS_TEST_SKIPLOCAL skips acceptance tests on cloud runs that already have
-// testserver coverage. Every acceptance test runs locally, so this skips them all
-// unless withchanged re-enables tests touched on the branch.
+// DATABRICKS_TEST_SKIPLOCAL skips acceptance tests on cloud runs. All tests already
+// run locally against the testserver; withchanged re-enables tests this branch touches.
 const (
 	SkipLocalEnvVar = "DATABRICKS_TEST_SKIPLOCAL"
 
 	// SkipLocalAll skips every acceptance test.
 	SkipLocalAll = "true"
-	// SkipLocalWithChanged skips acceptance tests except those added or changed on
-	// this branch (relative to the merge base with origin/main), so a cloud run
-	// still exercises the tests this branch touches.
+	// SkipLocalWithChanged skips acceptance tests except those added or changed
+	// relative to origin/main.
 	SkipLocalWithChanged = "withchanged"
 
 	// maxChangedLocalTests caps how many changed tests SkipLocalWithChanged re-enables,

--- a/acceptance/ssh/connect-serverless-cpu/out.test.toml
+++ b/acceptance/ssh/connect-serverless-cpu/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 RequiresUnityCatalog = true
 GOOS.darwin = false

--- a/acceptance/ssh/connect-serverless-cpu/test.toml
+++ b/acceptance/ssh/connect-serverless-cpu/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 
 # Serverless requires Unity Catalog.

--- a/acceptance/ssh/connect-serverless-gpu/out.test.toml
+++ b/acceptance/ssh/connect-serverless-gpu/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 RequiresUnityCatalog = true
 GOOS.darwin = false

--- a/acceptance/ssh/connect-serverless-gpu/test.toml
+++ b/acceptance/ssh/connect-serverless-gpu/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 
 # Serverless GPU is only available in newer environments

--- a/acceptance/ssh/connection/out.test.toml
+++ b/acceptance/ssh/connection/out.test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 RequiresCluster = true
 GOOS.darwin = false

--- a/acceptance/ssh/connection/test.toml
+++ b/acceptance/ssh/connection/test.toml
@@ -1,4 +1,3 @@
-Local = true
 Cloud = false
 
 # On cloud this needs a real dedicated single-user cluster; locally the default

--- a/acceptance/telemetry/failure/out.test.toml
+++ b/acceptance/telemetry/failure/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/telemetry/partial-success/out.test.toml
+++ b/acceptance/telemetry/partial-success/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/telemetry/skipped/out.test.toml
+++ b/acceptance/telemetry/skipped/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/telemetry/success/out.test.toml
+++ b/acceptance/telemetry/success/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/telemetry/test.toml
+++ b/acceptance/telemetry/test.toml
@@ -1,7 +1,6 @@
 IncludeRequestHeaders = ["Authorization", "X-Databricks-Workspace-Id"]
 RecordRequests = true
 
-Local = true
 Cloud = false
 
 [[Repls]]

--- a/acceptance/telemetry/timeout/out.test.toml
+++ b/acceptance/telemetry/timeout/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/test.toml
+++ b/acceptance/test.toml
@@ -1,5 +1,5 @@
 # Default settings that apply to all tests unless overriden by test.toml files in inner directories.
-# Every test runs locally against the testserver; Cloud opts into real-workspace runs.
+# Tests always run locally; set Cloud/CloudSlow to also run on a real workspace.
 Cloud = false
 
 # default timeouts

--- a/acceptance/test.toml
+++ b/acceptance/test.toml
@@ -1,5 +1,5 @@
 # Default settings that apply to all tests unless overriden by test.toml files in inner directories.
-Local = true
+# Every test runs locally against the testserver; Cloud opts into real-workspace runs.
 Cloud = false
 
 # default timeouts

--- a/acceptance/workspace/jobs/create-error/out.test.toml
+++ b/acceptance/workspace/jobs/create-error/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/workspace/jobs/create/out.test.toml
+++ b/acceptance/workspace/jobs/create/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/workspace/lakeview/publish/out.test.toml
+++ b/acceptance/workspace/lakeview/publish/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/workspace/repos/create_with_provider/out.test.toml
+++ b/acceptance/workspace/repos/create_with_provider/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/workspace/repos/create_without_provider/out.test.toml
+++ b/acceptance/workspace/repos/create_without_provider/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/workspace/repos/delete_by_path/out.test.toml
+++ b/acceptance/workspace/repos/delete_by_path/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/workspace/repos/get_errors/out.test.toml
+++ b/acceptance/workspace/repos/get_errors/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/workspace/repos/git_cli_folder/out.test.toml
+++ b/acceptance/workspace/repos/git_cli_folder/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/workspace/repos/update/out.test.toml
+++ b/acceptance/workspace/repos/update/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]


### PR DESCRIPTION
## Changes

Drop the `Local` `test.toml` knob. Every acceptance test already runs against the testserver, so local runs include all tests by default; `Cloud` / `CloudSlow` still opt into real-workspace runs. `DATABRICKS_TEST_SKIPLOCAL` keeps skipping acceptance tests on cloud PR/integration runs (with `withchanged` re-enabling touched tests).

Most of the diff is mechanical `Local = true` removals from `test.toml` / `out.test.toml`.

After this merges, any `test.toml` that still sets `Local` will fail config loading with an undecoded-key error. Drop the `Local` line (tests always run locally now).

## Why

There are now no remaining `Local = false` tests. Keeping an opt-out that nobody uses invites new cloud-only gaps and forces every `test.toml` / `out.test.toml` to repeat `Local = true`.