### PR TITLE
environments: add telemetry to setup-local

### DIFF
--- a/cmd/environments/output.go
+++ b/cmd/environments/output.go
@@ -19,6 +19,10 @@ import (
 // Result (with the canonical phase list and error object) on every path,
 // including failures, so no nil guard is needed here.
 func renderResult(ctx context.Context, cmd *cobra.Command, res *libslocalenv.Result, pipelineErr error) error {
+	// Emit one telemetry event per real run (success, failure, or cancel);
+	// dry-run runs are not recorded. Best-effort: never affects output.
+	logSetupLocalEvent(ctx, res)
+
 	if root.OutputType(cmd) == flags.OutputJSON {
 		if err := cmdio.Render(ctx, res); err != nil {
 			return err

--- a/cmd/environments/telemetry.go
+++ b/cmd/environments/telemetry.go
@@ -1,0 +1,135 @@
+package environments
+
+import (
+	"context"
+
+	libslocalenv "github.com/databricks/cli/libs/localenv"
+	"github.com/databricks/cli/libs/telemetry"
+	"github.com/databricks/cli/libs/telemetry/protos"
+)
+
+// logSetupLocalEvent buffers a setup-local telemetry event for a real run;
+// cmd/root uploads it at exit. It is a no-op for dry-run (buildSetupLocalEvent
+// returns nil), so callers do not need to guard on res.DryRun.
+func logSetupLocalEvent(ctx context.Context, res *libslocalenv.Result) {
+	event := buildSetupLocalEvent(res)
+	if event == nil {
+		return
+	}
+	telemetry.Log(ctx, protos.DatabricksCliLog{SetupLocalEvent: event})
+}
+
+// buildSetupLocalEvent maps a pipeline Result to the telemetry event, or returns
+// nil when there is nothing to report (nil result, or a --dry-run run, which is
+// not recorded). The Result is already PII-safe: it backs the --output json
+// contract, so only abstracted fields (source, mode, env key, error class) are
+// read here — never cluster names/ids or paths.
+func buildSetupLocalEvent(res *libslocalenv.Result) *protos.SetupLocalEvent {
+	if res == nil || res.DryRun {
+		return nil
+	}
+	event := &protos.SetupLocalEvent{
+		Success:       res.OK,
+		Mode:          modeType(res.Mode),
+		Greenfield:    res.Greenfield,
+		ComputeSource: protos.SetupLocalComputeSourceUnspecified,
+	}
+	if res.Compute != nil {
+		event.ComputeSource = computeSourceType(res.Compute.Source)
+		event.EnvKey = res.Compute.EnvKey
+	}
+	if res.Error != nil {
+		event.ErrorCode = errorCodeType(res.Error.Code)
+		event.FailurePhase = phaseType(res.Error.FailurePhase)
+		event.DiskMutated = res.Error.DiskMutated
+	}
+	return event
+}
+
+// computeSourceType maps a resolved ComputeInfo.Source to its telemetry enum.
+func computeSourceType(source string) protos.SetupLocalComputeSource {
+	switch source {
+	case "cluster":
+		return protos.SetupLocalComputeSourceCluster
+	case "serverless":
+		return protos.SetupLocalComputeSourceServerless
+	case "job":
+		return protos.SetupLocalComputeSourceJob
+	case "bundle":
+		return protos.SetupLocalComputeSourceBundle
+	default:
+		return protos.SetupLocalComputeSourceUnspecified
+	}
+}
+
+// modeType maps the Result.Mode string (Mode.String()) to its telemetry enum.
+func modeType(mode string) protos.SetupLocalMode {
+	switch mode {
+	case libslocalenv.ModeDefault.String():
+		return protos.SetupLocalModeDefault
+	case libslocalenv.ModeConstraintsOnly.String():
+		return protos.SetupLocalModeConstraintsOnly
+	default:
+		return protos.SetupLocalModeUnspecified
+	}
+}
+
+// errorCodeType maps a pipeline ErrorCode to its telemetry enum. Every
+// localenv.ErrorCode must have a case here; TestErrorCodeCoversLocalenv fails if
+// one is missing, guarding against silently logging a new code as UNSPECIFIED.
+func errorCodeType(code libslocalenv.ErrorCode) protos.SetupLocalErrorCode {
+	switch code {
+	case libslocalenv.ErrUsage:
+		return protos.SetupLocalErrorCodeUsage
+	case libslocalenv.ErrManagerUnsupported:
+		return protos.SetupLocalErrorCodeManagerUnsupported
+	case libslocalenv.ErrNotWritable:
+		return protos.SetupLocalErrorCodeNotWritable
+	case libslocalenv.ErrUvMissing:
+		return protos.SetupLocalErrorCodeUvMissing
+	case libslocalenv.ErrNoTarget:
+		return protos.SetupLocalErrorCodeNoTarget
+	case libslocalenv.ErrResolve:
+		return protos.SetupLocalErrorCodeResolve
+	case libslocalenv.ErrEnvUnsupported:
+		return protos.SetupLocalErrorCodeEnvUnsupported
+	case libslocalenv.ErrFetch:
+		return protos.SetupLocalErrorCodeFetch
+	case libslocalenv.ErrWrite:
+		return protos.SetupLocalErrorCodeWrite
+	case libslocalenv.ErrMerge:
+		return protos.SetupLocalErrorCodeMerge
+	case libslocalenv.ErrPythonInstall:
+		return protos.SetupLocalErrorCodePythonInstall
+	case libslocalenv.ErrProvision:
+		return protos.SetupLocalErrorCodeProvision
+	case libslocalenv.ErrValidate:
+		return protos.SetupLocalErrorCodeValidate
+	case libslocalenv.ErrCanceled:
+		return protos.SetupLocalErrorCodeCanceled
+	default:
+		return protos.SetupLocalErrorCodeUnspecified
+	}
+}
+
+// phaseType maps a pipeline PhaseName to its telemetry enum. Every
+// localenv.PhaseName must have a case here; TestPhaseCoversLocalenv fails if one
+// is missing.
+func phaseType(phase libslocalenv.PhaseName) protos.SetupLocalPhase {
+	switch phase {
+	case libslocalenv.PhasePreflight:
+		return protos.SetupLocalPhasePreflight
+	case libslocalenv.PhaseResolve:
+		return protos.SetupLocalPhaseResolve
+	case libslocalenv.PhaseFetch:
+		return protos.SetupLocalPhaseFetch
+	case libslocalenv.PhaseMerge:
+		return protos.SetupLocalPhaseMerge
+	case libslocalenv.PhaseProvision:
+		return protos.SetupLocalPhaseProvision
+	case libslocalenv.PhaseValidate:
+		return protos.SetupLocalPhaseValidate
+	default:
+		return protos.SetupLocalPhaseUnspecified
+	}
+}

--- a/cmd/environments/telemetry.go
+++ b/cmd/environments/telemetry.go
@@ -74,9 +74,11 @@ func modeType(mode string) protos.SetupLocalMode {
 	}
 }
 
-// errorCodeType maps a pipeline ErrorCode to its telemetry enum. Every
-// localenv.ErrorCode must have a case here; TestErrorCodeCoversLocalenv fails if
-// one is missing, guarding against silently logging a new code as UNSPECIFIED.
+// errorCodeType maps a pipeline ErrorCode to its telemetry enum. The switch has
+// no default, so the exhaustive linter fails the build if a new
+// localenv.ErrorCode is added without a case here, guarding against silently
+// logging a new code as UNSPECIFIED. The trailing return handles a value outside
+// the declared set (a newer localenv than this mapping).
 func errorCodeType(code libslocalenv.ErrorCode) protos.SetupLocalErrorCode {
 	switch code {
 	case libslocalenv.ErrUsage:
@@ -107,14 +109,13 @@ func errorCodeType(code libslocalenv.ErrorCode) protos.SetupLocalErrorCode {
 		return protos.SetupLocalErrorCodeValidate
 	case libslocalenv.ErrCanceled:
 		return protos.SetupLocalErrorCodeCanceled
-	default:
-		return protos.SetupLocalErrorCodeUnspecified
 	}
+	return protos.SetupLocalErrorCodeUnspecified
 }
 
-// phaseType maps a pipeline PhaseName to its telemetry enum. Every
-// localenv.PhaseName must have a case here; TestPhaseCoversLocalenv fails if one
-// is missing.
+// phaseType maps a pipeline PhaseName to its telemetry enum. As with
+// errorCodeType, the switch has no default so the exhaustive linter fails the
+// build if a new localenv.PhaseName is added without a case here.
 func phaseType(phase libslocalenv.PhaseName) protos.SetupLocalPhase {
 	switch phase {
 	case libslocalenv.PhasePreflight:
@@ -129,7 +130,6 @@ func phaseType(phase libslocalenv.PhaseName) protos.SetupLocalPhase {
 		return protos.SetupLocalPhaseProvision
 	case libslocalenv.PhaseValidate:
 		return protos.SetupLocalPhaseValidate
-	default:
-		return protos.SetupLocalPhaseUnspecified
 	}
+	return protos.SetupLocalPhaseUnspecified
 }

--- a/cmd/environments/telemetry_test.go
+++ b/cmd/environments/telemetry_test.go
@@ -77,9 +77,11 @@ func TestBuildSetupLocalEvent(t *testing.T) {
 	})
 }
 
-// TestErrorCodeCoversLocalenv fails when a new localenv.ErrorCode is added
-// without a matching telemetry enum in errorCodeType. Keep this list in sync
-// with the const block in libs/localenv/result.go.
+// TestErrorCodeCoversLocalenv asserts every localenv.ErrorCode maps to a
+// non-unspecified telemetry enum. Completeness of the switch itself is enforced
+// by the exhaustive linter (errorCodeType has no default); this test additionally
+// catches a case that maps to UNSPECIFIED by mistake. Keep this list in sync with
+// the const block in libs/localenv/result.go.
 func TestErrorCodeCoversLocalenv(t *testing.T) {
 	all := []libslocalenv.ErrorCode{
 		libslocalenv.ErrUsage,
@@ -104,8 +106,10 @@ func TestErrorCodeCoversLocalenv(t *testing.T) {
 	}
 }
 
-// TestPhaseCoversLocalenv fails when a new localenv.PhaseName is added without a
-// matching telemetry enum in phaseType.
+// TestPhaseCoversLocalenv asserts every localenv.PhaseName maps to a
+// non-unspecified telemetry enum. As with TestErrorCodeCoversLocalenv, switch
+// completeness is enforced by the exhaustive linter; this guards against a case
+// mapping to UNSPECIFIED by mistake.
 func TestPhaseCoversLocalenv(t *testing.T) {
 	all := []libslocalenv.PhaseName{
 		libslocalenv.PhasePreflight,

--- a/cmd/environments/telemetry_test.go
+++ b/cmd/environments/telemetry_test.go
@@ -1,0 +1,72 @@
+package environments
+
+import (
+	"testing"
+
+	libslocalenv "github.com/databricks/cli/libs/localenv"
+	"github.com/databricks/cli/libs/telemetry/protos"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildSetupLocalEvent(t *testing.T) {
+	t.Run("dry-run emits no event", func(t *testing.T) {
+		res := &libslocalenv.Result{DryRun: true, OK: true}
+		assert.Nil(t, buildSetupLocalEvent(res))
+	})
+
+	t.Run("nil result emits no event", func(t *testing.T) {
+		assert.Nil(t, buildSetupLocalEvent(nil))
+	})
+
+	t.Run("success run maps fields", func(t *testing.T) {
+		res := &libslocalenv.Result{
+			OK:         true,
+			Mode:       libslocalenv.ModeDefault.String(),
+			Greenfield: true,
+			Compute:    &libslocalenv.ComputeInfo{Source: "serverless", EnvKey: "serverless/serverless-v5"},
+		}
+		got := buildSetupLocalEvent(res)
+		assert.Equal(t, &protos.SetupLocalEvent{
+			Success:       true,
+			ComputeSource: protos.SetupLocalComputeSourceServerless,
+			Mode:          protos.SetupLocalModeDefault,
+			Greenfield:    true,
+			EnvKey:        "serverless/serverless-v5",
+		}, got)
+	})
+
+	t.Run("failure run maps error code, phase, diskMutated", func(t *testing.T) {
+		res := &libslocalenv.Result{
+			OK:      false,
+			Mode:    libslocalenv.ModeConstraintsOnly.String(),
+			Compute: &libslocalenv.ComputeInfo{Source: "cluster", EnvKey: "dbr/16.4"},
+			Error: &libslocalenv.PipelineError{
+				Code:         libslocalenv.ErrProvision,
+				FailurePhase: libslocalenv.PhaseProvision,
+				DiskMutated:  true,
+			},
+		}
+		got := buildSetupLocalEvent(res)
+		assert.Equal(t, &protos.SetupLocalEvent{
+			Success:       false,
+			ComputeSource: protos.SetupLocalComputeSourceCluster,
+			Mode:          protos.SetupLocalModeConstraintsOnly,
+			EnvKey:        "dbr/16.4",
+			ErrorCode:     protos.SetupLocalErrorCodeProvision,
+			FailurePhase:  protos.SetupLocalPhaseProvision,
+			DiskMutated:   true,
+		}, got)
+	})
+
+	t.Run("nil compute leaves source and envKey empty", func(t *testing.T) {
+		res := &libslocalenv.Result{
+			OK:    false,
+			Mode:  libslocalenv.ModeDefault.String(),
+			Error: &libslocalenv.PipelineError{Code: libslocalenv.ErrNoTarget, FailurePhase: libslocalenv.PhaseResolve},
+		}
+		got := buildSetupLocalEvent(res)
+		assert.Equal(t, protos.SetupLocalComputeSourceUnspecified, got.ComputeSource)
+		assert.Empty(t, got.EnvKey)
+		assert.Equal(t, protos.SetupLocalErrorCodeNoTarget, got.ErrorCode)
+	})
+}

--- a/cmd/environments/telemetry_test.go
+++ b/cmd/environments/telemetry_test.go
@@ -1,11 +1,17 @@
 package environments
 
 import (
+	"encoding/json"
 	"testing"
 
+	"github.com/databricks/cli/libs/cmdctx"
 	libslocalenv "github.com/databricks/cli/libs/localenv"
+	"github.com/databricks/cli/libs/telemetry"
 	"github.com/databricks/cli/libs/telemetry/protos"
+	"github.com/databricks/cli/libs/testserver"
+	"github.com/databricks/databricks-sdk-go/config"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBuildSetupLocalEvent(t *testing.T) {
@@ -114,4 +120,52 @@ func TestPhaseCoversLocalenv(t *testing.T) {
 			"phase %q has no telemetry enum: add a case to phaseType and a value to "+
 				"SetupLocalPhase (setup_local.go + universe proto)", phase)
 	}
+}
+
+func TestLogSetupLocalEventRoundTrip(t *testing.T) {
+	t.Run("real run uploads one setup_local_event", func(t *testing.T) {
+		server := testserver.New(t)
+		t.Cleanup(server.Close)
+
+		var bodies []telemetry.RequestBody
+		server.Handle("POST", "/telemetry-ext", func(req testserver.Request) any {
+			var body telemetry.RequestBody
+			require.NoError(t, json.Unmarshal(req.Body, &body))
+			bodies = append(bodies, body)
+			return telemetry.ResponseBody{NumProtoSuccess: int64(len(body.ProtoLogs))}
+		})
+
+		ctx := telemetry.WithNewLogger(t.Context())
+		logSetupLocalEvent(ctx, &libslocalenv.Result{
+			OK:      true,
+			Mode:    libslocalenv.ModeDefault.String(),
+			Compute: &libslocalenv.ComputeInfo{Source: "serverless", EnvKey: "serverless/serverless-v5"},
+		})
+
+		ctx = cmdctx.SetConfigUsed(ctx, &config.Config{Host: server.URL, Token: "token"})
+		require.NoError(t, telemetry.Upload(ctx, protos.ExecutionContext{}))
+
+		require.Len(t, bodies, 1)
+		require.Len(t, bodies[0].ProtoLogs, 1)
+		assert.Contains(t, bodies[0].ProtoLogs[0], `"setup_local_event"`)
+		assert.Contains(t, bodies[0].ProtoLogs[0], `"env_key":"serverless/serverless-v5"`)
+	})
+
+	t.Run("dry-run buffers nothing to upload", func(t *testing.T) {
+		called := false
+		server := testserver.New(t)
+		t.Cleanup(server.Close)
+		server.Handle("POST", "/telemetry-ext", func(req testserver.Request) any {
+			called = true
+			return telemetry.ResponseBody{}
+		})
+
+		ctx := telemetry.WithNewLogger(t.Context())
+		logSetupLocalEvent(ctx, &libslocalenv.Result{DryRun: true, OK: true})
+
+		ctx = cmdctx.SetConfigUsed(ctx, &config.Config{Host: server.URL, Token: "token"})
+		// Upload no-ops when the buffer is empty, so the endpoint is never hit.
+		require.NoError(t, telemetry.Upload(ctx, protos.ExecutionContext{}))
+		assert.False(t, called, "dry-run must not upload any telemetry")
+	})
 }

--- a/cmd/environments/telemetry_test.go
+++ b/cmd/environments/telemetry_test.go
@@ -70,3 +70,48 @@ func TestBuildSetupLocalEvent(t *testing.T) {
 		assert.Equal(t, protos.SetupLocalErrorCodeNoTarget, got.ErrorCode)
 	})
 }
+
+// TestErrorCodeCoversLocalenv fails when a new localenv.ErrorCode is added
+// without a matching telemetry enum in errorCodeType. Keep this list in sync
+// with the const block in libs/localenv/result.go.
+func TestErrorCodeCoversLocalenv(t *testing.T) {
+	all := []libslocalenv.ErrorCode{
+		libslocalenv.ErrUsage,
+		libslocalenv.ErrManagerUnsupported,
+		libslocalenv.ErrNotWritable,
+		libslocalenv.ErrUvMissing,
+		libslocalenv.ErrNoTarget,
+		libslocalenv.ErrResolve,
+		libslocalenv.ErrEnvUnsupported,
+		libslocalenv.ErrFetch,
+		libslocalenv.ErrWrite,
+		libslocalenv.ErrMerge,
+		libslocalenv.ErrPythonInstall,
+		libslocalenv.ErrProvision,
+		libslocalenv.ErrValidate,
+		libslocalenv.ErrCanceled,
+	}
+	for _, code := range all {
+		assert.NotEqualf(t, protos.SetupLocalErrorCodeUnspecified, errorCodeType(code),
+			"error code %q has no telemetry enum: add a case to errorCodeType and a "+
+				"value to SetupLocalErrorCode (setup_local.go + universe proto)", code)
+	}
+}
+
+// TestPhaseCoversLocalenv fails when a new localenv.PhaseName is added without a
+// matching telemetry enum in phaseType.
+func TestPhaseCoversLocalenv(t *testing.T) {
+	all := []libslocalenv.PhaseName{
+		libslocalenv.PhasePreflight,
+		libslocalenv.PhaseResolve,
+		libslocalenv.PhaseFetch,
+		libslocalenv.PhaseMerge,
+		libslocalenv.PhaseProvision,
+		libslocalenv.PhaseValidate,
+	}
+	for _, phase := range all {
+		assert.NotEqualf(t, protos.SetupLocalPhaseUnspecified, phaseType(phase),
+			"phase %q has no telemetry enum: add a case to phaseType and a value to "+
+				"SetupLocalPhase (setup_local.go + universe proto)", phase)
+	}
+}

--- a/libs/telemetry/protos/frontend_log.go
+++ b/libs/telemetry/protos/frontend_log.go
@@ -22,4 +22,5 @@ type DatabricksCliLog struct {
 	SshTunnelEvent              *SshTunnelEvent              `json:"ssh_tunnel_event,omitempty"`
 	BundleConfigRemoteSyncEvent *BundleConfigRemoteSyncEvent `json:"bundle_config_remote_sync_event,omitempty"`
 	AitoolsInstallEvent         *AitoolsInstallEvent         `json:"aitools_install_event,omitempty"`
+	SetupLocalEvent             *SetupLocalEvent             `json:"setup_local_event,omitempty"`
 }

--- a/libs/telemetry/protos/setup_local.go
+++ b/libs/telemetry/protos/setup_local.go
@@ -51,12 +51,12 @@ type SetupLocalPhase string
 
 const (
 	SetupLocalPhaseUnspecified SetupLocalPhase = "TYPE_UNSPECIFIED"
-	SetupLocalPhasePreflight   SetupLocalPhase = "preflight"
-	SetupLocalPhaseResolve     SetupLocalPhase = "resolve"
-	SetupLocalPhaseFetch       SetupLocalPhase = "fetch"
-	SetupLocalPhaseMerge       SetupLocalPhase = "merge"
-	SetupLocalPhaseProvision   SetupLocalPhase = "provision"
-	SetupLocalPhaseValidate    SetupLocalPhase = "validate"
+	SetupLocalPhasePreflight   SetupLocalPhase = "PREFLIGHT"
+	SetupLocalPhaseResolve     SetupLocalPhase = "RESOLVE"
+	SetupLocalPhaseFetch       SetupLocalPhase = "FETCH"
+	SetupLocalPhaseMerge       SetupLocalPhase = "MERGE"
+	SetupLocalPhaseProvision   SetupLocalPhase = "PROVISION"
+	SetupLocalPhaseValidate    SetupLocalPhase = "VALIDATE"
 )
 
 // SetupLocalEvent is emitted on every real (non-dry-run) execution of the

--- a/libs/telemetry/protos/setup_local.go
+++ b/libs/telemetry/protos/setup_local.go
@@ -1,0 +1,92 @@
+package protos
+
+// SetupLocalComputeSource mirrors SetupLocalComputeSource.Type in the
+// databricks_cli lumberjack proto. Unspecified absorbs a source a newer CLI
+// knows about but the server proto does not yet.
+type SetupLocalComputeSource string
+
+const (
+	SetupLocalComputeSourceUnspecified SetupLocalComputeSource = "TYPE_UNSPECIFIED"
+	SetupLocalComputeSourceCluster     SetupLocalComputeSource = "CLUSTER"
+	SetupLocalComputeSourceServerless  SetupLocalComputeSource = "SERVERLESS"
+	SetupLocalComputeSourceJob         SetupLocalComputeSource = "JOB"
+	SetupLocalComputeSourceBundle      SetupLocalComputeSource = "BUNDLE"
+)
+
+// SetupLocalMode mirrors SetupLocalMode.Type in the databricks_cli lumberjack proto.
+type SetupLocalMode string
+
+const (
+	SetupLocalModeUnspecified     SetupLocalMode = "TYPE_UNSPECIFIED"
+	SetupLocalModeDefault         SetupLocalMode = "DEFAULT"
+	SetupLocalModeConstraintsOnly SetupLocalMode = "CONSTRAINTS_ONLY"
+)
+
+// SetupLocalErrorCode mirrors SetupLocalErrorCode.Type in the databricks_cli
+// lumberjack proto. It carries the pipeline's stable failure class on a failed
+// run and is empty on success.
+type SetupLocalErrorCode string
+
+const (
+	SetupLocalErrorCodeUnspecified        SetupLocalErrorCode = "TYPE_UNSPECIFIED"
+	SetupLocalErrorCodeUsage              SetupLocalErrorCode = "E_USAGE"
+	SetupLocalErrorCodeManagerUnsupported SetupLocalErrorCode = "E_MANAGER_UNSUPPORTED"
+	SetupLocalErrorCodeNotWritable        SetupLocalErrorCode = "E_NOT_WRITABLE"
+	SetupLocalErrorCodeUvMissing          SetupLocalErrorCode = "E_UV_MISSING"
+	SetupLocalErrorCodeNoTarget           SetupLocalErrorCode = "E_NO_TARGET"
+	SetupLocalErrorCodeResolve            SetupLocalErrorCode = "E_RESOLVE"
+	SetupLocalErrorCodeEnvUnsupported     SetupLocalErrorCode = "E_ENV_UNSUPPORTED"
+	SetupLocalErrorCodeFetch              SetupLocalErrorCode = "E_FETCH"
+	SetupLocalErrorCodeWrite              SetupLocalErrorCode = "E_WRITE"
+	SetupLocalErrorCodeMerge              SetupLocalErrorCode = "E_MERGE"
+	SetupLocalErrorCodePythonInstall      SetupLocalErrorCode = "E_PYTHON_INSTALL"
+	SetupLocalErrorCodeProvision          SetupLocalErrorCode = "E_PROVISION"
+	SetupLocalErrorCodeValidate           SetupLocalErrorCode = "E_VALIDATE"
+	SetupLocalErrorCodeCanceled           SetupLocalErrorCode = "E_CANCELED"
+)
+
+// SetupLocalPhase mirrors SetupLocalPhase.Type in the databricks_cli lumberjack
+// proto. On a failed run it records which phase failed; empty on success.
+type SetupLocalPhase string
+
+const (
+	SetupLocalPhaseUnspecified SetupLocalPhase = "TYPE_UNSPECIFIED"
+	SetupLocalPhasePreflight   SetupLocalPhase = "preflight"
+	SetupLocalPhaseResolve     SetupLocalPhase = "resolve"
+	SetupLocalPhaseFetch       SetupLocalPhase = "fetch"
+	SetupLocalPhaseMerge       SetupLocalPhase = "merge"
+	SetupLocalPhaseProvision   SetupLocalPhase = "provision"
+	SetupLocalPhaseValidate    SetupLocalPhase = "validate"
+)
+
+// SetupLocalEvent is emitted on every real (non-dry-run) execution of the
+// `databricks environments setup-local` command.
+type SetupLocalEvent struct {
+	// Whether the run completed successfully. Not omitempty: a genuine false
+	// must be distinguishable from an older CLI that did not report the field.
+	Success bool `json:"success"`
+
+	// Which precedence source supplied the compute target.
+	ComputeSource SetupLocalComputeSource `json:"compute_source,omitempty"`
+
+	// Provisioning mode: default or constraints-only.
+	Mode SetupLocalMode `json:"mode,omitempty"`
+
+	// Whether pyproject.toml was created fresh (true) vs an existing project
+	// updated (false). Not omitempty for the same reason as Success.
+	Greenfield bool `json:"greenfield"`
+
+	// Published constraint catalog key, e.g. "dbr/16.4" or
+	// "serverless/serverless-v5". Not PII.
+	EnvKey string `json:"env_key,omitempty"`
+
+	// Stable failure class on a failed run; empty on success.
+	ErrorCode SetupLocalErrorCode `json:"error_code,omitempty"`
+
+	// Phase that failed on a failed run; empty on success.
+	FailurePhase SetupLocalPhase `json:"failure_phase,omitempty"`
+
+	// Whether a failure left the project's pyproject.toml partially written.
+	// Not omitempty so false is reported explicitly.
+	DiskMutated bool `json:"disk_mutated"`
+}


### PR DESCRIPTION
## Summary

Adds client-side telemetry to the (hidden/experimental) `databricks environments setup-local` command. One event is emitted per **real** (non-dry-run) run, reusing the existing `telemetry.Log` → upload-at-exit machinery (no new upload path).

The new `SetupLocalEvent` captures enough to answer three questions:
- **Adoption** — `success` (headline success-rate).
- **Reliability** — `error_code`, `failure_phase`, `disk_mutated` (what breaks, where, and whether a failure left pyproject.toml half-written).
- **Feature usage** — `compute_source` (cluster/serverless/job/bundle), `mode` (default/constraints-only), `greenfield`, and `env_key` (the published catalog key, e.g. `dbr/16.4`).

Total duration and exit code are already carried by `ExecutionContext`, so they are not duplicated here.

## Design notes

- **PII-safe:** only abstracted enums plus `env_key` leave the machine. Cluster ids/names, paths, and error message text are never read.
- **Best-effort:** `telemetry.Log` cannot fail the command; the emit does not touch `renderResult`'s output or return value.
- Enums use string constants with a `TYPE_UNSPECIFIED` fallback (matching the `aitools` pattern) so a newer CLI never drops an event an older server proto doesn't understand.
- The localenv→proto enum mapping lives in `cmd/environments`, keeping `libs/localenv` telemetry-agnostic.
- Dry-run runs emit nothing.

## What's here

- `libs/telemetry/protos/setup_local.go` — `SetupLocalEvent` + its four enum types; field wired into `DatabricksCliLog`.
- `cmd/environments/telemetry.go` — `buildSetupLocalEvent`/`logSetupLocalEvent` and the mapping helpers; emit call added at the top of `renderResult`.
- Tests: field-mapping table test, enum-coverage guard tests (a new `localenv` error code/phase without a mapping fails CI), and an end-to-end upload round-trip.

## Follow-up (separate, out of this repo)

The CLI proto is a hand-maintained mirror; a matching lumberjack proto must be added in the universe repo (`proto/logs/frontend/databricks_cli/`) for the fields to land in the `team_eng_deco` table. The CLI can ship first (ingestion ignores unknown fields).

## Testing

- `go test ./cmd/environments/... ./libs/telemetry/...` — pass.
- Acceptance (`TestAccept/localenv`, `TestAccept/telemetry`) — pass, no golden diffs (telemetry doesn't touch stdout/stderr or the `--json` contract).

No changelog fragment: the command is hidden/experimental and there is no user-visible behavior change.

This pull request and its description were written by Isaac.