### PR TITLE
[AIR Validation to Backend] Pre-flight config against ValidateConfig before submit

### DIFF
--- a/acceptance/experimental/air/run-submit-deps/test.toml
+++ b/acceptance/experimental/air/run-submit-deps/test.toml
@@ -8,6 +8,10 @@ Pattern = "HEAD /"
 Response.Body = ''
 
 [[Server]]
+Pattern = "POST /api/2.0/ai-training/config:validate"
+Response.Body = '{}'
+
+[[Server]]
 Pattern = "POST /api/2.2/jobs/runs/submit"
 Response.Body = '''
 {"run_id": 555}

--- a/acceptance/experimental/air/run-submit/test.toml
+++ b/acceptance/experimental/air/run-submit/test.toml
@@ -12,6 +12,10 @@ Pattern = "HEAD /"
 Response.Body = ''
 
 [[Server]]
+Pattern = "POST /api/2.0/ai-training/config:validate"
+Response.Body = '{}'
+
+[[Server]]
 Pattern = "POST /api/2.2/jobs/runs/submit"
 Response.Body = '''
 {"run_id": 555}

--- a/experimental/air/cmd/runsubmit.go
+++ b/experimental/air/cmd/runsubmit.go
@@ -160,9 +160,24 @@ func withSpinner(ctx context.Context, show bool, msg string, fn func() error) er
 // returns the new run_id and its dashboard URL. showProgress enables the
 // stderr upload/packaging spinners (text mode only).
 func submitWorkload(ctx context.Context, w *databricks.WorkspaceClient, cfg *runConfig, configPath, idempotencyKey string, showProgress bool) (int64, string, error) {
-	// Pre-flight the config server-side before touching the workspace, so a bad
-	// config fails with the backend's field-level errors and no orphaned uploads.
-	if err := preflightValidate(ctx, w, cfg); err != nil {
+	// Compute the launch dir and command_path up front — a read-only workspace lookup plus a
+	// local path build, no writes yet — so the pre-flight validates the real command_path. The
+	// same path is reused for the upload and submit below, so the validated path is the submitted
+	// one.
+	base, err := userWorkspaceDir(ctx, w)
+	if err != nil {
+		return 0, "", err
+	}
+	runName := ""
+	if cfg.MLflowRunName != nil {
+		runName = *cfg.MLflowRunName
+	}
+	funcDir := cliLaunchDir(base, cfg.ExperimentName, runName)
+	commandPath := path.Join(funcDir, commandScriptName)
+
+	// Pre-flight the config server-side before any upload, so a bad config fails with the
+	// backend's field-level errors and no orphaned artifacts.
+	if err := preflightValidate(ctx, w, cfg, commandPath); err != nil {
 		return 0, "", err
 	}
 
@@ -203,16 +218,6 @@ func submitWorkload(ctx context.Context, w *databricks.WorkspaceClient, cfg *run
 		return 0, "", err
 	}
 
-	base, err := userWorkspaceDir(ctx, w)
-	if err != nil {
-		return 0, "", err
-	}
-	runName := ""
-	if cfg.MLflowRunName != nil {
-		runName = *cfg.MLflowRunName
-	}
-	funcDir := cliLaunchDir(base, cfg.ExperimentName, runName)
-
 	fc, err := filer.NewWorkspaceFilesClient(w, funcDir)
 	if err != nil {
 		return 0, "", err
@@ -249,7 +254,7 @@ func submitWorkload(ctx context.Context, w *databricks.WorkspaceClient, cfg *run
 	if !ok {
 		runtimeVersion = fileVersion
 	}
-	payload := buildSubmitPayload(cfg, path.Join(funcDir, commandScriptName), dlRuntimeImage(ctx, runtimeVersion), usagePolicyID, snap, deps)
+	payload := buildSubmitPayload(cfg, commandPath, dlRuntimeImage(ctx, runtimeVersion), usagePolicyID, snap, deps)
 	payload.IdempotencyToken = token
 
 	// Submit returns as soon as the run is created; we don't wait for it to finish.

--- a/experimental/air/cmd/runsubmit.go
+++ b/experimental/air/cmd/runsubmit.go
@@ -160,6 +160,12 @@ func withSpinner(ctx context.Context, show bool, msg string, fn func() error) er
 // returns the new run_id and its dashboard URL. showProgress enables the
 // stderr upload/packaging spinners (text mode only).
 func submitWorkload(ctx context.Context, w *databricks.WorkspaceClient, cfg *runConfig, configPath, idempotencyKey string, showProgress bool) (int64, string, error) {
+	// Pre-flight the config server-side before touching the workspace, so a bad
+	// config fails with the backend's field-level errors and no orphaned uploads.
+	if err := preflightValidate(ctx, w, cfg); err != nil {
+		return 0, "", err
+	}
+
 	// Resolve the idempotency token first so a bad key fails before any upload,
 	// and before the policy lookup below spends a round trip on it.
 	token, err := submitToken(idempotencyKey, cfg)

--- a/experimental/air/cmd/runsubmit_test.go
+++ b/experimental/air/cmd/runsubmit_test.go
@@ -18,6 +18,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// stubValidateConfig registers an OK ValidateConfig response so submitWorkload's
+// pre-flight passes. Register before AddDefaultHandlers (the router is first-wins).
+func stubValidateConfig(server *testserver.Server) {
+	server.Handle("POST", "/api/2.0/ai-training/config:validate", func(req testserver.Request) any {
+		return validateConfigResponse{}
+	})
+}
+
 func TestDlRuntimeImage(t *testing.T) {
 	ctx := t.Context()
 	// A config runtime version wins and is used bare.
@@ -216,6 +224,7 @@ func TestSubmitWorkload(t *testing.T) {
 		require.NoError(t, json.Unmarshal(req.Body, &got))
 		return jobs.SubmitRunResponse{RunId: 777}
 	})
+	stubValidateConfig(server)
 	testserver.AddDefaultHandlers(server)
 
 	w, err := databricks.NewWorkspaceClient(&databricks.Config{Host: server.URL, Token: "token"})
@@ -260,6 +269,7 @@ func TestSubmitWorkloadHonorsOverride(t *testing.T) {
 		require.NoError(t, json.Unmarshal(req.Body, &got))
 		return jobs.SubmitRunResponse{RunId: 777}
 	})
+	stubValidateConfig(server)
 	testserver.AddDefaultHandlers(server)
 	w, err := databricks.NewWorkspaceClient(&databricks.Config{Host: server.URL, Token: "token"})
 	require.NoError(t, err)
@@ -290,6 +300,7 @@ func TestSubmitWorkloadWithCodeSource(t *testing.T) {
 		require.NoError(t, json.Unmarshal(req.Body, &got))
 		return jobs.SubmitRunResponse{RunId: 555}
 	})
+	stubValidateConfig(server)
 	testserver.AddDefaultHandlers(server)
 	w, err := databricks.NewWorkspaceClient(&databricks.Config{Host: server.URL, Token: "token"})
 	require.NoError(t, err)
@@ -331,6 +342,7 @@ func TestSubmitWorkloadWithGitPinnedCodeSource(t *testing.T) {
 		require.NoError(t, json.Unmarshal(req.Body, &got))
 		return jobs.SubmitRunResponse{RunId: 555}
 	})
+	stubValidateConfig(server)
 	testserver.AddDefaultHandlers(server)
 	w, err := databricks.NewWorkspaceClient(&databricks.Config{Host: server.URL, Token: "token"})
 	require.NoError(t, err)
@@ -380,6 +392,7 @@ func TestSubmitWorkloadPlainTarNameIsUnique(t *testing.T) {
 	server.Handle("POST", "/api/2.2/jobs/runs/submit", func(req testserver.Request) any {
 		return jobs.SubmitRunResponse{RunId: 555}
 	})
+	stubValidateConfig(server)
 	testserver.AddDefaultHandlers(server)
 	w, err := databricks.NewWorkspaceClient(&databricks.Config{Host: server.URL, Token: "token"})
 	require.NoError(t, err)
@@ -431,6 +444,7 @@ func TestSubmitWorkloadGitArchiveCaching(t *testing.T) {
 		}
 		return req.Workspace.WorkspaceFilesImportFile(p, req.Body, req.URL.Query().Get("overwrite") == "true")
 	})
+	stubValidateConfig(server)
 	testserver.AddDefaultHandlers(server)
 	w, err := databricks.NewWorkspaceClient(&databricks.Config{Host: server.URL, Token: "token"})
 	require.NoError(t, err)
@@ -474,6 +488,7 @@ func TestSubmitWorkloadUploadsGitSidecars(t *testing.T) {
 	server.Handle("POST", "/api/2.2/jobs/runs/submit", func(req testserver.Request) any {
 		return jobs.SubmitRunResponse{RunId: 555}
 	})
+	stubValidateConfig(server)
 	testserver.AddDefaultHandlers(server)
 	w, err := databricks.NewWorkspaceClient(&databricks.Config{Host: server.URL, Token: "token"})
 	require.NoError(t, err)
@@ -531,6 +546,7 @@ func TestSubmitWorkloadWithRemoteVolumeCodeSource(t *testing.T) {
 	server.Handle("PUT", "/api/2.0/fs/files/Volumes/{path...}", func(req testserver.Request) any {
 		return testserver.Response{StatusCode: 204}
 	})
+	stubValidateConfig(server)
 	testserver.AddDefaultHandlers(server)
 	w, err := databricks.NewWorkspaceClient(&databricks.Config{Host: server.URL, Token: "token"})
 	require.NoError(t, err)
@@ -578,6 +594,7 @@ func TestSubmitWorkloadGuards(t *testing.T) {
 			paths = append(paths, req.URL.Path)
 			return testserver.Response{StatusCode: 200}
 		})
+		stubValidateConfig(server)
 		testserver.AddDefaultHandlers(server)
 		pw, err := databricks.NewWorkspaceClient(&databricks.Config{Host: server.URL, Token: "token"})
 		require.NoError(t, err)
@@ -599,6 +616,7 @@ func TestSubmitWorkloadGuards(t *testing.T) {
 			uploaded = true
 			return nil
 		})
+		stubValidateConfig(server)
 		testserver.AddDefaultHandlers(server)
 		tw, err := databricks.NewWorkspaceClient(&databricks.Config{Host: server.URL, Token: "token"})
 		require.NoError(t, err)
@@ -627,6 +645,7 @@ func TestSubmitWorkloadSendsUsagePolicy(t *testing.T) {
 		server.Handle("GET", "/api/2.0/serverless-policies", func(req testserver.Request) any {
 			return usagePoliciesResponse{Policies: []usagePolicy{{PolicyID: policyID, PolicyName: "team-a"}}}
 		})
+		stubValidateConfig(server)
 		testserver.AddDefaultHandlers(server)
 		w, err := databricks.NewWorkspaceClient(&databricks.Config{Host: server.URL, Token: "token"})
 		require.NoError(t, err)

--- a/experimental/air/cmd/validateconfig.go
+++ b/experimental/air/cmd/validateconfig.go
@@ -34,8 +34,9 @@ type validateConfigResponse struct {
 //
 // It fails open: the endpoint is behind a SAFE flag and older workspaces do not
 // have it, so a disabled or missing endpoint skips the check and lets submission
-// proceed (where the config is validated again, authoritatively). Only a
-// populated error list — a config the server actively rejected — blocks.
+// proceed (where the config is validated again, authoritatively). A 5xx is a
+// backend problem, not the user's config, so it fails open too. Only a 4xx (the
+// server rejected the config) or a populated error list blocks.
 func preflightValidate(ctx context.Context, w *databricks.WorkspaceClient, cfg *runConfig, commandPath string) error {
 	apiClient, err := client.New(w.Config)
 	if err != nil {
@@ -45,7 +46,7 @@ func preflightValidate(ctx context.Context, w *databricks.WorkspaceClient, cfg *
 	var resp validateConfigResponse
 	err = apiClient.Do(ctx, http.MethodPost, validateConfigPath, nil, nil, validateConfigRequest(cfg, commandPath), &resp)
 	if err != nil {
-		if endpointUnavailable(err) {
+		if endpointUnavailable(err) || serverError(err) {
 			return nil
 		}
 		return fmt.Errorf("failed to validate config: %w", err)
@@ -114,6 +115,15 @@ func endpointUnavailable(err error) bool {
 	return ok && (apiErr.ErrorCode == "FEATURE_DISABLED" ||
 		apiErr.StatusCode == http.StatusNotFound ||
 		apiErr.StatusCode == http.StatusNotImplemented)
+}
+
+// serverError reports whether the failure is a 5xx: a backend problem, not the
+// user's config. The SDK already retries the transient subset (503, 429, IO
+// errors); a 5xx that still surfaces here fails open, since blocking a submit on
+// a backend blip isn't actionable and submit re-validates anyway.
+func serverError(err error) bool {
+	apiErr, ok := errors.AsType[*apierr.APIError](err)
+	return ok && apiErr.StatusCode >= 500
 }
 
 // formatConfigErrors renders the field errors as one message, one problem per

--- a/experimental/air/cmd/validateconfig.go
+++ b/experimental/air/cmd/validateconfig.go
@@ -1,0 +1,140 @@
+package aircmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/databricks/databricks-sdk-go"
+	"github.com/databricks/databricks-sdk-go/apierr"
+	"github.com/databricks/databricks-sdk-go/client"
+)
+
+// validateConfigPath is AiTrainingService's pre-flight: it checks a training
+// config server-side and returns the problems, without submitting. Called with a
+// raw client.Do because the SDK does not model AiTrainingService.
+const validateConfigPath = "/api/2.0/ai-training/config:validate"
+
+// configFieldError is one problem the server found, addressed to the config
+// field that caused it. Mirrors the proto FieldError.
+type configFieldError struct {
+	Path    string `json:"path"`
+	Message string `json:"message"`
+	Code    string `json:"code"`
+}
+
+type validateConfigResponse struct {
+	Errors []configFieldError `json:"errors"`
+}
+
+// preflightValidate checks the config against the backend before any upload, so
+// a bad config fails fast with the server's own field-level errors.
+//
+// It fails open: the endpoint is behind a SAFE flag and older workspaces do not
+// have it, so a disabled or missing endpoint skips the check and lets submission
+// proceed (where the config is validated again, authoritatively). Only a
+// populated error list — a config the server actively rejected — blocks.
+func preflightValidate(ctx context.Context, w *databricks.WorkspaceClient, cfg *runConfig) error {
+	apiClient, err := client.New(w.Config)
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	var resp validateConfigResponse
+	err = apiClient.Do(ctx, http.MethodPost, validateConfigPath, nil, nil, validateConfigRequest(cfg), &resp)
+	if err != nil {
+		if endpointUnavailable(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to validate config: %w", err)
+	}
+	if len(resp.Errors) == 0 {
+		return nil
+	}
+	return errors.New(formatConfigErrors(resp.Errors))
+}
+
+// validateConfigRequest builds the {task, run_options} body from the user's
+// config. It carries what the user wrote — the fields set only at submit time
+// (command_path, code_source_path) are absent, which the server treats as
+// optional; the pre-flight's job is the config-level rules. Absent optional
+// fields are omitted so the server doesn't validate values the user never set.
+func validateConfigRequest(cfg *runConfig) map[string]any {
+	compute := map[string]any{}
+	if cfg.Compute != nil {
+		compute["accelerator_type"] = cfg.Compute.AcceleratorType
+		compute["accelerator_count"] = cfg.Compute.NumAccelerators
+	}
+	task := map[string]any{
+		"experiment":  cfg.ExperimentName,
+		"deployments": []any{map[string]any{"compute": compute}},
+	}
+	putOpt(task, "mlflow_run", cfg.MLflowRunName)
+	putOpt(task, "mlflow_experiment_directory", cfg.MLflowExperimentDirectory)
+	if len(cfg.Parameters) > 0 {
+		task["parameters"] = cfg.Parameters
+	}
+
+	req := map[string]any{"task": task}
+	if runOptions := validateConfigRunOptions(cfg); len(runOptions) > 0 {
+		req["run_options"] = runOptions
+	}
+	return req
+}
+
+// validateConfigRunOptions gathers the run-level fields into run_options,
+// omitting any the user didn't set.
+func validateConfigRunOptions(cfg *runConfig) map[string]any {
+	runOptions := map[string]any{}
+	putOpt(runOptions, "max_retries", cfg.MaxRetries)
+	putOpt(runOptions, "timeout_minutes", cfg.TimeoutMinutes)
+	putOpt(runOptions, "idempotency_token", cfg.IdempotencyToken)
+	putOpt(runOptions, "usage_policy_name", cfg.UsagePolicyName)
+	putOpt(runOptions, "usage_policy_id", cfg.UsagePolicyID)
+	if len(cfg.EnvVariables) > 0 {
+		runOptions["env_variables"] = cfg.EnvVariables
+	}
+	if len(cfg.Secrets) > 0 {
+		runOptions["secrets"] = cfg.Secrets
+	}
+	return runOptions
+}
+
+// putOpt sets key to the pointer's value only when it is non-nil, so an unset
+// config field is left out of the request rather than sent as a zero value.
+func putOpt[T any](m map[string]any, key string, value *T) {
+	if value != nil {
+		m[key] = *value
+	}
+}
+
+// endpointUnavailable reports whether the failure means the endpoint isn't there
+// to answer — the flag is off, or the workspace predates it — as opposed to the
+// config being rejected. Those cases fail open.
+func endpointUnavailable(err error) bool {
+	var apiErr *apierr.APIError
+	if errors.As(err, &apiErr) {
+		return apiErr.ErrorCode == "FEATURE_DISABLED" ||
+			apiErr.StatusCode == http.StatusNotFound ||
+			apiErr.StatusCode == http.StatusNotImplemented
+	}
+	return false
+}
+
+// formatConfigErrors renders the field errors as one message, one problem per
+// line, each pointing at the config field the user wrote.
+func formatConfigErrors(fieldErrors []configFieldError) string {
+	var b strings.Builder
+	b.WriteString("config validation failed:")
+	for _, e := range fieldErrors {
+		b.WriteString("\n  ")
+		if e.Path != "" {
+			b.WriteString(e.Path)
+			b.WriteString(": ")
+		}
+		b.WriteString(e.Message)
+	}
+	return b.String()
+}

--- a/experimental/air/cmd/validateconfig.go
+++ b/experimental/air/cmd/validateconfig.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/databricks/cli/libs/env"
 	"github.com/databricks/databricks-sdk-go"
 	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/databricks-sdk-go/client"
@@ -37,18 +36,14 @@ type validateConfigResponse struct {
 // have it, so a disabled or missing endpoint skips the check and lets submission
 // proceed (where the config is validated again, authoritatively). Only a
 // populated error list — a config the server actively rejected — blocks.
-func preflightValidate(ctx context.Context, w *databricks.WorkspaceClient, cfg *runConfig) error {
+func preflightValidate(ctx context.Context, w *databricks.WorkspaceClient, cfg *runConfig, commandPath string) error {
 	apiClient, err := client.New(w.Config)
 	if err != nil {
 		return fmt.Errorf("failed to create API client: %w", err)
 	}
 
 	var resp validateConfigResponse
-	headers := map[string]string(nil)
-	if id := env.Get(ctx, "AIR_LITESWAP_ID"); id != "" {
-		headers = map[string]string{"x-databricks-traffic-id": "testenv://liteswap/" + id}
-	}
-	err = apiClient.Do(ctx, http.MethodPost, validateConfigPath, headers, nil, validateConfigRequest(cfg), &resp)
+	err = apiClient.Do(ctx, http.MethodPost, validateConfigPath, nil, nil, validateConfigRequest(cfg, commandPath), &resp)
 	if err != nil {
 		if endpointUnavailable(err) {
 			return nil
@@ -61,12 +56,11 @@ func preflightValidate(ctx context.Context, w *databricks.WorkspaceClient, cfg *
 	return errors.New(formatConfigErrors(resp.Errors))
 }
 
-// validateConfigRequest builds the {task, run_options} body from the user's
-// config. It carries what the user wrote — the fields set only at submit time
-// (command_path, code_source_path) are absent, which the server treats as
-// optional; the pre-flight's job is the config-level rules. Absent optional
-// fields are omitted so the server doesn't validate values the user never set.
-func validateConfigRequest(cfg *runConfig) map[string]any {
+// validateConfigRequest builds the {task, run_options} body from the user's config. commandPath is
+// the workspace path where the command script will be uploaded; the caller computes it before this
+// call so the server can validate the real path. `parameters` is intentionally omitted: it is
+// free-form nested hyperparameters uploaded as a YAML file at submit, not the proto's string map.
+func validateConfigRequest(cfg *runConfig, commandPath string) map[string]any {
 	compute := map[string]any{}
 	if cfg.Compute != nil {
 		compute["accelerator_type"] = cfg.Compute.AcceleratorType
@@ -74,13 +68,10 @@ func validateConfigRequest(cfg *runConfig) map[string]any {
 	}
 	task := map[string]any{
 		"experiment":  cfg.ExperimentName,
-		"deployments": []any{map[string]any{"compute": compute}},
+		"deployments": []any{map[string]any{"command_path": commandPath, "compute": compute}},
 	}
 	putOpt(task, "mlflow_run", cfg.MLflowRunName)
 	putOpt(task, "mlflow_experiment_directory", cfg.MLflowExperimentDirectory)
-	if len(cfg.Parameters) > 0 {
-		task["parameters"] = cfg.Parameters
-	}
 
 	req := map[string]any{"task": task}
 	if runOptions := validateConfigRunOptions(cfg); len(runOptions) > 0 {

--- a/experimental/air/cmd/validateconfig.go
+++ b/experimental/air/cmd/validateconfig.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/databricks/cli/libs/env"
 	"github.com/databricks/databricks-sdk-go"
 	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/databricks-sdk-go/client"
@@ -43,7 +44,11 @@ func preflightValidate(ctx context.Context, w *databricks.WorkspaceClient, cfg *
 	}
 
 	var resp validateConfigResponse
-	err = apiClient.Do(ctx, http.MethodPost, validateConfigPath, nil, nil, validateConfigRequest(cfg), &resp)
+	headers := map[string]string(nil)
+	if id := env.Get(ctx, "AIR_LITESWAP_ID"); id != "" {
+		headers = map[string]string{"x-databricks-traffic-id": "testenv://liteswap/" + id}
+	}
+	err = apiClient.Do(ctx, http.MethodPost, validateConfigPath, headers, nil, validateConfigRequest(cfg), &resp)
 	if err != nil {
 		if endpointUnavailable(err) {
 			return nil
@@ -114,13 +119,10 @@ func putOpt[T any](m map[string]any, key string, value *T) {
 // to answer — the flag is off, or the workspace predates it — as opposed to the
 // config being rejected. Those cases fail open.
 func endpointUnavailable(err error) bool {
-	var apiErr *apierr.APIError
-	if errors.As(err, &apiErr) {
-		return apiErr.ErrorCode == "FEATURE_DISABLED" ||
-			apiErr.StatusCode == http.StatusNotFound ||
-			apiErr.StatusCode == http.StatusNotImplemented
-	}
-	return false
+	apiErr, ok := errors.AsType[*apierr.APIError](err)
+	return ok && (apiErr.ErrorCode == "FEATURE_DISABLED" ||
+		apiErr.StatusCode == http.StatusNotFound ||
+		apiErr.StatusCode == http.StatusNotImplemented)
 }
 
 // formatConfigErrors renders the field errors as one message, one problem per

--- a/experimental/air/cmd/validateconfig_test.go
+++ b/experimental/air/cmd/validateconfig_test.go
@@ -1,0 +1,111 @@
+package aircmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func baseRunConfig() *runConfig {
+	return &runConfig{
+		ExperimentName: "llama-fine-tune",
+		Compute:        &computeConfig{NumAccelerators: 16, AcceleratorType: "GPU_8xH100"},
+	}
+}
+
+// validateServer serves one ValidateConfig response with the given status and
+// body, and records the request body it received.
+func validateServer(t *testing.T, status int, body string, gotReq *map[string]any) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == validateConfigPath {
+			if gotReq != nil {
+				_ = json.NewDecoder(r.Body).Decode(gotReq)
+			}
+			w.WriteHeader(status)
+			_, _ = w.Write([]byte(body))
+			return
+		}
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestPreflightValidatePasses(t *testing.T) {
+	srv := validateServer(t, http.StatusOK, `{}`, nil)
+	err := preflightValidate(t.Context(), newTestWorkspaceClient(t, srv.URL), baseRunConfig())
+	assert.NoError(t, err)
+}
+
+func TestPreflightValidateReportsErrors(t *testing.T) {
+	body := `{"errors":[
+		{"path":"experiment","message":"only letters, digits, hyphens, underscores","code":"DISALLOWED_CHARACTERS"},
+		{"path":"deployments[0].compute.accelerator_count","message":"must be a multiple of 8","code":"COUNT_NOT_MULTIPLE"}
+	]}`
+	srv := validateServer(t, http.StatusOK, body, nil)
+	err := preflightValidate(t.Context(), newTestWorkspaceClient(t, srv.URL), baseRunConfig())
+	require.Error(t, err)
+	// Every problem is surfaced, each pointing at its config field.
+	assert.Contains(t, err.Error(), "experiment: only letters")
+	assert.Contains(t, err.Error(), "deployments[0].compute.accelerator_count: must be a multiple of 8")
+}
+
+func TestPreflightValidateFailsOpenWhenDisabled(t *testing.T) {
+	// The endpoint is behind a SAFE flag; a disabled endpoint must not block the run.
+	srv := validateServer(t, http.StatusBadRequest,
+		`{"error_code":"FEATURE_DISABLED","message":"ValidateConfig is not yet enabled."}`, nil)
+	err := preflightValidate(t.Context(), newTestWorkspaceClient(t, srv.URL), baseRunConfig())
+	assert.NoError(t, err)
+}
+
+func TestPreflightValidateFailsOpenWhenNotFound(t *testing.T) {
+	// A workspace that predates the endpoint returns 404; skip and let submit proceed.
+	srv := validateServer(t, http.StatusNotFound, `{"error_code":"ENDPOINT_NOT_FOUND","message":"not found"}`, nil)
+	err := preflightValidate(t.Context(), newTestWorkspaceClient(t, srv.URL), baseRunConfig())
+	assert.NoError(t, err)
+}
+
+func TestValidateConfigRequestShape(t *testing.T) {
+	var gotReq map[string]any
+	srv := validateServer(t, http.StatusOK, `{}`, &gotReq)
+
+	cfg := baseRunConfig()
+	cfg.MaxRetries = intPtr(3)
+	cfg.EnvVariables = map[string]string{"HF_HOME": "/tmp/hf"}
+	err := preflightValidate(t.Context(), newTestWorkspaceClient(t, srv.URL), cfg)
+	require.NoError(t, err)
+
+	task := gotReq["task"].(map[string]any)
+	assert.Equal(t, "llama-fine-tune", task["experiment"])
+	deployment := task["deployments"].([]any)[0].(map[string]any)
+	compute := deployment["compute"].(map[string]any)
+	assert.Equal(t, "GPU_8xH100", compute["accelerator_type"])
+	assert.EqualValues(t, 16, compute["accelerator_count"])
+
+	runOptions := gotReq["run_options"].(map[string]any)
+	assert.EqualValues(t, 3, runOptions["max_retries"])
+	assert.Equal(t, map[string]any{"HF_HOME": "/tmp/hf"}, runOptions["env_variables"])
+}
+
+func TestValidateConfigRequestOmitsUnsetOptions(t *testing.T) {
+	// A minimal config carries no run_options and only the fields it set, so the
+	// server never validates values the user didn't provide.
+	var gotReq map[string]any
+	srv := validateServer(t, http.StatusOK, `{}`, &gotReq)
+
+	err := preflightValidate(t.Context(), newTestWorkspaceClient(t, srv.URL), baseRunConfig())
+	require.NoError(t, err)
+
+	_, hasRunOptions := gotReq["run_options"]
+	assert.False(t, hasRunOptions)
+	task := gotReq["task"].(map[string]any)
+	_, hasMlflowRun := task["mlflow_run"]
+	assert.False(t, hasMlflowRun)
+}
+
+func intPtr(v int) *int { return &v }

--- a/experimental/air/cmd/validateconfig_test.go
+++ b/experimental/air/cmd/validateconfig_test.go
@@ -70,6 +70,24 @@ func TestPreflightValidateFailsOpenWhenNotFound(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestPreflightValidateFailsOpenOnServerError(t *testing.T) {
+	// A 5xx is a backend problem, not the user's config; blocking a submit on it
+	// isn't actionable, and submit re-validates anyway.
+	srv := validateServer(t, http.StatusInternalServerError,
+		`{"error_code":"INTERNAL_ERROR","message":"backend blew up"}`, nil)
+	err := preflightValidate(t.Context(), newTestWorkspaceClient(t, srv.URL), baseRunConfig(), "/Workspace/Users/me/cmd.sh")
+	assert.NoError(t, err)
+}
+
+func TestPreflightValidateBlocksOnClientError(t *testing.T) {
+	// A 4xx other than the fail-open cases means the request itself was rejected
+	// (e.g. the proto hook flagged a missing required field); surface it.
+	srv := validateServer(t, http.StatusBadRequest,
+		`{"error_code":"INVALID_PARAMETER_VALUE","message":"command_path is required"}`, nil)
+	err := preflightValidate(t.Context(), newTestWorkspaceClient(t, srv.URL), baseRunConfig(), "/Workspace/Users/me/cmd.sh")
+	require.Error(t, err)
+}
+
 func TestValidateConfigRequestShape(t *testing.T) {
 	var gotReq map[string]any
 	srv := validateServer(t, http.StatusOK, `{}`, &gotReq)

--- a/experimental/air/cmd/validateconfig_test.go
+++ b/experimental/air/cmd/validateconfig_test.go
@@ -75,7 +75,7 @@ func TestValidateConfigRequestShape(t *testing.T) {
 	srv := validateServer(t, http.StatusOK, `{}`, &gotReq)
 
 	cfg := baseRunConfig()
-	cfg.MaxRetries = intPtr(3)
+	cfg.MaxRetries = new(3)
 	cfg.EnvVariables = map[string]string{"HF_HOME": "/tmp/hf"}
 	err := preflightValidate(t.Context(), newTestWorkspaceClient(t, srv.URL), cfg)
 	require.NoError(t, err)
@@ -107,5 +107,3 @@ func TestValidateConfigRequestOmitsUnsetOptions(t *testing.T) {
 	_, hasMlflowRun := task["mlflow_run"]
 	assert.False(t, hasMlflowRun)
 }
-
-func intPtr(v int) *int { return &v }

--- a/experimental/air/cmd/validateconfig_test.go
+++ b/experimental/air/cmd/validateconfig_test.go
@@ -38,7 +38,7 @@ func validateServer(t *testing.T, status int, body string, gotReq *map[string]an
 
 func TestPreflightValidatePasses(t *testing.T) {
 	srv := validateServer(t, http.StatusOK, `{}`, nil)
-	err := preflightValidate(t.Context(), newTestWorkspaceClient(t, srv.URL), baseRunConfig())
+	err := preflightValidate(t.Context(), newTestWorkspaceClient(t, srv.URL), baseRunConfig(), "/Workspace/Users/me/cmd.sh")
 	assert.NoError(t, err)
 }
 
@@ -48,7 +48,7 @@ func TestPreflightValidateReportsErrors(t *testing.T) {
 		{"path":"deployments[0].compute.accelerator_count","message":"must be a multiple of 8","code":"COUNT_NOT_MULTIPLE"}
 	]}`
 	srv := validateServer(t, http.StatusOK, body, nil)
-	err := preflightValidate(t.Context(), newTestWorkspaceClient(t, srv.URL), baseRunConfig())
+	err := preflightValidate(t.Context(), newTestWorkspaceClient(t, srv.URL), baseRunConfig(), "/Workspace/Users/me/cmd.sh")
 	require.Error(t, err)
 	// Every problem is surfaced, each pointing at its config field.
 	assert.Contains(t, err.Error(), "experiment: only letters")
@@ -59,14 +59,14 @@ func TestPreflightValidateFailsOpenWhenDisabled(t *testing.T) {
 	// The endpoint is behind a SAFE flag; a disabled endpoint must not block the run.
 	srv := validateServer(t, http.StatusBadRequest,
 		`{"error_code":"FEATURE_DISABLED","message":"ValidateConfig is not yet enabled."}`, nil)
-	err := preflightValidate(t.Context(), newTestWorkspaceClient(t, srv.URL), baseRunConfig())
+	err := preflightValidate(t.Context(), newTestWorkspaceClient(t, srv.URL), baseRunConfig(), "/Workspace/Users/me/cmd.sh")
 	assert.NoError(t, err)
 }
 
 func TestPreflightValidateFailsOpenWhenNotFound(t *testing.T) {
 	// A workspace that predates the endpoint returns 404; skip and let submit proceed.
 	srv := validateServer(t, http.StatusNotFound, `{"error_code":"ENDPOINT_NOT_FOUND","message":"not found"}`, nil)
-	err := preflightValidate(t.Context(), newTestWorkspaceClient(t, srv.URL), baseRunConfig())
+	err := preflightValidate(t.Context(), newTestWorkspaceClient(t, srv.URL), baseRunConfig(), "/Workspace/Users/me/cmd.sh")
 	assert.NoError(t, err)
 }
 
@@ -77,7 +77,7 @@ func TestValidateConfigRequestShape(t *testing.T) {
 	cfg := baseRunConfig()
 	cfg.MaxRetries = new(3)
 	cfg.EnvVariables = map[string]string{"HF_HOME": "/tmp/hf"}
-	err := preflightValidate(t.Context(), newTestWorkspaceClient(t, srv.URL), cfg)
+	err := preflightValidate(t.Context(), newTestWorkspaceClient(t, srv.URL), cfg, "/Workspace/Users/me/cmd.sh")
 	require.NoError(t, err)
 
 	task := gotReq["task"].(map[string]any)
@@ -98,7 +98,7 @@ func TestValidateConfigRequestOmitsUnsetOptions(t *testing.T) {
 	var gotReq map[string]any
 	srv := validateServer(t, http.StatusOK, `{}`, &gotReq)
 
-	err := preflightValidate(t.Context(), newTestWorkspaceClient(t, srv.URL), baseRunConfig())
+	err := preflightValidate(t.Context(), newTestWorkspaceClient(t, srv.URL), baseRunConfig(), "/Workspace/Users/me/cmd.sh")
 	require.NoError(t, err)
 
 	_, hasRunOptions := gotReq["run_options"]


### PR DESCRIPTION
## What & why

`air run` now pre-flights the config against the backend `ValidateConfig` RPC before uploading anything, so a bad config fails fast with the server's field-level errors instead of after the code snapshot is packaged and uploaded. The same rules back the submit gate, so the pre-flight can't disagree with what submission enforces.

(See 1DD: https://docs.google.com/document/d/1xWKHisVk9YbsnmWyHE1J5OOTZTIHx2DSiyrkuTNM0NA/edit?tab=t.0#heading=h.culzh2kyug09 )

## How do you know it works?

`validateconfig_test.go` covers valid→pass, errors→blocking message (each pointing at its config field), fail-open on both `FEATURE_DISABLED` and 404, and the request-shape mapping (incl. omitting unset options). The submit acceptance tests (`run-submit`, `run-submit-deps`) exercise the pre-flight end-to-end: it fires, is served, and submission proceeds. `go test ./experimental/air/...` and the air acceptance tests pass.

Manual verification (tested with the corresponding backend in liteswap pod): 
<img width="1446" height="963" alt="Screenshot 2026-08-11 at 12 00 38 PM" src="https://github.com/user-attachments/assets/f09dafed-1181-430c-afa9-e664d04e85dd" />


## How to review

- `validateconfig.go`: `preflightValidate` builds the `{task, run_options}` body from `runConfig`, POSTs to `/api/2.0/ai-training/config:validate` (raw `client.Do`, since the SDK doesn't model AiTrainingService, matching `aitraining.go`), and renders any `FieldError`s.
- the endpoint is behind a SAFE flag (default off) and older workspaces lack it, so `FEATURE_DISABLED` / 404 / 501 skip the check and let submission proceed and only a populated error list blocks.
- `runsubmit.go` the call is the first thing `submitWorkload` does, before token/policy resolution and any upload.
- `--dry-run` is unchanged since it stays local-only and needs no workspace