### PR TITLE
owners: add @rugpanov and @rclarey as maintainers

### DIFF
--- a/.github/OWNERS
+++ b/.github/OWNERS
@@ -1,5 +1,5 @@
 # Maintainers (can approve any PR)
-*                           @andrewnester @anton-107 @denik @pietern @shreyas-goenka @simonfaltum @renaudhartert-db @janniklasrose @lennartkats-db
+*                           @andrewnester @anton-107 @denik @pietern @shreyas-goenka @simonfaltum @renaudhartert-db @janniklasrose @lennartkats-db @rugpanov @rclarey
 
 # Bundles
 /bundle/                    team:bundle


### PR DESCRIPTION
## Summary

Add `@rugpanov` and `@rclarey` to the `*` maintainer catch-all in `.github/OWNERS` so they can approve any part of the CLI.

The `team:ide` alias (which includes `@misha-db`) and its localenv / environments directory rules are left unchanged.

## Testing

- `node .github/scripts/owners.js validate` passes.
- `node --test .github/scripts/owners.test.js .github/workflows/maintainer-approval.test.js` — all 64 tests pass.

This pull request and its description were written by Isaac.