### PR TITLE
internal: Do not trigger all invariant tests when only specific one added

### DIFF
--- a/acceptance/skiplocal_test.go
+++ b/acceptance/skiplocal_test.go
@@ -109,7 +109,7 @@ func selectChangedLocalTests(t *testing.T, testDirs map[string]bool) map[string]
 		// test.toml and out.test.toml under the invariant tree regenerate
 		// automatically when INPUT_CONFIG changes; ignore them so they don't
 		// unlock all variants of every invariant subdir.
-		if strings.HasPrefix(path, filepath.Join("acceptance", invariantDirPrefix)) {
+		if strings.HasPrefix(path, "acceptance/"+invariantDirPrefix) {
 			if name := filepath.Base(path); name == "test.toml" || name == "out.test.toml" {
 				continue
 			}

--- a/acceptance/skiplocal_test.go
+++ b/acceptance/skiplocal_test.go
@@ -106,6 +106,15 @@ func selectChangedLocalTests(t *testing.T, testDirs map[string]bool) map[string]
 			continue
 		}
 
+		// test.toml and out.test.toml under the invariant tree regenerate
+		// automatically when INPUT_CONFIG changes; ignore them so they don't
+		// unlock all variants of every invariant subdir.
+		if strings.HasPrefix(path, "acceptance/"+invariantDirPrefix) {
+			if name := filepath.Base(path); name == "test.toml" || name == "out.test.toml" {
+				continue
+			}
+		}
+
 		dir := testDirForFile(path, testDirs)
 		if dir == "" {
 			continue

--- a/acceptance/skiplocal_test.go
+++ b/acceptance/skiplocal_test.go
@@ -109,7 +109,7 @@ func selectChangedLocalTests(t *testing.T, testDirs map[string]bool) map[string]
 		// test.toml and out.test.toml under the invariant tree regenerate
 		// automatically when INPUT_CONFIG changes; ignore them so they don't
 		// unlock all variants of every invariant subdir.
-		if strings.HasPrefix(path, "acceptance/"+invariantDirPrefix) {
+		if strings.HasPrefix(path, filepath.Join("acceptance", invariantDirPrefix)) {
 			if name := filepath.Base(path); name == "test.toml" || name == "out.test.toml" {
 				continue
 			}


### PR DESCRIPTION
## Changes
Do not trigger all invariant tests when only specific one added

## Why
Adding *.yml.tmpl requires updating `acceptance/bundle/invariant/test.toml` (to add it to EnvMatrix.INPUT_CONFIG), which then causes all five invariant subdirs' out.test.toml files to regenerate.

The fix is to skip test.toml and out.test.toml files under the invariant tree, they change as a side-effect of adding a config, not because the test logic itself changed.


<!-- If your PR needs to be included in the release notes for next release,
add a changelog fragment: create .nextchanges/<section>/<name>.md with a
one-line description (e.g. .nextchanges/cli/quickstart.md). See .nextchanges/README.md. -->
