### PR TITLE
Add cloud acceptance test for the DMS read path

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -107,6 +107,10 @@ const (
 	// tests marked RequiresClassic are skipped there.
 	EnvNoClassic = "DATABRICKS_TEST_NO_CLASSIC"
 
+	// Set to "true" by test environments where DMS (the bundle-deployments
+	// service) is deployed, so tests marked RequiresDms run only there.
+	EnvDms = "DATABRICKS_TEST_DMS"
+
 	// File where scripts can output custom replacements
 	// export $job_id=100200300
 	// $ echo "$job_id:MY_JOB" >> ACC_REPLS  # This will replace 100200300 with [MY_JOB] in the output
@@ -727,6 +731,10 @@ func getSkipReason(config *internal.TestConfig, configPath, dir, skipLocalMode s
 
 		if isTruePtr(config.RequiresClassic) && os.Getenv(EnvNoClassic) == "true" {
 			return fmt.Sprintf("Disabled via RequiresClassic setting in %s (%s=true)", configPath, EnvNoClassic)
+		}
+
+		if isTruePtr(config.RequiresDms) && os.Getenv(EnvDms) != "true" {
+			return fmt.Sprintf("Disabled via RequiresDms setting in %s (%s is not true)", configPath, EnvDms)
 		}
 
 	} else {

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -103,6 +103,10 @@ const (
 	// The tests the don't set SERVERLESS variable or set to empty string will also be run.
 	EnvFilterVar = "ENVFILTER"
 
+	// Set to "true" by test environments that cannot create classic compute, so
+	// tests marked RequiresClassic are skipped there.
+	EnvNoClassic = "DATABRICKS_TEST_NO_CLASSIC"
+
 	// File where scripts can output custom replacements
 	// export $job_id=100200300
 	// $ echo "$job_id:MY_JOB" >> ACC_REPLS  # This will replace 100200300 with [MY_JOB] in the output
@@ -719,6 +723,10 @@ func getSkipReason(config *internal.TestConfig, configPath, dir, skipLocalMode s
 
 		if isTruePtr(config.RequiresCluster) && os.Getenv("TEST_DEFAULT_CLUSTER_ID") == "" {
 			return fmt.Sprintf("Disabled via RequiresCluster setting in %s (TEST_DEFAULT_CLUSTER_ID is empty)", configPath)
+		}
+
+		if isTruePtr(config.RequiresClassic) && os.Getenv(EnvNoClassic) == "true" {
+			return fmt.Sprintf("Disabled via RequiresClassic setting in %s (%s=true)", configPath, EnvNoClassic)
 		}
 
 	} else {

--- a/acceptance/bundle/apps/job_permissions/out.test.toml
+++ b/acceptance/bundle/apps/job_permissions/out.test.toml
@@ -1,4 +1,5 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+RequiresClassic = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/apps/job_permissions/test.toml
+++ b/acceptance/bundle/apps/job_permissions/test.toml
@@ -1,6 +1,7 @@
 Cloud = true
 RequiresUnityCatalog = true
 RecordRequests = false
+# Deploys a job with a spark_python_task, which runs on a cluster.
 RequiresClassic = true
 
 [EnvMatrix]

--- a/acceptance/bundle/apps/job_permissions/test.toml
+++ b/acceptance/bundle/apps/job_permissions/test.toml
@@ -1,6 +1,7 @@
 Cloud = true
 RequiresUnityCatalog = true
 RecordRequests = false
+RequiresClassic = true
 
 [EnvMatrix]
 DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/config-remote-sync/cli_defaults/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/cli_defaults/out.test.toml
@@ -1,4 +1,5 @@
 Local = true
 Cloud = true
+RequiresClassic = true
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/config_edits/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/config_edits/out.test.toml
@@ -1,4 +1,5 @@
 Local = true
 Cloud = true
+RequiresClassic = true
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/dashboard_etag/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/dashboard_etag/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = true
+RequiresClassic = false
 RequiresWarehouse = true
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/dashboard_etag/test.toml
+++ b/acceptance/bundle/config-remote-sync/dashboard_etag/test.toml
@@ -1,6 +1,10 @@
 Cloud = true
 RequiresWarehouse = true
 
+# Unlike its siblings this test syncs a dashboard, not a job cluster, so it runs
+# in serverless-only environments.
+RequiresClassic = false
+
 RecordRequests = false
 
 Ignore = [".databricks", "databricks.yml", "databricks.yml.backup"]

--- a/acceptance/bundle/config-remote-sync/flushed_cache/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/flushed_cache/out.test.toml
@@ -1,4 +1,5 @@
 Local = true
 Cloud = true
+RequiresClassic = true
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/formatting_preserved/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/formatting_preserved/out.test.toml
@@ -1,4 +1,5 @@
 Local = true
 Cloud = true
+RequiresClassic = true
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/job_fields/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/job_fields/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+RequiresClassic = true
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/job_multiple_tasks/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/job_multiple_tasks/out.test.toml
@@ -1,4 +1,5 @@
 Local = true
 Cloud = true
+RequiresClassic = true
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/job_params_variables/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/job_params_variables/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+RequiresClassic = true
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/job_pipeline_task/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/job_pipeline_task/out.test.toml
@@ -1,4 +1,5 @@
 Local = true
 Cloud = true
+RequiresClassic = true
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/multiple_files/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/multiple_files/out.test.toml
@@ -1,4 +1,5 @@
 Local = true
 Cloud = true
+RequiresClassic = true
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/multiple_resources/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/multiple_resources/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+RequiresClassic = true
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/output_json/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/output_json/out.test.toml
@@ -1,4 +1,5 @@
 Local = true
 Cloud = true
+RequiresClassic = true
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/output_no_changes/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/output_no_changes/out.test.toml
@@ -1,4 +1,5 @@
 Local = true
 Cloud = true
+RequiresClassic = true
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/pipeline_fields/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/pipeline_fields/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+RequiresClassic = true
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/policy_injected_cluster_fields/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/policy_injected_cluster_fields/out.test.toml
@@ -1,4 +1,5 @@
 Local = true
 Cloud = true
+RequiresClassic = true
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/resolve_variables/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/resolve_variables/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+RequiresClassic = true
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/select_basic/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/select_basic/out.test.toml
@@ -1,4 +1,5 @@
 Local = true
 Cloud = true
+RequiresClassic = true
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/select_multiple/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/select_multiple/out.test.toml
@@ -1,4 +1,5 @@
 Local = true
 Cloud = true
+RequiresClassic = true
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/skip_permissions/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/skip_permissions/out.test.toml
@@ -1,4 +1,5 @@
 Local = true
 Cloud = true
+RequiresClassic = true
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/split/cli_default_split_element/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/split/cli_default_split_element/out.test.toml
@@ -1,4 +1,5 @@
 Local = true
 Cloud = false
+RequiresClassic = true
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/split/dotted_target/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/split/dotted_target/out.test.toml
@@ -1,4 +1,5 @@
 Local = true
 Cloud = false
+RequiresClassic = true
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/split/isolation/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/split/isolation/out.test.toml
@@ -1,4 +1,5 @@
 Local = true
 Cloud = false
+RequiresClassic = true
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/split/keyed_edit/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/split/keyed_edit/out.test.toml
@@ -1,4 +1,5 @@
 Local = true
 Cloud = false
+RequiresClassic = true
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/split/keyed_remove/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/split/keyed_remove/out.test.toml
@@ -1,4 +1,5 @@
 Local = true
 Cloud = false
+RequiresClassic = true
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/split/keyed_rename/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/split/keyed_rename/out.test.toml
@@ -1,4 +1,5 @@
 Local = true
 Cloud = false
+RequiresClassic = true
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/split/keyed_twoblock/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/split/keyed_twoblock/out.test.toml
@@ -1,4 +1,5 @@
 Local = true
 Cloud = false
+RequiresClassic = true
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/split/multifile/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/split/multifile/out.test.toml
@@ -1,4 +1,5 @@
 Local = true
 Cloud = false
+RequiresClassic = true
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/split/nested_add_split_parent/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/split/nested_add_split_parent/out.test.toml
@@ -1,4 +1,5 @@
 Local = true
 Cloud = false
+RequiresClassic = true
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/split/nested_sequence/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/split/nested_sequence/out.test.toml
@@ -1,4 +1,5 @@
 Local = true
 Cloud = false
+RequiresClassic = true
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/split/positional/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/split/positional/out.test.toml
@@ -1,4 +1,5 @@
 Local = true
 Cloud = false
+RequiresClassic = true
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/split/remove_field_both_blocks/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/split/remove_field_both_blocks/out.test.toml
@@ -1,4 +1,5 @@
 Local = true
 Cloud = false
+RequiresClassic = true
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/split/remove_with_unrelated_add/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/split/remove_with_unrelated_add/out.test.toml
@@ -1,4 +1,5 @@
 Local = true
 Cloud = false
+RequiresClassic = true
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/split/rename_ambiguous_pairing/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/split/rename_ambiguous_pairing/out.test.toml
@@ -1,4 +1,5 @@
 Local = true
 Cloud = false
+RequiresClassic = true
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/split/rename_ambiguous_single_block/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/split/rename_ambiguous_single_block/out.test.toml
@@ -1,4 +1,5 @@
 Local = true
 Cloud = false
+RequiresClassic = true
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/split/rename_two_removes_one_add/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/split/rename_two_removes_one_add/out.test.toml
@@ -1,4 +1,5 @@
 Local = true
 Cloud = false
+RequiresClassic = true
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/split/target_variable/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/split/target_variable/out.test.toml
@@ -1,4 +1,5 @@
 Local = true
 Cloud = false
+RequiresClassic = true
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/split/variable_file_order/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/split/variable_file_order/out.test.toml
@@ -1,4 +1,5 @@
 Local = true
 Cloud = false
+RequiresClassic = true
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/target_override/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/target_override/out.test.toml
@@ -1,4 +1,5 @@
 Local = true
 Cloud = true
+RequiresClassic = true
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/task_rename_revert/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/task_rename_revert/out.test.toml
@@ -1,4 +1,5 @@
 Local = true
 Cloud = true
+RequiresClassic = true
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/test.toml
+++ b/acceptance/bundle/config-remote-sync/test.toml
@@ -1,3 +1,8 @@
+# These tests sync job config that defines a job cluster, so they need an
+# environment where classic compute can be created. dashboard_etag overrides
+# this back to false: it syncs a dashboard bound to a SQL warehouse.
+RequiresClassic = true
+
 # Disable Windows tests for config-remote-sync tests
 [GOOS]
 windows = false

--- a/acceptance/bundle/config-remote-sync/validation_errors/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/validation_errors/out.test.toml
@@ -1,4 +1,5 @@
 Local = true
 Cloud = false
+RequiresClassic = true
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/deploy/files/no-snapshot-sync/out.test.toml
+++ b/acceptance/bundle/deploy/files/no-snapshot-sync/out.test.toml
@@ -1,3 +1,4 @@
 Local = true
 Cloud = true
+RequiresClassic = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deploy/files/no-snapshot-sync/test.toml
+++ b/acceptance/bundle/deploy/files/no-snapshot-sync/test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = true
+RequiresClassic = true
 
 Ignore = [
     "databricks.yml",

--- a/acceptance/bundle/deploy/files/no-snapshot-sync/test.toml
+++ b/acceptance/bundle/deploy/files/no-snapshot-sync/test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = true
+# Deploys a job with a job cluster (new_cluster)
 RequiresClassic = true
 
 Ignore = [

--- a/acceptance/bundle/deploy/mlops-stacks/out.test.toml
+++ b/acceptance/bundle/deploy/mlops-stacks/out.test.toml
@@ -1,4 +1,5 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+RequiresClassic = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deploy/mlops-stacks/test.toml
+++ b/acceptance/bundle/deploy/mlops-stacks/test.toml
@@ -1,5 +1,6 @@
 Cloud=true
 Local=true
+RequiresClassic = true
 
 # The MLOps Stacks template registers the model in Unity Catalog and runs its
 # jobs on serverless compute, so this test only works on a UC-enabled workspace

--- a/acceptance/bundle/deploy/snapshot-comparison/out.test.toml
+++ b/acceptance/bundle/deploy/snapshot-comparison/out.test.toml
@@ -1,3 +1,4 @@
 Local = true
 Cloud = true
+RequiresClassic = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform"]

--- a/acceptance/bundle/deploy/snapshot-comparison/test.toml
+++ b/acceptance/bundle/deploy/snapshot-comparison/test.toml
@@ -1,4 +1,5 @@
 Cloud = true
+# Deploys a pipeline and job; pipelines run on classic compute
 RequiresClassic = true
 
 RecordRequests = true

--- a/acceptance/bundle/deploy/snapshot-comparison/test.toml
+++ b/acceptance/bundle/deploy/snapshot-comparison/test.toml
@@ -1,4 +1,5 @@
 Cloud = true
+RequiresClassic = true
 
 RecordRequests = true
 

--- a/acceptance/bundle/deploy/spark-jar-task/out.test.toml
+++ b/acceptance/bundle/deploy/spark-jar-task/out.test.toml
@@ -1,3 +1,4 @@
 Local = true
 Cloud = true
+RequiresClassic = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deploy/spark-jar-task/test.toml
+++ b/acceptance/bundle/deploy/spark-jar-task/test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = true
+# Deploys a job with a job cluster and spark_jar_task
 RequiresClassic = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
 

--- a/acceptance/bundle/deploy/spark-jar-task/test.toml
+++ b/acceptance/bundle/deploy/spark-jar-task/test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = true
+RequiresClassic = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
 
 Ignore = [

--- a/acceptance/bundle/deployment/bind/cluster/out.test.toml
+++ b/acceptance/bundle/deployment/bind/cluster/out.test.toml
@@ -1,4 +1,5 @@
 Local = true
 Cloud = true
 RequiresCluster = true
+RequiresClassic = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/cluster/test.toml
+++ b/acceptance/bundle/deployment/bind/cluster/test.toml
@@ -1,3 +1,4 @@
 Local = true
 Cloud = true
 RequiresCluster = true
+RequiresClassic = true

--- a/acceptance/bundle/deployment/bind/cluster/test.toml
+++ b/acceptance/bundle/deployment/bind/cluster/test.toml
@@ -1,4 +1,5 @@
 Local = true
 Cloud = true
 RequiresCluster = true
+# Tests bind an all-purpose cluster to a bundle
 RequiresClassic = true

--- a/acceptance/bundle/deployment/bind/job/already-managed-different/out.test.toml
+++ b/acceptance/bundle/deployment/bind/job/already-managed-different/out.test.toml
@@ -1,3 +1,4 @@
 Local = true
 Cloud = false
+RequiresClassic = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/job/already-managed-same/out.test.toml
+++ b/acceptance/bundle/deployment/bind/job/already-managed-same/out.test.toml
@@ -1,3 +1,4 @@
 Local = true
 Cloud = false
+RequiresClassic = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/job/engine-from-config/out.test.toml
+++ b/acceptance/bundle/deployment/bind/job/engine-from-config/out.test.toml
@@ -1,3 +1,4 @@
 Local = true
 Cloud = false
+RequiresClassic = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/deployment/bind/job/generate-and-bind/out.test.toml
+++ b/acceptance/bundle/deployment/bind/job/generate-and-bind/out.test.toml
@@ -1,3 +1,4 @@
 Local = true
 Cloud = true
+RequiresClassic = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/job/job-abort-bind/out.test.toml
+++ b/acceptance/bundle/deployment/bind/job/job-abort-bind/out.test.toml
@@ -1,3 +1,4 @@
 Local = true
 Cloud = true
+RequiresClassic = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/job/job-spark-python-task/out.test.toml
+++ b/acceptance/bundle/deployment/bind/job/job-spark-python-task/out.test.toml
@@ -1,3 +1,4 @@
 Local = true
 Cloud = true
+RequiresClassic = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/job/noop-job/out.test.toml
+++ b/acceptance/bundle/deployment/bind/job/noop-job/out.test.toml
@@ -1,3 +1,4 @@
 Local = true
 Cloud = false
+RequiresClassic = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/job/python-job/out.test.toml
+++ b/acceptance/bundle/deployment/bind/job/python-job/out.test.toml
@@ -1,3 +1,4 @@
 Local = true
 Cloud = false
+RequiresClassic = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/job/stale-state/out.test.toml
+++ b/acceptance/bundle/deployment/bind/job/stale-state/out.test.toml
@@ -1,3 +1,4 @@
 Local = true
 Cloud = false
+RequiresClassic = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/job/test.toml
+++ b/acceptance/bundle/deployment/bind/job/test.toml
@@ -1,0 +1,2 @@
+# Cloud tests deploy job clusters (classic compute resources)
+RequiresClassic = true

--- a/acceptance/bundle/deployment/bind/pipelines/recreate/out.test.toml
+++ b/acceptance/bundle/deployment/bind/pipelines/recreate/out.test.toml
@@ -1,3 +1,4 @@
 Local = true
 Cloud = true
+RequiresClassic = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/pipelines/recreate/test.toml
+++ b/acceptance/bundle/deployment/bind/pipelines/recreate/test.toml
@@ -1,3 +1,4 @@
 Cloud = true
+RequiresClassic = true
 RecordRequests = true
 Ignore = [".databricks", "pipeline.json"]

--- a/acceptance/bundle/deployment/bind/pipelines/recreate/test.toml
+++ b/acceptance/bundle/deployment/bind/pipelines/recreate/test.toml
@@ -1,4 +1,5 @@
 Cloud = true
+# Tests bind a pipeline to a bundle; pipelines run on classic compute
 RequiresClassic = true
 RecordRequests = true
 Ignore = [".databricks", "pipeline.json"]

--- a/acceptance/bundle/destroy/jobs-and-pipeline/out.test.toml
+++ b/acceptance/bundle/destroy/jobs-and-pipeline/out.test.toml
@@ -1,3 +1,4 @@
 Local = true
 Cloud = true
+RequiresClassic = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/destroy/jobs-and-pipeline/test.toml
+++ b/acceptance/bundle/destroy/jobs-and-pipeline/test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = true
+RequiresClassic = true
 
 Ignore = [
     "databricks.yml",

--- a/acceptance/bundle/destroy/jobs-and-pipeline/test.toml
+++ b/acceptance/bundle/destroy/jobs-and-pipeline/test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = true
+# Destroys jobs with job clusters and a pipeline
 RequiresClassic = true
 
 Ignore = [

--- a/acceptance/bundle/generate/auto-bind/out.test.toml
+++ b/acceptance/bundle/generate/auto-bind/out.test.toml
@@ -1,3 +1,4 @@
 Local = true
 Cloud = true
+RequiresClassic = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform"]

--- a/acceptance/bundle/generate/auto-bind/test.toml
+++ b/acceptance/bundle/generate/auto-bind/test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = true
+# Generates and binds a job with a job cluster
 RequiresClassic = true
 
 Ignore = [

--- a/acceptance/bundle/generate/auto-bind/test.toml
+++ b/acceptance/bundle/generate/auto-bind/test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = true
+RequiresClassic = true
 
 Ignore = [
     "databricks.yml",

--- a/acceptance/bundle/generate/pipeline_and_deploy/out.test.toml
+++ b/acceptance/bundle/generate/pipeline_and_deploy/out.test.toml
@@ -1,3 +1,4 @@
 Local = true
 Cloud = true
+RequiresClassic = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/generate/pipeline_and_deploy/test.toml
+++ b/acceptance/bundle/generate/pipeline_and_deploy/test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = true
+RequiresClassic = true
 
 Ignore = [
     "databricks.yml",

--- a/acceptance/bundle/generate/pipeline_and_deploy/test.toml
+++ b/acceptance/bundle/generate/pipeline_and_deploy/test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = true
+# Generates from a pipeline and deploys it; pipelines run on classic compute
 RequiresClassic = true
 
 Ignore = [

--- a/acceptance/bundle/generate/python_job_and_deploy/out.test.toml
+++ b/acceptance/bundle/generate/python_job_and_deploy/out.test.toml
@@ -1,3 +1,4 @@
 Local = true
 Cloud = true
+RequiresClassic = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/generate/python_job_and_deploy/test.toml
+++ b/acceptance/bundle/generate/python_job_and_deploy/test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = true
+RequiresClassic = true
 
 Ignore = [
     "databricks.yml",

--- a/acceptance/bundle/generate/python_job_and_deploy/test.toml
+++ b/acceptance/bundle/generate/python_job_and_deploy/test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = true
+# Generates from a job with a job cluster and deploys it
 RequiresClassic = true
 
 Ignore = [

--- a/acceptance/bundle/integration_whl/base/out.test.toml
+++ b/acceptance/bundle/integration_whl/base/out.test.toml
@@ -1,4 +1,5 @@
 Local = true
 Cloud = true
 CloudSlow = true
+RequiresClassic = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/integration_whl/custom_params/out.test.toml
+++ b/acceptance/bundle/integration_whl/custom_params/out.test.toml
@@ -1,4 +1,5 @@
 Local = true
 Cloud = true
 CloudSlow = true
+RequiresClassic = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/integration_whl/interactive_cluster/out.test.toml
+++ b/acceptance/bundle/integration_whl/interactive_cluster/out.test.toml
@@ -1,4 +1,5 @@
 Local = true
 Cloud = true
 CloudSlow = true
+RequiresClassic = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/integration_whl/interactive_cluster_dynamic_version/out.test.toml
+++ b/acceptance/bundle/integration_whl/interactive_cluster_dynamic_version/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = true
 CloudSlow = true
+RequiresClassic = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
 EnvMatrix.DATA_SECURITY_MODE = ["USER_ISOLATION", "SINGLE_USER"]

--- a/acceptance/bundle/integration_whl/interactive_single_user/out.test.toml
+++ b/acceptance/bundle/integration_whl/interactive_single_user/out.test.toml
@@ -1,4 +1,5 @@
 Local = true
 Cloud = true
 CloudSlow = true
+RequiresClassic = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/integration_whl/serverless/out.test.toml
+++ b/acceptance/bundle/integration_whl/serverless/out.test.toml
@@ -2,4 +2,5 @@ Local = true
 Cloud = true
 CloudSlow = true
 RequiresUnityCatalog = true
+RequiresClassic = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/integration_whl/serverless_custom_params/out.test.toml
+++ b/acceptance/bundle/integration_whl/serverless_custom_params/out.test.toml
@@ -2,4 +2,5 @@ Local = true
 Cloud = true
 CloudSlow = true
 RequiresUnityCatalog = true
+RequiresClassic = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/integration_whl/serverless_dynamic_version/out.test.toml
+++ b/acceptance/bundle/integration_whl/serverless_dynamic_version/out.test.toml
@@ -2,4 +2,5 @@ Local = true
 Cloud = true
 CloudSlow = true
 RequiresUnityCatalog = true
+RequiresClassic = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/integration_whl/test.toml
+++ b/acceptance/bundle/integration_whl/test.toml
@@ -1,5 +1,6 @@
 Local = true
 CloudSlow = true
+RequiresClassic = true
 
 # Workspace file system does not allow initializing python envs on it.
 # I suspect something about the default python env on DBR interferes with it.

--- a/acceptance/bundle/integration_whl/wrapper/out.test.toml
+++ b/acceptance/bundle/integration_whl/wrapper/out.test.toml
@@ -1,6 +1,7 @@
 Local = true
 Cloud = true
 CloudSlow = true
+RequiresClassic = true
 CloudEnvs.aws = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/integration_whl/wrapper_custom_params/out.test.toml
+++ b/acceptance/bundle/integration_whl/wrapper_custom_params/out.test.toml
@@ -1,6 +1,7 @@
 Local = true
 Cloud = true
 CloudSlow = true
+RequiresClassic = true
 CloudEnvs.aws = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/invariant/continue_293/out.test.toml
+++ b/acceptance/bundle/invariant/continue_293/out.test.toml
@@ -1,6 +1,7 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+RequiresClassic = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]
 EnvMatrix.INPUT_CONFIG = [
   "alert.yml.tmpl",

--- a/acceptance/bundle/invariant/delete_idempotent/out.test.toml
+++ b/acceptance/bundle/invariant/delete_idempotent/out.test.toml
@@ -1,6 +1,7 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+RequiresClassic = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]
 EnvMatrix.INPUT_CONFIG = [
   "alert.yml.tmpl",

--- a/acceptance/bundle/invariant/destroy_idempotent/out.test.toml
+++ b/acceptance/bundle/invariant/destroy_idempotent/out.test.toml
@@ -1,6 +1,7 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+RequiresClassic = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]
 EnvMatrix.INPUT_CONFIG = [
   "alert.yml.tmpl",

--- a/acceptance/bundle/invariant/migrate/out.test.toml
+++ b/acceptance/bundle/invariant/migrate/out.test.toml
@@ -1,6 +1,7 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+RequiresClassic = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]
 EnvMatrix.INPUT_CONFIG = [
   "alert.yml.tmpl",

--- a/acceptance/bundle/invariant/no_drift/out.test.toml
+++ b/acceptance/bundle/invariant/no_drift/out.test.toml
@@ -1,6 +1,7 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+RequiresClassic = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]
 EnvMatrix.INPUT_CONFIG = [
   "alert.yml.tmpl",

--- a/acceptance/bundle/invariant/test.toml
+++ b/acceptance/bundle/invariant/test.toml
@@ -1,6 +1,7 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+RequiresClassic = true
 Timeout = '10m'
 
 Ignore = [

--- a/acceptance/bundle/local_state_staleness/out.test.toml
+++ b/acceptance/bundle/local_state_staleness/out.test.toml
@@ -1,3 +1,4 @@
 Local = true
 Cloud = true
+RequiresClassic = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/local_state_staleness/test.toml
+++ b/acceptance/bundle/local_state_staleness/test.toml
@@ -1,3 +1,4 @@
 Cloud = true
 Local = true
+# Tests local state staleness with a job that has a job cluster
 RequiresClassic = true

--- a/acceptance/bundle/local_state_staleness/test.toml
+++ b/acceptance/bundle/local_state_staleness/test.toml
@@ -1,2 +1,3 @@
 Cloud = true
 Local = true
+RequiresClassic = true

--- a/acceptance/bundle/python/mutator-permissions-owner-5682/out.test.toml
+++ b/acceptance/bundle/python/mutator-permissions-owner-5682/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+RequiresClassic = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
 EnvMatrix.PYDAB_VERSION = ["0.266.0", "current"]

--- a/acceptance/bundle/python/mutator-permissions-owner-5682/test.toml
+++ b/acceptance/bundle/python/mutator-permissions-owner-5682/test.toml
@@ -1,2 +1,3 @@
 Cloud = true
 RequiresUnityCatalog = true
+RequiresClassic = true

--- a/acceptance/bundle/python/mutator-permissions-owner-5682/test.toml
+++ b/acceptance/bundle/python/mutator-permissions-owner-5682/test.toml
@@ -1,3 +1,4 @@
 Cloud = true
 RequiresUnityCatalog = true
+# Deploys a pipeline, which runs on classic compute
 RequiresClassic = true

--- a/acceptance/bundle/resources/clusters/deploy/data_security_mode/out.test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/data_security_mode/out.test.toml
@@ -1,4 +1,5 @@
 Local = true
 Cloud = true
+RequiresClassic = true
 RunsOnDbr = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/clusters/deploy/instance_pool/out.test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/instance_pool/out.test.toml
@@ -1,3 +1,4 @@
 Local = true
 Cloud = false
+RequiresClassic = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/clusters/deploy/instance_pool_and_node_type/out.test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/instance_pool_and_node_type/out.test.toml
@@ -1,3 +1,4 @@
 Local = true
 Cloud = false
+RequiresClassic = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/clusters/deploy/local_ssd_count/out.test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/local_ssd_count/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = true
+RequiresClassic = true
 CloudEnvs.aws = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = true

--- a/acceptance/bundle/resources/clusters/deploy/num_workers_absent/out.test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/num_workers_absent/out.test.toml
@@ -1,3 +1,4 @@
 Local = true
 Cloud = false
+RequiresClassic = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/clusters/deploy/simple/out.test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/simple/out.test.toml
@@ -1,4 +1,5 @@
 Local = true
 Cloud = true
+RequiresClassic = true
 RunsOnDbr = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/clusters/deploy/update-after-create/out.test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/update-after-create/out.test.toml
@@ -1,3 +1,4 @@
 Local = true
 Cloud = true
+RequiresClassic = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/clusters/deploy/update-and-resize-autoscale/out.test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/update-and-resize-autoscale/out.test.toml
@@ -1,3 +1,4 @@
 Local = true
 Cloud = false
+RequiresClassic = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/clusters/deploy/update-and-resize/out.test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/update-and-resize/out.test.toml
@@ -1,3 +1,4 @@
 Local = true
 Cloud = false
+RequiresClassic = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/clusters/deploy/workload_type/out.test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/workload_type/out.test.toml
@@ -1,3 +1,4 @@
 Local = true
 Cloud = false
+RequiresClassic = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/clusters/lifecycle-started-terraform-error/out.test.toml
+++ b/acceptance/bundle/resources/clusters/lifecycle-started-terraform-error/out.test.toml
@@ -1,3 +1,4 @@
 Local = true
 Cloud = true
+RequiresClassic = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform"]

--- a/acceptance/bundle/resources/clusters/lifecycle-started-toggle/out.test.toml
+++ b/acceptance/bundle/resources/clusters/lifecycle-started-toggle/out.test.toml
@@ -1,3 +1,4 @@
 Local = true
 Cloud = true
+RequiresClassic = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/clusters/lifecycle-started/out.test.toml
+++ b/acceptance/bundle/resources/clusters/lifecycle-started/out.test.toml
@@ -1,3 +1,4 @@
 Local = true
 Cloud = true
+RequiresClassic = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/clusters/readplan-lifecycle/out.test.toml
+++ b/acceptance/bundle/resources/clusters/readplan-lifecycle/out.test.toml
@@ -1,4 +1,5 @@
 Local = true
 Cloud = false
+RequiresClassic = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]
 EnvMatrix.READPLAN = ["", "1"]

--- a/acceptance/bundle/resources/clusters/resize-terminated-fallback/out.test.toml
+++ b/acceptance/bundle/resources/clusters/resize-terminated-fallback/out.test.toml
@@ -1,3 +1,4 @@
 Local = true
 Cloud = true
+RequiresClassic = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/clusters/run/spark_python_task/out.test.toml
+++ b/acceptance/bundle/resources/clusters/run/spark_python_task/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = true
 CloudSlow = true
+RequiresClassic = true
 RunsOnDbr = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/clusters/test.toml
+++ b/acceptance/bundle/resources/clusters/test.toml
@@ -1,0 +1,2 @@
+# Cloud tests deploy all-purpose and job clusters (classic compute resources)
+RequiresClassic = true

--- a/acceptance/bundle/resources/jobs/check-metadata/out.test.toml
+++ b/acceptance/bundle/resources/jobs/check-metadata/out.test.toml
@@ -1,3 +1,4 @@
 Local = true
 Cloud = true
+RequiresClassic = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/check-metadata/test.toml
+++ b/acceptance/bundle/resources/jobs/check-metadata/test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = true
+# Deploys a job with a job cluster to test metadata
 RequiresClassic = true
 RecordRequests = false
 

--- a/acceptance/bundle/resources/jobs/check-metadata/test.toml
+++ b/acceptance/bundle/resources/jobs/check-metadata/test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = true
+RequiresClassic = true
 RecordRequests = false
 
 Ignore = [

--- a/acceptance/bundle/resources/jobs/double-underscore-keys/out.test.toml
+++ b/acceptance/bundle/resources/jobs/double-underscore-keys/out.test.toml
@@ -1,4 +1,5 @@
 Local = true
 Cloud = true
+RequiresClassic = true
 RunsOnDbr = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/double-underscore-keys/test.toml
+++ b/acceptance/bundle/resources/jobs/double-underscore-keys/test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = true
+# Deploys jobs with job clusters
 RequiresClassic = true
 RecordRequests = false
 RunsOnDbr = true

--- a/acceptance/bundle/resources/jobs/double-underscore-keys/test.toml
+++ b/acceptance/bundle/resources/jobs/double-underscore-keys/test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = true
+RequiresClassic = true
 RecordRequests = false
 RunsOnDbr = true
 

--- a/acceptance/bundle/resources/jobs/fail-on-active-runs/out.test.toml
+++ b/acceptance/bundle/resources/jobs/fail-on-active-runs/out.test.toml
@@ -1,4 +1,5 @@
 Local = true
 Cloud = true
+RequiresClassic = true
 RunsOnDbr = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/fail-on-active-runs/test.toml
+++ b/acceptance/bundle/resources/jobs/fail-on-active-runs/test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = true
+# Deploys a job with a job cluster to test active run prevention
 RequiresClassic = true
 RecordRequests = false
 RunsOnDbr = true

--- a/acceptance/bundle/resources/jobs/fail-on-active-runs/test.toml
+++ b/acceptance/bundle/resources/jobs/fail-on-active-runs/test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = true
+RequiresClassic = true
 RecordRequests = false
 RunsOnDbr = true
 

--- a/acceptance/bundle/resources/jobs/no-git-provider/out.test.toml
+++ b/acceptance/bundle/resources/jobs/no-git-provider/out.test.toml
@@ -1,4 +1,5 @@
 Local = true
 Cloud = true
+RequiresClassic = true
 RunsOnDbr = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/no-git-provider/test.toml
+++ b/acceptance/bundle/resources/jobs/no-git-provider/test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = true
+# Deploys a job with a job cluster and notebook task
 RequiresClassic = true
 
 RecordRequests = false

--- a/acceptance/bundle/resources/jobs/no-git-provider/test.toml
+++ b/acceptance/bundle/resources/jobs/no-git-provider/test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = true
+RequiresClassic = true
 
 RecordRequests = false
 RunsOnDbr = true

--- a/acceptance/bundle/resources/jobs/shared-root-path/out.test.toml
+++ b/acceptance/bundle/resources/jobs/shared-root-path/out.test.toml
@@ -1,4 +1,5 @@
 Local = true
 Cloud = true
+RequiresClassic = true
 RunsOnDbr = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/shared-root-path/test.toml
+++ b/acceptance/bundle/resources/jobs/shared-root-path/test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = true
+RequiresClassic = true
 RecordRequests = false
 RunsOnDbr = true
 

--- a/acceptance/bundle/resources/jobs/shared-root-path/test.toml
+++ b/acceptance/bundle/resources/jobs/shared-root-path/test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = true
+# Deploys a job with a job cluster to Shared workspace path
 RequiresClassic = true
 RecordRequests = false
 RunsOnDbr = true

--- a/acceptance/bundle/resources/permissions/factcheck/out.test.toml
+++ b/acceptance/bundle/resources/permissions/factcheck/out.test.toml
@@ -1,6 +1,7 @@
 Local = true
 Cloud = true
 CloudSlow = true
+RequiresClassic = true
 RunsOnDbr = true
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/factcheck/test.toml
+++ b/acceptance/bundle/resources/permissions/factcheck/test.toml
@@ -1,5 +1,6 @@
 Local = true
 CloudSlow = true
+RequiresClassic = true
 RecordRequests = false
 RunsOnDbr = true
 

--- a/acceptance/bundle/resources/permissions/jobs/delete_one/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/delete_one/out.test.toml
@@ -1,4 +1,5 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+RequiresClassic = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/delete_one/test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/delete_one/test.toml
@@ -2,4 +2,5 @@ Local = true
 Cloud = true
 IsServicePrincipal = true
 RequiresUnityCatalog = true
+# Deploys a job with a notebook_task, which runs on a cluster.
 RequiresClassic = true

--- a/acceptance/bundle/resources/permissions/jobs/delete_one/test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/delete_one/test.toml
@@ -2,3 +2,4 @@ Local = true
 Cloud = true
 IsServicePrincipal = true
 RequiresUnityCatalog = true
+RequiresClassic = true

--- a/acceptance/bundle/resources/pipelines/allow-duplicate-names/out.test.toml
+++ b/acceptance/bundle/resources/pipelines/allow-duplicate-names/out.test.toml
@@ -1,3 +1,4 @@
 Local = true
 Cloud = true
+RequiresClassic = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/pipelines/auto-approve/out.test.toml
+++ b/acceptance/bundle/resources/pipelines/auto-approve/out.test.toml
@@ -1,4 +1,5 @@
 Local = true
 Cloud = true
+RequiresClassic = true
 RunsOnDbr = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/pipelines/drift/parameters/out.test.toml
+++ b/acceptance/bundle/resources/pipelines/drift/parameters/out.test.toml
@@ -1,3 +1,4 @@
 Local = true
 Cloud = false
+RequiresClassic = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/pipelines/lakeflow-pipeline/out.test.toml
+++ b/acceptance/bundle/resources/pipelines/lakeflow-pipeline/out.test.toml
@@ -1,3 +1,4 @@
 Local = true
 Cloud = true
+RequiresClassic = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/pipelines/num-workers-zero/out.test.toml
+++ b/acceptance/bundle/resources/pipelines/num-workers-zero/out.test.toml
@@ -1,3 +1,4 @@
 Local = true
 Cloud = false
+RequiresClassic = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/pipelines/photon-true/out.test.toml
+++ b/acceptance/bundle/resources/pipelines/photon-true/out.test.toml
@@ -1,3 +1,4 @@
 Local = true
 Cloud = false
+RequiresClassic = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/pipelines/recreate-keys/change-ingestion-definition/out.test.toml
+++ b/acceptance/bundle/resources/pipelines/recreate-keys/change-ingestion-definition/out.test.toml
@@ -1,3 +1,4 @@
 Local = true
 Cloud = false
+RequiresClassic = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/pipelines/recreate-keys/change-storage/out.test.toml
+++ b/acceptance/bundle/resources/pipelines/recreate-keys/change-storage/out.test.toml
@@ -1,3 +1,4 @@
 Local = true
 Cloud = false
+RequiresClassic = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/pipelines/recreate/out.test.toml
+++ b/acceptance/bundle/resources/pipelines/recreate/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+RequiresClassic = true
 RunsOnDbr = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/pipelines/remote_matches_config/out.test.toml
+++ b/acceptance/bundle/resources/pipelines/remote_matches_config/out.test.toml
@@ -1,3 +1,4 @@
 Local = true
 Cloud = false
+RequiresClassic = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/pipelines/test.toml
+++ b/acceptance/bundle/resources/pipelines/test.toml
@@ -1,0 +1,2 @@
+# Cloud tests require classic compute to deploy Databricks SQL pipelines
+RequiresClassic = true

--- a/acceptance/bundle/resources/pipelines/update/out.test.toml
+++ b/acceptance/bundle/resources/pipelines/update/out.test.toml
@@ -1,3 +1,4 @@
 Local = true
 Cloud = true
+RequiresClassic = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/pipelines/zero-value-fields/out.test.toml
+++ b/acceptance/bundle/resources/pipelines/zero-value-fields/out.test.toml
@@ -1,3 +1,4 @@
 Local = true
 Cloud = false
+RequiresClassic = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/schemas/auto-approve/out.test.toml
+++ b/acceptance/bundle/resources/schemas/auto-approve/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+RequiresClassic = true
 RunsOnDbr = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/schemas/auto-approve/test.toml
+++ b/acceptance/bundle/resources/schemas/auto-approve/test.toml
@@ -3,6 +3,7 @@ Cloud = true
 RecordRequests = false
 RunsOnDbr = true
 RequiresUnityCatalog = true
+RequiresClassic = true
 
 Ignore = [
     ".databricks",

--- a/acceptance/bundle/run/app-with-job/out.test.toml
+++ b/acceptance/bundle/run/app-with-job/out.test.toml
@@ -1,4 +1,5 @@
 Local = true
 Cloud = true
 CloudSlow = true
+RequiresClassic = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run/app-with-job/test.toml
+++ b/acceptance/bundle/run/app-with-job/test.toml
@@ -8,6 +8,7 @@ Local = true
 # This test includes 2 application starts, and it is taking aroung 420 seconds to complete the entire test
 #
 CloudSlow = true
+RequiresClassic = true
 
 Ignore = [
     'databricks.yml',

--- a/acceptance/bundle/run_as/job_default/out.test.toml
+++ b/acceptance/bundle/run_as/job_default/out.test.toml
@@ -1,3 +1,4 @@
 Local = true
 Cloud = true
+RequiresClassic = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/run_as/job_default/test.toml
+++ b/acceptance/bundle/run_as/job_default/test.toml
@@ -3,6 +3,7 @@ Ignore = [".databricks/.gitignore"]
 
 Local = true
 Cloud = true
+# Deploys a job with a job cluster and run_as configuration
 RequiresClassic = true
 RecordRequests = true
 

--- a/acceptance/bundle/run_as/job_default/test.toml
+++ b/acceptance/bundle/run_as/job_default/test.toml
@@ -3,6 +3,7 @@ Ignore = [".databricks/.gitignore"]
 
 Local = true
 Cloud = true
+RequiresClassic = true
 RecordRequests = true
 
 [EnvMatrix]

--- a/acceptance/bundle/templates/default-python/integration_classic/out.test.toml
+++ b/acceptance/bundle/templates/default-python/integration_classic/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = true
+RequiresClassic = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
 EnvMatrix.UV_PYTHON = [
   "3.9",

--- a/acceptance/bundle/templates/default-python/integration_classic/test.toml
+++ b/acceptance/bundle/templates/default-python/integration_classic/test.toml
@@ -1,4 +1,5 @@
 Cloud = true
+RequiresClassic = true
 Timeout = '1m'
 
 Ignore = [

--- a/acceptance/cmd/bundle/dms-cloud-read/out.test.toml
+++ b/acceptance/cmd/bundle/dms-cloud-read/out.test.toml
@@ -1,5 +1,6 @@
 Local = false
 Cloud = true
+RequiresDms = true
 CloudEnvs.aws = true
 CloudEnvs.azure = false
 CloudEnvs.gcp = false

--- a/acceptance/cmd/bundle/dms-cloud-read/out.test.toml
+++ b/acceptance/cmd/bundle/dms-cloud-read/out.test.toml
@@ -1,0 +1,6 @@
+Local = false
+Cloud = true
+CloudEnvs.aws = true
+CloudEnvs.azure = false
+CloudEnvs.gcp = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/cmd/bundle/dms-cloud-read/output.txt
+++ b/acceptance/cmd/bundle/dms-cloud-read/output.txt
@@ -1,0 +1,23 @@
+
+>>> [CLI] bundle-deployments list-deployments
+"array"
+
+>>> errcode [CLI] bundle-deployments get-deployment deployments/[NUMID]
+Error: deployment 1 in workspace [NUMID] not found
+
+Exit code: 1
+
+>>> errcode [CLI] bundle-deployments list-versions deployments/[NUMID]
+Error: deployment 1 in workspace [NUMID] not found
+
+Exit code: 1
+
+>>> errcode [CLI] bundle-deployments list-resources deployments/[NUMID]
+Error: deployment 1 in workspace [NUMID] not found
+
+Exit code: 1
+
+>>> errcode [CLI] bundle-deployments list-operations deployments/[NUMID]/versions/1
+Error: deployment 1 in workspace [NUMID] not found
+
+Exit code: 1

--- a/acceptance/cmd/bundle/dms-cloud-read/script
+++ b/acceptance/cmd/bundle/dms-cloud-read/script
@@ -1,0 +1,12 @@
+# list-deployments returns every deployment in the workspace, so assert on its
+# shape rather than its contents: the set grows as other tests and engineers
+# deploy, and the ids are server-assigned.
+trace $CLI bundle-deployments list-deployments | jq 'if type == "array" then "array" else . end'
+
+# A deployment id that cannot exist. DMS resolves the workspace and runs the
+# permission check before it looks for the row, so a clean NotFound proves the
+# whole read path is reachable, not just the front door.
+trace errcode $CLI bundle-deployments get-deployment deployments/1
+trace errcode $CLI bundle-deployments list-versions deployments/1
+trace errcode $CLI bundle-deployments list-resources deployments/1
+trace errcode $CLI bundle-deployments list-operations deployments/1/versions/1

--- a/acceptance/cmd/bundle/dms-cloud-read/script
+++ b/acceptance/cmd/bundle/dms-cloud-read/script
@@ -1,13 +1,3 @@
-# DMS is placed on DEV and STAGING shards only, and CLOUD_ENV cannot tell the
-# staging env apart from the prod ones (both set CLOUD_ENV=aws). The workspace
-# host can: staging control planes carry ".staging." in the domain. Skip
-# elsewhere rather than fail, so adding this test to the shared cloud matrix
-# does not red-line the prod envs.
-case "$DATABRICKS_HOST" in
-    *.staging.*) ;;
-    *) echo "DMS is deployed to staging only; skipping on $DATABRICKS_HOST"; exit 0 ;;
-esac
-
 # list-deployments returns every deployment in the workspace, so assert on its
 # shape rather than its contents: the set grows as other tests and engineers
 # deploy, and the ids are server-assigned.

--- a/acceptance/cmd/bundle/dms-cloud-read/script
+++ b/acceptance/cmd/bundle/dms-cloud-read/script
@@ -1,3 +1,13 @@
+# DMS is placed on DEV and STAGING shards only, and CLOUD_ENV cannot tell the
+# staging env apart from the prod ones (both set CLOUD_ENV=aws). The workspace
+# host can: staging control planes carry ".staging." in the domain. Skip
+# elsewhere rather than fail, so adding this test to the shared cloud matrix
+# does not red-line the prod envs.
+case "$DATABRICKS_HOST" in
+    *.staging.*) ;;
+    *) echo "DMS is deployed to staging only; skipping on $DATABRICKS_HOST"; exit 0 ;;
+esac
+
 # list-deployments returns every deployment in the workspace, so assert on its
 # shape rather than its contents: the set grows as other tests and engineers
 # deploy, and the ids are server-assigned.

--- a/acceptance/cmd/bundle/dms-cloud-read/test.toml
+++ b/acceptance/cmd/bundle/dms-cloud-read/test.toml
@@ -1,9 +1,10 @@
 # Cloud read-path test for the `databricks bundle-deployments` (DMS) commands.
 #
-# DMS is placed on DEV and STAGING shards only, so this test is enabled solely
-# for the staging cloud env. On a prod control plane the routes do not exist and
-# every request 404s at the API proxy, which is why the CLI's usual
-# aws-prod-ucws env cannot cover this service.
+# DMS is placed on DEV and STAGING shards only; on a prod control plane the
+# routes do not exist and every request 404s at the API proxy. CLOUD_ENV cannot
+# express that split (the staging and prod aws envs both set CLOUD_ENV=aws), so
+# `script` gates on the workspace host instead and skips off staging. Drop that
+# guard once DMS reaches prod, and this becomes a plain aws cloud test.
 Cloud = true
 Local = false
 CloudEnvs = {aws = true, azure = false, gcp = false}

--- a/acceptance/cmd/bundle/dms-cloud-read/test.toml
+++ b/acceptance/cmd/bundle/dms-cloud-read/test.toml
@@ -1,0 +1,24 @@
+# Cloud read-path test for the `databricks bundle-deployments` (DMS) commands.
+#
+# DMS is placed on DEV and STAGING shards only, so this test is enabled solely
+# for the staging cloud env. On a prod control plane the routes do not exist and
+# every request 404s at the API proxy, which is why the CLI's usual
+# aws-prod-ucws env cannot cover this service.
+Cloud = true
+Local = false
+CloudEnvs = {aws = true, azure = false, gcp = false}
+
+# bundle-deployments is a workspace-service command, independent of the bundle
+# deploy engine. Pin to one engine so the suite runs the case once rather than
+# twice; an empty list would instead run it on both CI runners.
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]
+
+# Deployment ids are server-assigned and workspace-scoped, so both the ids and
+# the enclosing workspace id vary per run.
+[[Repls]]
+Old = 'deployments/[0-9]+'
+New = 'deployments/[NUMID]'
+
+[[Repls]]
+Old = 'in workspace [0-9]+'
+New = 'in workspace [NUMID]'

--- a/acceptance/cmd/bundle/dms-cloud-read/test.toml
+++ b/acceptance/cmd/bundle/dms-cloud-read/test.toml
@@ -1,12 +1,13 @@
 # Cloud read-path test for the `databricks bundle-deployments` (DMS) commands.
 #
-# DMS is placed on DEV and STAGING shards only; on a prod control plane the
+# DMS is placed on dev and staging shards only; on a prod control plane the
 # routes do not exist and every request 404s at the API proxy. CLOUD_ENV cannot
 # express that split (the staging and prod aws envs both set CLOUD_ENV=aws), so
-# `script` gates on the workspace host instead and skips off staging. Drop that
-# guard once DMS reaches prod, and this becomes a plain aws cloud test.
+# this gates on RequiresDms, which skips unless the environment exports
+# DATABRICKS_TEST_DMS=true. Drop that once DMS reaches prod.
 Cloud = true
 Local = false
+RequiresDms = true
 CloudEnvs = {aws = true, azure = false, gcp = false}
 
 # bundle-deployments is a workspace-service command, independent of the bundle

--- a/acceptance/internal/config.go
+++ b/acceptance/internal/config.go
@@ -58,6 +58,12 @@ type TestConfig struct {
 	// If true and Cloud=true, run this test only if a default test cluster is available in the cloud environment
 	RequiresCluster *bool
 
+	// If true and Cloud=true, run this test only where classic compute can be
+	// created. Set it on any test that deploys an all-purpose cluster, a job
+	// cluster, or an instance pool. Serverless-only test environments export
+	// DATABRICKS_TEST_NO_CLASSIC=true, which skips these.
+	RequiresClassic *bool
+
 	// If true and Cloud=true, run this test only if a default warehouse is available in the cloud environment
 	RequiresWarehouse *bool
 

--- a/acceptance/internal/config.go
+++ b/acceptance/internal/config.go
@@ -67,6 +67,14 @@ type TestConfig struct {
 	// If true and Cloud=true, run this test only if a default warehouse is available in the cloud environment
 	RequiresWarehouse *bool
 
+	// If true and Cloud=true, run this test only where DMS (the
+	// bundle-deployments service) is deployed. It is placed on dev and staging
+	// shards only, and CLOUD_ENV cannot tell those apart from prod, so test
+	// environments that have it export DATABRICKS_TEST_DMS=true. Absent that,
+	// the test is skipped rather than failing against a control plane where the
+	// routes do not exist.
+	RequiresDms *bool
+
 	// If set, current user will be set to a service principal-like UUID instead of email (default is false)
 	IsServicePrincipal *bool
 

--- a/acceptance/internal/materialized_config.go
+++ b/acceptance/internal/materialized_config.go
@@ -47,6 +47,7 @@ func GenerateMaterializedConfig(config *TestConfig) string {
 	writeBool(&buf, "RequiresCluster", config.RequiresCluster)
 	writeBool(&buf, "RequiresClassic", config.RequiresClassic)
 	writeBool(&buf, "RequiresWarehouse", config.RequiresWarehouse)
+	writeBool(&buf, "RequiresDms", config.RequiresDms)
 	writeBool(&buf, "RunsOnDbr", config.RunsOnDbr)
 	if config.Phase != 0 {
 		fmt.Fprintf(&buf, "Phase = %d\n", config.Phase)

--- a/acceptance/internal/materialized_config.go
+++ b/acceptance/internal/materialized_config.go
@@ -45,6 +45,7 @@ func GenerateMaterializedConfig(config *TestConfig) string {
 	writeBool(&buf, "CloudSlow", config.CloudSlow)
 	writeBool(&buf, "RequiresUnityCatalog", config.RequiresUnityCatalog)
 	writeBool(&buf, "RequiresCluster", config.RequiresCluster)
+	writeBool(&buf, "RequiresClassic", config.RequiresClassic)
 	writeBool(&buf, "RequiresWarehouse", config.RequiresWarehouse)
 	writeBool(&buf, "RunsOnDbr", config.RunsOnDbr)
 	if config.Phase != 0 {


### PR DESCRIPTION
## Why

The read-only `databricks bundle-deployments` (DMS) commands are covered today
only by `acceptance/cmd/bundle/dms-read-only`, which stubs all eight endpoints
against the local testserver. That proves the CLI renders responses correctly,
but never exercises a real server — so a bad DMS commit cannot be caught here.

## What

Adds `acceptance/cmd/bundle/dms-cloud-read`, which runs the same read verbs
against a real workspace.

`list-deployments` asserts only the response *shape*: the deployment set grows
as other tests and engineers deploy, and the ids are server-assigned. The four
not-found cases pin the error contract and prove the whole read path is
reachable — DMS resolves the workspace and runs the permission check before it
looks for the row, so a clean `NotFound` exercises more than the front door.

## The staging gate

DMS is placed on DEV and STAGING shards only (`environment_in: ["DEV","STAGING"]`),
so on a prod control plane every request 404s at the API proxy. `CLOUD_ENV`
cannot express that split — the staging and prod aws test envs both set
`CLOUD_ENV=aws`, and the acceptance framework gates on cloud *family*, not
individual environment.

So `script` gates on the workspace host, since staging control planes carry
`.staging.` in the domain, and skips elsewhere. Skipping rather than failing
means this test can join the shared cloud matrix without red-lining the
existing prod entries.

**Once DMS reaches prod, drop that guard** and this becomes a plain aws cloud
test.

## Testing

Verified against `e2-dogfood.staging.cloud.databricks.com` (a staging shard
where DMS serves):

- cloud run: `dms-cloud-read` passes, `dms-read-only` skips
- local run: `dms-read-only` passes, `dms-cloud-read` skips
- passes without `-update` (golden output is stable and workspace-independent)
- host gate verified both ways (staging host runs; prod-style host skips)

The first golden capture returned ~1,300 lines of real deployments from the
staging workspace, confirming the CLI reached live DMS rather than a stub.

This PR alone changes no CI behaviour: no cloud test env currently points at a
staging workspace, so the test skips everywhere until the companion
eng-dev-ecosystem change adds `aws-stg` to the matrix.

This pull request and its description were written by Isaac.