### PR TITLE
Reject secret scope permissions with no principal

### DIFF
--- a/.nextchanges/bundles/secret-scope-permission-principal-required.md
+++ b/.nextchanges/bundles/secret-scope-permission-principal-required.md
@@ -1,0 +1,1 @@
+Reject secret scope permissions that name no principal, instead of failing after the scope is created.

--- a/acceptance/bundle/validate/secret_scope_required_principal/databricks.yml
+++ b/acceptance/bundle/validate/secret_scope_required_principal/databricks.yml
@@ -1,0 +1,27 @@
+bundle:
+  name: test-bundle
+
+resources:
+  secret_scopes:
+    no_principal:
+      name: test-scope-no-principal
+      permissions:
+        # Missing principal: rejected.
+        - level: READ
+    empty_principal:
+      name: test-scope-empty-principal
+      permissions:
+        # Empty principal: rejected.
+        - level: READ
+          group_name: ""
+    wrong_type_principal:
+      name: test-scope-wrong-type-principal
+      permissions:
+        # Normalization only warns and drops the value, leaving no principal: rejected.
+        - level: READ
+          group_name: []
+    valid:
+      name: test-scope-valid
+      permissions:
+        - level: READ
+          group_name: users

--- a/acceptance/bundle/validate/secret_scope_required_principal/databricks.yml
+++ b/acceptance/bundle/validate/secret_scope_required_principal/databricks.yml
@@ -17,7 +17,7 @@ resources:
     wrong_type_principal:
       name: test-scope-wrong-type-principal
       permissions:
-        # Normalization only warns and drops the value, leaving no principal: rejected.
+        # Wrong-typed principal: normalization drops it, so treated as missing.
         - level: READ
           group_name: []
     valid:

--- a/acceptance/bundle/validate/secret_scope_required_principal/out.test.toml
+++ b/acceptance/bundle/validate/secret_scope_required_principal/out.test.toml
@@ -1,0 +1,2 @@
+Cloud = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/secret_scope_required_principal/output.txt
+++ b/acceptance/bundle/validate/secret_scope_required_principal/output.txt
@@ -1,0 +1,57 @@
+
+>>> [CLI] bundle validate
+Warning: expected string, found sequence
+  at resources.secret_scopes.wrong_type_principal.permissions[0].group_name
+  in databricks.yml:22:23
+
+Error: secret scope permission principal is required
+  at resources.secret_scopes.empty_principal.permissions[0]
+  in databricks.yml:12:7
+
+Set one of user_name, group_name or service_principal_name
+
+Error: secret scope permission principal is required
+  at resources.secret_scopes.wrong_type_principal.permissions[0]
+  in databricks.yml:18:7
+
+Set one of user_name, group_name or service_principal_name
+
+Error: secret scope permission principal is required
+  at resources.secret_scopes.no_principal.permissions[0]
+  in databricks.yml:7:7
+
+Set one of user_name, group_name or service_principal_name
+
+Name: test-bundle
+Target: default
+Workspace:
+  User: [USERNAME]
+  Path: /Workspace/Users/[USERNAME]/.bundle/test-bundle/default
+
+Found 3 errors and 1 warning
+
+>>> [CLI] bundle deploy
+Warning: expected string, found sequence
+  at resources.secret_scopes.wrong_type_principal.permissions[0].group_name
+  in databricks.yml:22:23
+
+Error: secret scope permission principal is required
+  at resources.secret_scopes.empty_principal.permissions[0]
+  in databricks.yml:12:7
+
+Set one of user_name, group_name or service_principal_name
+
+Error: secret scope permission principal is required
+  at resources.secret_scopes.wrong_type_principal.permissions[0]
+  in databricks.yml:18:7
+
+Set one of user_name, group_name or service_principal_name
+
+Error: secret scope permission principal is required
+  at resources.secret_scopes.no_principal.permissions[0]
+  in databricks.yml:7:7
+
+Set one of user_name, group_name or service_principal_name
+
+
+>>> print_requests.py //secrets

--- a/acceptance/bundle/validate/secret_scope_required_principal/script
+++ b/acceptance/bundle/validate/secret_scope_required_principal/script
@@ -1,0 +1,7 @@
+musterr trace $CLI bundle validate
+
+# Deploy must abort at validation: no scope is created, so no partial deploy.
+musterr trace $CLI bundle deploy
+trace print_requests.py //secrets
+
+rm -f out.requests.txt

--- a/acceptance/bundle/validate/secret_scope_required_principal/script
+++ b/acceptance/bundle/validate/secret_scope_required_principal/script
@@ -1,3 +1,5 @@
+# Without the fix, validate only warns; deploy fails later in SecretScopeFixups (direct)
+# or leaves empty-principal ACLs that destroy cannot remove (terraform).
 musterr trace $CLI bundle validate
 
 # Deploy must abort at validation: no scope is created, so no partial deploy.

--- a/acceptance/bundle/validate/secret_scope_required_principal/test.toml
+++ b/acceptance/bundle/validate/secret_scope_required_principal/test.toml
@@ -1,0 +1,1 @@
+RecordRequests = true

--- a/bundle/config/validate/required.go
+++ b/bundle/config/validate/required.go
@@ -83,8 +83,14 @@ func sortDiagnostics(diags diag.Diagnostics) {
 			return n
 		}
 
-		// Finally sort by locations as a tie breaker if summaries are the same.
-		return cmp.Compare(fmt.Sprintf("%v", a.Locations), fmt.Sprintf("%v", b.Locations))
+		// Then sort by locations as a tie breaker if summaries are the same.
+		if n := cmp.Compare(fmt.Sprintf("%v", a.Locations), fmt.Sprintf("%v", b.Locations)); n != 0 {
+			return n
+		}
+
+		// Diagnostics for sibling entries of one resource share a location, so fall back to
+		// the path to keep the order stable.
+		return cmp.Compare(fmt.Sprintf("%v", a.Paths), fmt.Sprintf("%v", b.Paths))
 	})
 }
 
@@ -184,6 +190,53 @@ func errorForInvalidGrants(ctx context.Context, b *bundle.Bundle) diag.Diagnosti
 	return diags
 }
 
+// errorForInvalidSecretScopePermissions errors for secret scope permissions that name no
+// principal. The backend rejects a secret ACL without one, but nothing rejects the input:
+// the direct engine only fails later while collapsing permissions, and Terraform creates
+// the scope before the ACL call fails, leaving a partial deploy.
+func errorForInvalidSecretScopePermissions(ctx context.Context, b *bundle.Bundle) diag.Diagnostics {
+	diags := diag.Diagnostics{}
+
+	_, err := dyn.MapByPattern(
+		b.Config.Value(),
+		dyn.NewPattern(dyn.Key("resources"), dyn.Key("secret_scopes"), dyn.AnyKey(), dyn.Key("permissions"), dyn.AnyIndex()),
+		func(p dyn.Path, v dyn.Value) (dyn.Value, error) {
+			if hasSecretScopePrincipal(v) {
+				return v, nil
+			}
+			// ApplyBundlePermissions rebuilds the permissions sequence through
+			// convert.FromTyped, which drops the entries' locations, so point at the scope.
+			diags = diags.Append(diag.Diagnostic{
+				Severity:  diag.Error,
+				Summary:   "secret scope permission principal is required",
+				Detail:    "Set one of user_name, group_name or service_principal_name",
+				Locations: b.Config.GetLocations("resources.secret_scopes." + p[2].Key()),
+				Paths:     []dyn.Path{slices.Clone(p)},
+			})
+			return v, nil
+		},
+	)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	sortDiagnostics(diags)
+
+	return diags
+}
+
+// hasSecretScopePrincipal reports whether the permission names a principal. A value of the
+// wrong type counts as missing: normalization only warns and drops it, so the permission
+// would still reach the backend without a principal.
+func hasSecretScopePrincipal(v dyn.Value) bool {
+	for _, field := range []string{"user_name", "group_name", "service_principal_name"} {
+		if s, ok := v.Get(field).AsString(); ok && s != "" {
+			return true
+		}
+	}
+	return false
+}
+
 // isMissingOrEmptyString reports whether v is unset, null, or an empty string.
 func isMissingOrEmptyString(v dyn.Value) bool {
 	switch v.Kind() {
@@ -211,6 +264,7 @@ func isMissingOrEmptySequence(v dyn.Value) bool {
 func (f *required) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnostics {
 	diags := errorForMissingFields(ctx, b)
 	diags = diags.Extend(errorForInvalidGrants(ctx, b))
+	diags = diags.Extend(errorForInvalidSecretScopePermissions(ctx, b))
 	if diags.HasError() {
 		return diags
 	}

--- a/bundle/config/validate/required.go
+++ b/bundle/config/validate/required.go
@@ -88,8 +88,7 @@ func sortDiagnostics(diags diag.Diagnostics) {
 			return n
 		}
 
-		// Diagnostics for sibling entries of one resource share a location, so fall back to
-		// the path to keep the order stable.
+		// Sibling entries can share a location; fall back to path for a stable order.
 		return cmp.Compare(fmt.Sprintf("%v", a.Paths), fmt.Sprintf("%v", b.Paths))
 	})
 }
@@ -190,10 +189,9 @@ func errorForInvalidGrants(ctx context.Context, b *bundle.Bundle) diag.Diagnosti
 	return diags
 }
 
-// errorForInvalidSecretScopePermissions errors for secret scope permissions that name no
-// principal. The backend rejects a secret ACL without one, but nothing rejects the input:
-// the direct engine only fails later while collapsing permissions, and Terraform creates
-// the scope before the ACL call fails, leaving a partial deploy.
+// errorForInvalidSecretScopePermissions errors when a permission names no principal.
+// The backend rejects that ACL; erroring here avoids a partial deploy where Terraform
+// creates the scope before the ACL call fails.
 func errorForInvalidSecretScopePermissions(ctx context.Context, b *bundle.Bundle) diag.Diagnostics {
 	diags := diag.Diagnostics{}
 
@@ -204,8 +202,8 @@ func errorForInvalidSecretScopePermissions(ctx context.Context, b *bundle.Bundle
 			if hasSecretScopePrincipal(v) {
 				return v, nil
 			}
-			// ApplyBundlePermissions rebuilds the permissions sequence through
-			// convert.FromTyped, which drops the entries' locations, so point at the scope.
+			// ApplyBundlePermissions rebuilds permissions via convert.FromTyped and drops
+			// per-entry locations, so point at the scope.
 			diags = diags.Append(diag.Diagnostic{
 				Severity:  diag.Error,
 				Summary:   "secret scope permission principal is required",
@@ -225,9 +223,8 @@ func errorForInvalidSecretScopePermissions(ctx context.Context, b *bundle.Bundle
 	return diags
 }
 
-// hasSecretScopePrincipal reports whether the permission names a principal. A value of the
-// wrong type counts as missing: normalization only warns and drops it, so the permission
-// would still reach the backend without a principal.
+// hasSecretScopePrincipal reports whether a principal is set. Wrong-typed values count as
+// missing: normalization only warns and drops them.
 func hasSecretScopePrincipal(v dyn.Value) bool {
 	for _, field := range []string{"user_name", "group_name", "service_principal_name"} {
 		if s, ok := v.Get(field).AsString(); ok && s != "" {

--- a/bundle/config/validate/required.go
+++ b/bundle/config/validate/required.go
@@ -190,48 +190,31 @@ func errorForInvalidGrants(ctx context.Context, b *bundle.Bundle) diag.Diagnosti
 }
 
 // errorForInvalidSecretScopePermissions errors when a permission names no principal.
-// The backend rejects that ACL; erroring here avoids a partial deploy where Terraform
-// creates the scope before the ACL call fails.
+// Wrong-typed values are already empty here (normalization only warns and drops them).
 func errorForInvalidSecretScopePermissions(ctx context.Context, b *bundle.Bundle) diag.Diagnostics {
 	diags := diag.Diagnostics{}
 
-	_, err := dyn.MapByPattern(
-		b.Config.Value(),
-		dyn.NewPattern(dyn.Key("resources"), dyn.Key("secret_scopes"), dyn.AnyKey(), dyn.Key("permissions"), dyn.AnyIndex()),
-		func(p dyn.Path, v dyn.Value) (dyn.Value, error) {
-			if hasSecretScopePrincipal(v) {
-				return v, nil
+	for key, scope := range b.Config.Resources.SecretScopes {
+		for i, perm := range scope.Permissions {
+			if perm.UserName != "" || perm.GroupName != "" || perm.ServicePrincipalName != "" {
+				continue
 			}
+			path := fmt.Sprintf("resources.secret_scopes.%s.permissions[%d]", key, i)
 			// ApplyBundlePermissions rebuilds permissions via convert.FromTyped and drops
 			// per-entry locations, so point at the scope.
 			diags = diags.Append(diag.Diagnostic{
 				Severity:  diag.Error,
 				Summary:   "secret scope permission principal is required",
 				Detail:    "Set one of user_name, group_name or service_principal_name",
-				Locations: b.Config.GetLocations("resources.secret_scopes." + p[2].Key()),
-				Paths:     []dyn.Path{slices.Clone(p)},
+				Locations: b.Config.GetLocations("resources.secret_scopes." + key),
+				Paths:     []dyn.Path{dyn.MustPathFromString(path)},
 			})
-			return v, nil
-		},
-	)
-	if err != nil {
-		return diag.FromErr(err)
+		}
 	}
 
 	sortDiagnostics(diags)
 
 	return diags
-}
-
-// hasSecretScopePrincipal reports whether a principal is set. Wrong-typed values count as
-// missing: normalization only warns and drops them.
-func hasSecretScopePrincipal(v dyn.Value) bool {
-	for _, field := range []string{"user_name", "group_name", "service_principal_name"} {
-		if s, ok := v.Get(field).AsString(); ok && s != "" {
-			return true
-		}
-	}
-	return false
 }
 
 // isMissingOrEmptyString reports whether v is unset, null, or an empty string.


### PR DESCRIPTION
## Changes

Add `errorForInvalidSecretScopePermissions` to `validate.Required()`. Validate and deploy fail early with:

```
Error: secret scope permission principal is required
  at resources.secret_scopes.<key>.permissions[0]

Set one of user_name, group_name or service_principal_name
```

Diagnostics point at the scope (`ApplyBundlePermissions` drops per-entry locations). `sortDiagnostics` ties on path when locations match.

## Why

A secret scope permission with no principal passes `bundle validate` (only a type warning for wrong-typed values). Three shapes slip through: missing, empty-string, and wrong-typed principal (normalization warns and drops it).

Without this check, failure is late and engine-specific:

**Direct** — deploy fails in `SecretScopeFixups` before any `//secrets` calls:

```
Error: Failed to collapse permissions for secret scope
  at resources.secret_scopes.no_principal

missing principal in permissions for secret scope "test-scope-no-principal"
```

**Terraform** — deploy succeeds and creates scopes plus ACLs with `"principal": ""`. Destroy then fails and cannot clean up:

```
Error: cannot read secret acl: principal cannot be empty

  with databricks_secret_acl.secret_acl_no_principal_0,
  on bundle.tf.json line 30, in resource.databricks_secret_acl.secret_acl_no_principal_0:
  30:       },
```

_Found by fuzz testing._

## Tests

New acceptance test `bundle/validate/secret_scope_required_principal` covering the three bad shapes plus a valid one. Asserts early rejection and zero `//secrets` requests on deploy.