### PR TITLE
job_runs: add lifecycle.triggers.on_bundle_deploy

### DIFF
--- a/.nextchanges/bundles/job-runs-on-bundle-deploy.md
+++ b/.nextchanges/bundles/job-runs-on-bundle-deploy.md
@@ -1,0 +1,1 @@
+direct: `resources.job_runs` can set `lifecycle.triggers.on_bundle_deploy: true` to re-fire the run on every bundle deploy, even when the run configuration is unchanged.

--- a/.nextchanges/bundles/job-runs-on-bundle-deploy.md
+++ b/.nextchanges/bundles/job-runs-on-bundle-deploy.md
@@ -1,1 +1,1 @@
-direct: `resources.job_runs` can set `lifecycle.triggers.on_bundle_deploy: true` to re-fire the run on every bundle deploy, even when the run configuration is unchanged.
+direct: `resources.job_runs` can set `lifecycle.triggers.on_bundle_deploy: true` to re-fire the run on every bundle deploy.

--- a/.nextchanges/bundles/job-runs-on-bundle-deploy.md
+++ b/.nextchanges/bundles/job-runs-on-bundle-deploy.md
@@ -1,1 +1,1 @@
-direct: `resources.job_runs` can set `lifecycle.triggers.on_bundle_deploy: true` to re-fire the run on every bundle deploy.
+direct: `resources.job_runs` can set `lifecycle.triggers.on_bundle_deploy: true` to re-fire the run on every bundle deploy. Removing the trigger does not recreate the existing run.

--- a/acceptance/bundle/refschema/out.fields.txt
+++ b/acceptance/bundle/refschema/out.fields.txt
@@ -845,8 +845,12 @@ resources.job_runs.*.jar_params[*]	string	ALL
 resources.job_runs.*.job_id	int64	ALL
 resources.job_runs.*.job_parameters	map[string]string	ALL
 resources.job_runs.*.job_parameters.*	string	ALL
+resources.job_runs.*.lifecycle	*resources.JobRunLifecycle	INPUT
 resources.job_runs.*.lifecycle	resources.Lifecycle	INPUT
 resources.job_runs.*.lifecycle.prevent_destroy	bool	INPUT
+resources.job_runs.*.lifecycle.triggers	[]resources.JobRunTrigger	INPUT
+resources.job_runs.*.lifecycle.triggers[*]	resources.JobRunTrigger	INPUT
+resources.job_runs.*.lifecycle.triggers[*].on_bundle_deploy	*bool	INPUT
 resources.job_runs.*.modified_status	string	INPUT
 resources.job_runs.*.notebook_params	map[string]string	ALL
 resources.job_runs.*.notebook_params.*	string	ALL
@@ -885,6 +889,8 @@ resources.job_runs.*.state.queue_reason	string	REMOTE
 resources.job_runs.*.state.result_state	jobs.RunResultState	REMOTE
 resources.job_runs.*.state.state_message	string	REMOTE
 resources.job_runs.*.state.user_cancelled_or_timedout	bool	REMOTE
+resources.job_runs.*.triggers	*dresources.JobRunTriggersState	STATE
+resources.job_runs.*.triggers.on_bundle_deploy	string	STATE
 resources.job_runs.*.url	string	INPUT
 resources.jobs.*.budget_policy_id	string	ALL
 resources.jobs.*.continuous	*jobs.Continuous	ALL

--- a/acceptance/bundle/refschema/out.fields.txt
+++ b/acceptance/bundle/refschema/out.fields.txt
@@ -845,10 +845,13 @@ resources.job_runs.*.jar_params[*]	string	ALL
 resources.job_runs.*.job_id	int64	ALL
 resources.job_runs.*.job_parameters	map[string]string	ALL
 resources.job_runs.*.job_parameters.*	string	ALL
+resources.job_runs.*.lifecycle	*dresources.JobRunLifecycleState	STATE
 resources.job_runs.*.lifecycle	*resources.JobRunLifecycle	INPUT
 resources.job_runs.*.lifecycle	resources.Lifecycle	INPUT
 resources.job_runs.*.lifecycle.prevent_destroy	bool	INPUT
+resources.job_runs.*.lifecycle.triggers	*dresources.JobRunTriggersState	STATE
 resources.job_runs.*.lifecycle.triggers	[]resources.JobRunTrigger	INPUT
+resources.job_runs.*.lifecycle.triggers.on_bundle_deploy	string	STATE
 resources.job_runs.*.lifecycle.triggers[*]	resources.JobRunTrigger	INPUT
 resources.job_runs.*.lifecycle.triggers[*].on_bundle_deploy	*bool	INPUT
 resources.job_runs.*.modified_status	string	INPUT
@@ -889,8 +892,6 @@ resources.job_runs.*.state.queue_reason	string	REMOTE
 resources.job_runs.*.state.result_state	jobs.RunResultState	REMOTE
 resources.job_runs.*.state.state_message	string	REMOTE
 resources.job_runs.*.state.user_cancelled_or_timedout	bool	REMOTE
-resources.job_runs.*.triggers	*dresources.JobRunTriggersState	STATE
-resources.job_runs.*.triggers.on_bundle_deploy	string	STATE
 resources.job_runs.*.url	string	INPUT
 resources.jobs.*.budget_policy_id	string	ALL
 resources.jobs.*.continuous	*jobs.Continuous	ALL

--- a/acceptance/bundle/resources/job_runs/basic/output.txt
+++ b/acceptance/bundle/resources/job_runs/basic/output.txt
@@ -37,7 +37,7 @@ job run [MY_RUN_ID]: Run URL: [DATABRICKS_URL]/jobs/[MY_JOB_ID]/runs/[MY_RUN_ID]
 job run [MY_RUN_ID]: SUCCESS
 Created job_runs.my_run
 Created jobs.my_job
-Files: 5 uploaded, 0 deleted
+Files: 4 uploaded, 0 deleted
 Resources: 2 created, 0 changed, 0 deleted, 0 unchanged
 
 >>> [CLI] bundle deploy

--- a/acceptance/bundle/resources/job_runs/failed_run/test.toml
+++ b/acceptance/bundle/resources/job_runs/failed_run/test.toml
@@ -1,7 +1,3 @@
-# job_runs is a direct-engine-only resource; the Terraform provider has no
-# equivalent, so restrict the matrix to direct.
-EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]
-
 # Runs the failing job for real, so the message the deploy names the task with is
 # one a workspace reported. Serverless needs Unity Catalog.
 Cloud = true

--- a/acceptance/bundle/resources/job_runs/interrupted_run/test.toml
+++ b/acceptance/bundle/resources/job_runs/interrupted_run/test.toml
@@ -1,8 +1,3 @@
-# job_runs is a direct-engine-only resource; the Terraform provider has no
-# equivalent, so restrict the matrix to direct.
-EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]
-
 # The interruption is staged by injecting a fault into the testserver, so this
 # stays off cloud.
-RecordRequests = true
 Ignore = ["tmp.plan.json"]

--- a/acceptance/bundle/resources/job_runs/job_parameters/output.txt
+++ b/acceptance/bundle/resources/job_runs/job_parameters/output.txt
@@ -6,7 +6,7 @@ job run [MY_RUN_ID]: Run URL: [DATABRICKS_URL]/jobs/[MY_JOB_ID]/runs/[MY_RUN_ID]
 job run [MY_RUN_ID]: SUCCESS
 Created job_runs.my_run
 Created jobs.my_job
-Files: 5 uploaded, 0 deleted
+Files: 4 uploaded, 0 deleted
 Resources: 2 created, 0 changed, 0 deleted, 0 unchanged
 
 >>> print_requests.py //jobs/run-now

--- a/acceptance/bundle/resources/job_runs/job_parameters/test.toml
+++ b/acceptance/bundle/resources/job_runs/job_parameters/test.toml
@@ -1,4 +1,0 @@
-# job_runs is a direct-engine-only resource; the Terraform provider has no
-# equivalent, so restrict the matrix to direct.
-EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]
-RecordRequests = true

--- a/acceptance/bundle/resources/job_runs/on_bundle_deploy/databricks.yml
+++ b/acceptance/bundle/resources/job_runs/on_bundle_deploy/databricks.yml
@@ -1,0 +1,18 @@
+bundle:
+  name: job-runs-on-bundle-deploy
+
+resources:
+  jobs:
+    my_job:
+      name: my-job
+      tasks:
+        - task_key: main
+          notebook_task:
+            notebook_path: /Workspace/test
+
+  job_runs:
+    my_run:
+      job_id: ${resources.jobs.my_job.id}
+      lifecycle:
+        triggers:
+          - on_bundle_deploy: true

--- a/acceptance/bundle/resources/job_runs/on_bundle_deploy/out.test.toml
+++ b/acceptance/bundle/resources/job_runs/on_bundle_deploy/out.test.toml
@@ -1,0 +1,2 @@
+Cloud = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/job_runs/on_bundle_deploy/out.test.toml
+++ b/acceptance/bundle/resources/job_runs/on_bundle_deploy/out.test.toml
@@ -1,2 +1,3 @@
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]
+EnvMatrix.READPLAN = ["", "1"]

--- a/acceptance/bundle/resources/job_runs/on_bundle_deploy/output.txt
+++ b/acceptance/bundle/resources/job_runs/on_bundle_deploy/output.txt
@@ -2,11 +2,12 @@
 === first deploy triggers a run
 >>> [CLI] bundle deploy
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/job-runs-on-bundle-deploy/default/files...
-Deploying resources...
 job run [MY_RUN_ID]: Run URL: [DATABRICKS_URL]/jobs/[MY_JOB_ID]/runs/[MY_RUN_ID]?o=[NUMID]
 job run [MY_RUN_ID]: SUCCESS
-Updating deployment state...
-Deployment complete!
+Created job_runs.my_run
+Created jobs.my_job
+Files: 5 uploaded, 0 deleted
+Resources: 2 created, 0 changed, 0 deleted, 0 unchanged
 
 >>> read_id.py my_job
 [MY_JOB_ID]
@@ -29,11 +30,11 @@ Plan: 1 to add, 0 to change, 1 to delete, 1 unchanged
 
 >>> [CLI] bundle deploy
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/job-runs-on-bundle-deploy/default/files...
-Deploying resources...
 job run [MY_RUN_ID_2]: Run URL: [DATABRICKS_URL]/jobs/[MY_JOB_ID]/runs/[MY_RUN_ID_2]?o=[NUMID]
 job run [MY_RUN_ID_2]: SUCCESS
-Updating deployment state...
-Deployment complete!
+Recreated job_runs.my_run
+Files: 2 uploaded, 0 deleted
+Resources: 1 created, 0 changed, 1 deleted, 1 unchanged
 
 >>> [CLI] bundle summary
 Name: job-runs-on-bundle-deploy
@@ -77,9 +78,8 @@ Plan: 0 to add, 0 to change, 0 to delete, 2 unchanged
 
 >>> [CLI] bundle deploy
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/job-runs-on-bundle-deploy/default/files...
-Deploying resources...
-Updating deployment state...
-Deployment complete!
+Files: 3 uploaded, 0 deleted
+Resources: 0 created, 0 changed, 0 deleted, 2 unchanged
 
 >>> print_requests.py //jobs/run-now
 
@@ -90,5 +90,4 @@ The following resources will be deleted:
 
 All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/job-runs-on-bundle-deploy/default
 
-Deleting files...
-Destroy complete!
+Destroy: 2 deleted

--- a/acceptance/bundle/resources/job_runs/on_bundle_deploy/output.txt
+++ b/acceptance/bundle/resources/job_runs/on_bundle_deploy/output.txt
@@ -1,0 +1,80 @@
+
+=== first deploy triggers a run
+>>> [CLI] bundle deploy
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/job-runs-on-bundle-deploy/default/files...
+Deploying resources...
+job run [MY_RUN_ID]: Run URL: [DATABRICKS_URL]/jobs/[MY_JOB_ID]/runs/[MY_RUN_ID]?o=[NUMID]
+job run [MY_RUN_ID]: SUCCESS
+Updating deployment state...
+Deployment complete!
+
+>>> read_id.py my_job
+[MY_JOB_ID]
+
+>>> print_requests.py //jobs/run-now
+{
+  "method": "POST",
+  "path": "/api/2.2/jobs/run-now",
+  "body": {
+    "job_id": [MY_JOB_ID]
+  }
+}
+
+=== redeploy with unchanged config still re-fires
+>>> [CLI] bundle plan
+recreate job_runs.my_run
+
+Plan: 1 to add, 0 to change, 1 to delete, 1 unchanged
+
+>>> [CLI] bundle deploy
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/job-runs-on-bundle-deploy/default/files...
+Deploying resources...
+job run [MY_RUN_ID_2]: Run URL: [DATABRICKS_URL]/jobs/[MY_JOB_ID]/runs/[MY_RUN_ID_2]?o=[NUMID]
+job run [MY_RUN_ID_2]: SUCCESS
+Updating deployment state...
+Deployment complete!
+
+>>> [CLI] bundle summary
+Name: job-runs-on-bundle-deploy
+Target: default
+Workspace:
+  User: [USERNAME]
+  Path: /Workspace/Users/[USERNAME]/.bundle/job-runs-on-bundle-deploy/default
+Resources:
+  Job Runs:
+    my_run:
+      Name: 
+      URL:  [DATABRICKS_URL]/jobs/[MY_JOB_ID]/runs/[MY_RUN_ID_2]?w=[NUMID]
+  Jobs:
+    my_job:
+      Name: my-job
+      URL:  [DATABRICKS_URL]/jobs/[MY_JOB_ID]?w=[NUMID]
+
+=== second run-now after recreate
+>>> print_requests.py --keep //jobs/runs/delete
+{
+  "method": "POST",
+  "path": "/api/2.2/jobs/runs/delete",
+  "body": {
+    "run_id": [MY_RUN_ID]
+  }
+}
+
+>>> print_requests.py //jobs/run-now
+{
+  "method": "POST",
+  "path": "/api/2.2/jobs/run-now",
+  "body": {
+    "job_id": [MY_JOB_ID]
+  }
+}
+
+>>> [CLI] bundle destroy --auto-approve
+The following resources will be deleted:
+  delete resources.job_runs.my_run
+  delete resources.jobs.my_job
+
+All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/job-runs-on-bundle-deploy/default
+
+Deleting files...
+Destroy complete!

--- a/acceptance/bundle/resources/job_runs/on_bundle_deploy/output.txt
+++ b/acceptance/bundle/resources/job_runs/on_bundle_deploy/output.txt
@@ -16,6 +16,7 @@ Deployment complete!
   "method": "POST",
   "path": "/api/2.2/jobs/run-now",
   "body": {
+    "idempotency_token": "[UUID]",
     "job_id": [MY_JOB_ID]
   }
 }
@@ -65,6 +66,7 @@ Resources:
   "method": "POST",
   "path": "/api/2.2/jobs/run-now",
   "body": {
+    "idempotency_token": "[UUID]",
     "job_id": [MY_JOB_ID]
   }
 }

--- a/acceptance/bundle/resources/job_runs/on_bundle_deploy/output.txt
+++ b/acceptance/bundle/resources/job_runs/on_bundle_deploy/output.txt
@@ -20,7 +20,7 @@ Deployment complete!
   }
 }
 
-=== redeploy with unchanged config still re-fires
+=== redeploy re-fires with unchanged config
 >>> [CLI] bundle plan
 recreate job_runs.my_run
 

--- a/acceptance/bundle/resources/job_runs/on_bundle_deploy/output.txt
+++ b/acceptance/bundle/resources/job_runs/on_bundle_deploy/output.txt
@@ -28,6 +28,36 @@ recreate job_runs.my_run
 
 Plan: 1 to add, 0 to change, 1 to delete, 1 unchanged
 
+>>> jq .plan["resources.job_runs.my_run"].changes tmp.plan.json
+{
+  "lifecycle": {
+    "action": "recreate",
+    "reason": "immutable",
+    "old": {
+      "triggers": {
+        "on_bundle_deploy": "[UUID]"
+      }
+    },
+    "new": {
+      "triggers": {
+        "on_bundle_deploy": "[UUID]"
+      }
+    }
+  },
+  "lifecycle.triggers.on_bundle_deploy": {
+    "action": "recreate",
+    "reason": "immutable",
+    "old": "[UUID]",
+    "new": "[UUID]"
+  },
+  "result_state": {
+    "action": "skip",
+    "reason": "remote_already_set",
+    "new": "SUCCESS",
+    "remote": "SUCCESS"
+  }
+}
+
 === bundle deploy
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/job-runs-on-bundle-deploy/default/files...
 job run [MY_RUN_ID_2]: Run URL: [DATABRICKS_URL]/jobs/[MY_JOB_ID]/runs/[MY_RUN_ID_2]?o=[NUMID]
@@ -77,6 +107,25 @@ Resources:
 update job_runs.my_run
 
 Plan: 0 to add, 1 to change, 0 to delete, 1 unchanged
+
+>>> jq .plan["resources.job_runs.my_run"].changes tmp.plan.json
+{
+  "lifecycle": {
+    "action": "update",
+    "reason": "trigger removed",
+    "old": {
+      "triggers": {
+        "on_bundle_deploy": "[UUID]"
+      }
+    }
+  },
+  "result_state": {
+    "action": "skip",
+    "reason": "remote_already_set",
+    "new": "SUCCESS",
+    "remote": "SUCCESS"
+  }
+}
 
 === bundle deploy
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/job-runs-on-bundle-deploy/default/files...

--- a/acceptance/bundle/resources/job_runs/on_bundle_deploy/output.txt
+++ b/acceptance/bundle/resources/job_runs/on_bundle_deploy/output.txt
@@ -72,14 +72,17 @@ Resources:
   }
 }
 
-=== removing on_bundle_deploy shows no drift
+=== removing on_bundle_deploy rewrites state without a run
 >>> [CLI] bundle plan
-Plan: 0 to add, 0 to change, 0 to delete, 2 unchanged
+update job_runs.my_run
+
+Plan: 0 to add, 1 to change, 0 to delete, 1 unchanged
 
 === bundle deploy
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/job-runs-on-bundle-deploy/default/files...
+Updated job_runs.my_run
 Files: 4 uploaded, 0 deleted
-Resources: 0 created, 0 changed, 0 deleted, 2 unchanged
+Resources: 0 created, 1 changed, 0 deleted, 1 unchanged
 
 >>> print_requests.py //jobs/run-now
 

--- a/acceptance/bundle/resources/job_runs/on_bundle_deploy/output.txt
+++ b/acceptance/bundle/resources/job_runs/on_bundle_deploy/output.txt
@@ -71,6 +71,18 @@ Resources:
   }
 }
 
+=== removing on_bundle_deploy shows no drift
+>>> [CLI] bundle plan
+Plan: 0 to add, 0 to change, 0 to delete, 2 unchanged
+
+>>> [CLI] bundle deploy
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/job-runs-on-bundle-deploy/default/files...
+Deploying resources...
+Updating deployment state...
+Deployment complete!
+
+>>> print_requests.py //jobs/run-now
+
 >>> [CLI] bundle destroy --auto-approve
 The following resources will be deleted:
   delete resources.job_runs.my_run

--- a/acceptance/bundle/resources/job_runs/on_bundle_deploy/output.txt
+++ b/acceptance/bundle/resources/job_runs/on_bundle_deploy/output.txt
@@ -28,12 +28,12 @@ recreate job_runs.my_run
 
 Plan: 1 to add, 0 to change, 1 to delete, 1 unchanged
 
->>> [CLI] bundle deploy
+=== bundle deploy
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/job-runs-on-bundle-deploy/default/files...
 job run [MY_RUN_ID_2]: Run URL: [DATABRICKS_URL]/jobs/[MY_JOB_ID]/runs/[MY_RUN_ID_2]?o=[NUMID]
 job run [MY_RUN_ID_2]: SUCCESS
 Recreated job_runs.my_run
-Files: 2 uploaded, 0 deleted
+Files: 3 uploaded, 0 deleted
 Resources: 1 created, 0 changed, 1 deleted, 1 unchanged
 
 >>> [CLI] bundle summary
@@ -76,9 +76,9 @@ Resources:
 >>> [CLI] bundle plan
 Plan: 0 to add, 0 to change, 0 to delete, 2 unchanged
 
->>> [CLI] bundle deploy
+=== bundle deploy
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/job-runs-on-bundle-deploy/default/files...
-Files: 3 uploaded, 0 deleted
+Files: 4 uploaded, 0 deleted
 Resources: 0 created, 0 changed, 0 deleted, 2 unchanged
 
 >>> print_requests.py //jobs/run-now

--- a/acceptance/bundle/resources/job_runs/on_bundle_deploy/script
+++ b/acceptance/bundle/resources/job_runs/on_bundle_deploy/script
@@ -1,0 +1,22 @@
+cleanup() {
+    trace $CLI bundle destroy --auto-approve
+    rm -f out.requests.txt
+}
+trap cleanup EXIT
+
+title "first deploy triggers a run"
+trace $CLI bundle deploy
+trace read_id.py my_job
+# Name the first run so the second becomes [MY_RUN_ID_2].
+read_id.py my_run > /dev/null
+trace print_requests.py //jobs/run-now
+
+title "redeploy with unchanged config still re-fires"
+trace $CLI bundle plan
+trace $CLI bundle deploy
+read_id.py my_run > /dev/null
+trace $CLI bundle summary
+
+title "second run-now after recreate"
+trace print_requests.py --keep //jobs/runs/delete
+trace print_requests.py //jobs/run-now

--- a/acceptance/bundle/resources/job_runs/on_bundle_deploy/script
+++ b/acceptance/bundle/resources/job_runs/on_bundle_deploy/script
@@ -20,3 +20,14 @@ trace $CLI bundle summary
 title "second run-now after recreate"
 trace print_requests.py --keep //jobs/runs/delete
 trace print_requests.py //jobs/run-now
+
+title "removing on_bundle_deploy shows no drift"
+# Drop the lifecycle block so the next plan compares a nil fingerprint against
+# the UUID left in state; that must not recreate.
+update_file.py databricks.yml "      lifecycle:
+        triggers:
+          - on_bundle_deploy: true
+" ""
+trace $CLI bundle plan
+trace $CLI bundle deploy
+trace print_requests.py //jobs/run-now

--- a/acceptance/bundle/resources/job_runs/on_bundle_deploy/script
+++ b/acceptance/bundle/resources/job_runs/on_bundle_deploy/script
@@ -11,7 +11,7 @@ trace read_id.py my_job
 read_id.py my_run > /dev/null
 trace print_requests.py //jobs/run-now
 
-title "redeploy with unchanged config still re-fires"
+title "redeploy re-fires with unchanged config"
 trace $CLI bundle plan
 trace $CLI bundle deploy
 read_id.py my_run > /dev/null

--- a/acceptance/bundle/resources/job_runs/on_bundle_deploy/script
+++ b/acceptance/bundle/resources/job_runs/on_bundle_deploy/script
@@ -13,7 +13,11 @@ trace print_requests.py //jobs/run-now
 
 title "redeploy re-fires with unchanged config"
 trace $CLI bundle plan
-trace $CLI bundle deploy
+# Save the plan so the READPLAN=1 variant deploys the fingerprint minted here.
+# The deploys are not traced: readplanarg makes the command line differ per variant.
+$CLI bundle plan -o json > tmp.plan.json
+title "bundle deploy\n"
+$CLI bundle deploy $(readplanarg tmp.plan.json)
 read_id.py my_run > /dev/null
 trace $CLI bundle summary
 
@@ -29,5 +33,7 @@ update_file.py databricks.yml "      lifecycle:
           - on_bundle_deploy: true
 " ""
 trace $CLI bundle plan
-trace $CLI bundle deploy
+$CLI bundle plan -o json > tmp.plan.json
+title "bundle deploy\n"
+$CLI bundle deploy $(readplanarg tmp.plan.json)
 trace print_requests.py //jobs/run-now

--- a/acceptance/bundle/resources/job_runs/on_bundle_deploy/script
+++ b/acceptance/bundle/resources/job_runs/on_bundle_deploy/script
@@ -16,6 +16,7 @@ trace $CLI bundle plan
 # Save the plan so the READPLAN=1 variant deploys the fingerprint minted here.
 # The deploys are not traced: readplanarg makes the command line differ per variant.
 $CLI bundle plan -o json > tmp.plan.json
+trace jq '.plan["resources.job_runs.my_run"].changes' tmp.plan.json
 title "bundle deploy\n"
 $CLI bundle deploy $(readplanarg tmp.plan.json)
 read_id.py my_run > /dev/null
@@ -34,6 +35,7 @@ update_file.py databricks.yml "      lifecycle:
 " ""
 trace $CLI bundle plan
 $CLI bundle plan -o json > tmp.plan.json
+trace jq '.plan["resources.job_runs.my_run"].changes' tmp.plan.json
 title "bundle deploy\n"
 $CLI bundle deploy $(readplanarg tmp.plan.json)
 trace print_requests.py //jobs/run-now

--- a/acceptance/bundle/resources/job_runs/on_bundle_deploy/script
+++ b/acceptance/bundle/resources/job_runs/on_bundle_deploy/script
@@ -25,9 +25,9 @@ title "second run-now after recreate"
 trace print_requests.py --keep //jobs/runs/delete
 trace print_requests.py //jobs/run-now
 
-title "removing on_bundle_deploy shows no drift"
+title "removing on_bundle_deploy rewrites state without a run"
 # Drop the lifecycle block so the next plan compares a nil fingerprint against
-# the UUID left in state; that must not recreate.
+# the UUID left in state: a state-only update that clears it, never a recreate.
 update_file.py databricks.yml "      lifecycle:
         triggers:
           - on_bundle_deploy: true

--- a/acceptance/bundle/resources/job_runs/on_bundle_deploy/test.toml
+++ b/acceptance/bundle/resources/job_runs/on_bundle_deploy/test.toml
@@ -1,0 +1,4 @@
+# job_runs is a direct-engine-only resource; the Terraform provider has no
+# equivalent, so restrict the matrix to direct.
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]
+RecordRequests = true

--- a/acceptance/bundle/resources/job_runs/on_bundle_deploy/test.toml
+++ b/acceptance/bundle/resources/job_runs/on_bundle_deploy/test.toml
@@ -1,4 +1,3 @@
-# job_runs is a direct-engine-only resource; the Terraform provider has no
-# equivalent, so restrict the matrix to direct.
+# Restrict the matrix to direct: job_runs is a direct-engine-only resource.
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]
 RecordRequests = true

--- a/acceptance/bundle/resources/job_runs/on_bundle_deploy/test.toml
+++ b/acceptance/bundle/resources/job_runs/on_bundle_deploy/test.toml
@@ -1,3 +1,6 @@
-# Restrict the matrix to direct: job_runs is a direct-engine-only resource.
-EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]
-RecordRequests = true
+# Deploy both by re-planning and from a plan saved on disk, so the fingerprint
+# minted during planning is exercised across plan serialization.
+EnvMatrix.READPLAN = ["", "1"]
+
+# The saved plan embeds a fresh fingerprint on every run.
+Ignore = ["tmp.plan.json"]

--- a/acceptance/bundle/resources/job_runs/redeploy/output.txt
+++ b/acceptance/bundle/resources/job_runs/redeploy/output.txt
@@ -6,7 +6,7 @@ job run [MY_RUN_ID]: Run URL: [DATABRICKS_URL]/jobs/[MY_JOB_ID]/runs/[MY_RUN_ID]
 job run [MY_RUN_ID]: SUCCESS
 Created job_runs.my_run
 Created jobs.my_job
-Files: 5 uploaded, 0 deleted
+Files: 4 uploaded, 0 deleted
 Resources: 2 created, 0 changed, 0 deleted, 0 unchanged
 
 >>> [CLI] bundle summary

--- a/acceptance/bundle/resources/job_runs/redeploy/test.toml
+++ b/acceptance/bundle/resources/job_runs/redeploy/test.toml
@@ -1,4 +1,0 @@
-# job_runs is a direct-engine-only resource; the Terraform provider has no
-# equivalent, so restrict the matrix to direct.
-EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]
-RecordRequests = true

--- a/acceptance/bundle/resources/job_runs/retried_run_now/test.toml
+++ b/acceptance/bundle/resources/job_runs/retried_run_now/test.toml
@@ -1,10 +1,4 @@
-# job_runs is a direct-engine-only resource; the Terraform provider has no
-# equivalent, so restrict the matrix to direct.
-EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]
-
 # Local only: the lost response is staged by injecting a fault into the testserver.
-RecordRequests = true
-
 Ignore = [".databricks"]
 
 # Number each distinct token so a reused token shows as [0] on both requests.

--- a/acceptance/bundle/resources/job_runs/test.toml
+++ b/acceptance/bundle/resources/job_runs/test.toml
@@ -1,4 +1,3 @@
 # job_runs is a direct-engine-only resource; the Terraform provider has no
 # equivalent, so restrict the matrix to direct.
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]
-RecordRequests = true

--- a/acceptance/bundle/resources/job_runs/wait/test.toml
+++ b/acceptance/bundle/resources/job_runs/wait/test.toml
@@ -1,7 +1,3 @@
-# job_runs is a direct-engine-only resource; the Terraform provider has no
-# equivalent, so restrict the matrix to direct.
-EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]
-
 # Runs the job for real on cloud. Serverless needs Unity Catalog.
 Cloud = true
 RequiresUnityCatalog = true

--- a/bundle/config/mutator/validate_job_run_triggers.go
+++ b/bundle/config/mutator/validate_job_run_triggers.go
@@ -27,32 +27,19 @@ func (*validateJobRunTriggers) Apply(_ context.Context, b *bundle.Bundle) diag.D
 		}
 		for i, t := range jr.Lifecycle.Triggers {
 			path := fmt.Sprintf("resources.job_runs.%s.lifecycle.triggers[%d]", name, i)
-			if t.FieldCount() != 1 {
+			if t.OnBundleDeploy == nil {
 				diags = diags.Append(diag.Diagnostic{
 					Severity:  diag.Error,
-					Summary:   "lifecycle.triggers entry must set exactly one trigger mode",
+					Summary:   "lifecycle.triggers entry must set on_bundle_deploy: true",
 					Locations: b.Config.GetLocations(path),
 				})
+				continue
 			}
-			if t.OnBundleDeploy != nil && !*t.OnBundleDeploy {
+			if !*t.OnBundleDeploy {
 				diags = diags.Append(diag.Diagnostic{
 					Severity:  diag.Error,
 					Summary:   "lifecycle.triggers.on_bundle_deploy must be true when set",
 					Locations: b.Config.GetLocations(path + ".on_bundle_deploy"),
-				})
-			}
-			if t.OnFileChange != "" {
-				diags = diags.Append(diag.Diagnostic{
-					Severity:  diag.Error,
-					Summary:   "lifecycle.triggers.on_file_change is not supported yet",
-					Locations: b.Config.GetLocations(path + ".on_file_change"),
-				})
-			}
-			if t.OnValueChange != "" {
-				diags = diags.Append(diag.Diagnostic{
-					Severity:  diag.Error,
-					Summary:   "lifecycle.triggers.on_value_change is not supported yet",
-					Locations: b.Config.GetLocations(path + ".on_value_change"),
 				})
 			}
 		}

--- a/bundle/config/mutator/validate_job_run_triggers.go
+++ b/bundle/config/mutator/validate_job_run_triggers.go
@@ -25,6 +25,14 @@ func (*validateJobRunTriggers) Apply(_ context.Context, b *bundle.Bundle) diag.D
 		if jr == nil || jr.Lifecycle == nil {
 			continue
 		}
+		// Recreate-every-deploy cannot coexist with prevent_destroy.
+		if jr.HasOnBundleDeploy() && jr.Lifecycle.PreventDestroy {
+			diags = diags.Append(diag.Diagnostic{
+				Severity:  diag.Error,
+				Summary:   "lifecycle.triggers.on_bundle_deploy is incompatible with lifecycle.prevent_destroy",
+				Locations: b.Config.GetLocations(fmt.Sprintf("resources.job_runs.%s.lifecycle", name)),
+			})
+		}
 		for i, t := range jr.Lifecycle.Triggers {
 			path := fmt.Sprintf("resources.job_runs.%s.lifecycle.triggers[%d]", name, i)
 			if t.OnBundleDeploy == nil {

--- a/bundle/config/mutator/validate_job_run_triggers.go
+++ b/bundle/config/mutator/validate_job_run_triggers.go
@@ -10,7 +10,7 @@ import (
 
 type validateJobRunTriggers struct{}
 
-// ValidateJobRunTriggers checks lifecycle.triggers on job_runs.
+// ValidateJobRunTriggers rejects invalid lifecycle.triggers on job_runs.
 func ValidateJobRunTriggers() bundle.Mutator {
 	return &validateJobRunTriggers{}
 }

--- a/bundle/config/mutator/validate_job_run_triggers.go
+++ b/bundle/config/mutator/validate_job_run_triggers.go
@@ -1,0 +1,61 @@
+package mutator
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/databricks/cli/bundle"
+	"github.com/databricks/cli/libs/diag"
+)
+
+type validateJobRunTriggers struct{}
+
+// ValidateJobRunTriggers checks lifecycle.triggers on job_runs.
+func ValidateJobRunTriggers() bundle.Mutator {
+	return &validateJobRunTriggers{}
+}
+
+func (*validateJobRunTriggers) Name() string {
+	return "ValidateJobRunTriggers"
+}
+
+func (*validateJobRunTriggers) Apply(_ context.Context, b *bundle.Bundle) diag.Diagnostics {
+	var diags diag.Diagnostics
+	for name, jr := range b.Config.Resources.JobRuns {
+		if jr == nil || jr.Lifecycle == nil {
+			continue
+		}
+		for i, t := range jr.Lifecycle.Triggers {
+			path := fmt.Sprintf("resources.job_runs.%s.lifecycle.triggers[%d]", name, i)
+			if t.FieldCount() != 1 {
+				diags = diags.Append(diag.Diagnostic{
+					Severity:  diag.Error,
+					Summary:   "lifecycle.triggers entry must set exactly one trigger mode",
+					Locations: b.Config.GetLocations(path),
+				})
+			}
+			if t.OnBundleDeploy != nil && !*t.OnBundleDeploy {
+				diags = diags.Append(diag.Diagnostic{
+					Severity:  diag.Error,
+					Summary:   "lifecycle.triggers.on_bundle_deploy must be true when set",
+					Locations: b.Config.GetLocations(path + ".on_bundle_deploy"),
+				})
+			}
+			if t.OnFileChange != "" {
+				diags = diags.Append(diag.Diagnostic{
+					Severity:  diag.Error,
+					Summary:   "lifecycle.triggers.on_file_change is not supported yet",
+					Locations: b.Config.GetLocations(path + ".on_file_change"),
+				})
+			}
+			if t.OnValueChange != "" {
+				diags = diags.Append(diag.Diagnostic{
+					Severity:  diag.Error,
+					Summary:   "lifecycle.triggers.on_value_change is not supported yet",
+					Locations: b.Config.GetLocations(path + ".on_value_change"),
+				})
+			}
+		}
+	}
+	return diags
+}

--- a/bundle/config/mutator/validate_job_run_triggers_test.go
+++ b/bundle/config/mutator/validate_job_run_triggers_test.go
@@ -15,9 +15,10 @@ func TestValidateJobRunTriggers(t *testing.T) {
 	falseVal := false
 
 	tests := []struct {
-		name     string
-		triggers []resources.JobRunTrigger
-		summary  string
+		name           string
+		triggers       []resources.JobRunTrigger
+		preventDestroy bool
+		summary        string
 	}{
 		{
 			name: "on_bundle_deploy true",
@@ -39,6 +40,18 @@ func TestValidateJobRunTriggers(t *testing.T) {
 			},
 			summary: "lifecycle.triggers.on_bundle_deploy must be true when set",
 		},
+		{
+			name: "on_bundle_deploy with prevent_destroy",
+			triggers: []resources.JobRunTrigger{
+				{OnBundleDeploy: &trueVal},
+			},
+			preventDestroy: true,
+			summary:        "lifecycle.triggers.on_bundle_deploy is incompatible with lifecycle.prevent_destroy",
+		},
+		{
+			name:           "prevent_destroy alone",
+			preventDestroy: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -49,7 +62,8 @@ func TestValidateJobRunTriggers(t *testing.T) {
 						JobRuns: map[string]*resources.JobRun{
 							"my_run": {
 								Lifecycle: &resources.JobRunLifecycle{
-									Triggers: tt.triggers,
+									Lifecycle: resources.Lifecycle{PreventDestroy: tt.preventDestroy},
+									Triggers:  tt.triggers,
 								},
 							},
 						},

--- a/bundle/config/mutator/validate_job_run_triggers_test.go
+++ b/bundle/config/mutator/validate_job_run_triggers_test.go
@@ -1,0 +1,89 @@
+package mutator_test
+
+import (
+	"testing"
+
+	"github.com/databricks/cli/bundle"
+	"github.com/databricks/cli/bundle/config"
+	"github.com/databricks/cli/bundle/config/mutator"
+	"github.com/databricks/cli/bundle/config/resources"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateJobRunTriggers(t *testing.T) {
+	trueVal := true
+	falseVal := false
+
+	tests := []struct {
+		name     string
+		triggers []resources.JobRunTrigger
+		summary  string
+	}{
+		{
+			name: "on_bundle_deploy true",
+			triggers: []resources.JobRunTrigger{
+				{OnBundleDeploy: &trueVal},
+			},
+		},
+		{
+			name: "empty entry",
+			triggers: []resources.JobRunTrigger{
+				{},
+			},
+			summary: "lifecycle.triggers entry must set exactly one trigger mode",
+		},
+		{
+			name: "two modes",
+			triggers: []resources.JobRunTrigger{
+				{OnBundleDeploy: &trueVal, OnFileChange: "src/**/*.py"},
+			},
+			summary: "lifecycle.triggers entry must set exactly one trigger mode",
+		},
+		{
+			name: "on_bundle_deploy false",
+			triggers: []resources.JobRunTrigger{
+				{OnBundleDeploy: &falseVal},
+			},
+			summary: "lifecycle.triggers.on_bundle_deploy must be true when set",
+		},
+		{
+			name: "on_file_change unsupported",
+			triggers: []resources.JobRunTrigger{
+				{OnFileChange: "src/**/*.py"},
+			},
+			summary: "lifecycle.triggers.on_file_change is not supported yet",
+		},
+		{
+			name: "on_value_change unsupported",
+			triggers: []resources.JobRunTrigger{
+				{OnValueChange: "${resources.jobs.foo.id}"},
+			},
+			summary: "lifecycle.triggers.on_value_change is not supported yet",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := &bundle.Bundle{
+				Config: config.Root{
+					Resources: config.Resources{
+						JobRuns: map[string]*resources.JobRun{
+							"my_run": {
+								Lifecycle: &resources.JobRunLifecycle{
+									Triggers: tt.triggers,
+								},
+							},
+						},
+					},
+				},
+			}
+			diags := bundle.Apply(t.Context(), b, mutator.ValidateJobRunTriggers())
+			if tt.summary == "" {
+				assert.Empty(t, diags)
+				return
+			}
+			assert.True(t, diags.HasError())
+			assert.Equal(t, tt.summary, diags[0].Summary)
+		})
+	}
+}

--- a/bundle/config/mutator/validate_job_run_triggers_test.go
+++ b/bundle/config/mutator/validate_job_run_triggers_test.go
@@ -30,14 +30,7 @@ func TestValidateJobRunTriggers(t *testing.T) {
 			triggers: []resources.JobRunTrigger{
 				{},
 			},
-			summary: "lifecycle.triggers entry must set exactly one trigger mode",
-		},
-		{
-			name: "two modes",
-			triggers: []resources.JobRunTrigger{
-				{OnBundleDeploy: &trueVal, OnFileChange: "src/**/*.py"},
-			},
-			summary: "lifecycle.triggers entry must set exactly one trigger mode",
+			summary: "lifecycle.triggers entry must set on_bundle_deploy: true",
 		},
 		{
 			name: "on_bundle_deploy false",
@@ -45,20 +38,6 @@ func TestValidateJobRunTriggers(t *testing.T) {
 				{OnBundleDeploy: &falseVal},
 			},
 			summary: "lifecycle.triggers.on_bundle_deploy must be true when set",
-		},
-		{
-			name: "on_file_change unsupported",
-			triggers: []resources.JobRunTrigger{
-				{OnFileChange: "src/**/*.py"},
-			},
-			summary: "lifecycle.triggers.on_file_change is not supported yet",
-		},
-		{
-			name: "on_value_change unsupported",
-			triggers: []resources.JobRunTrigger{
-				{OnValueChange: "${resources.jobs.foo.id}"},
-			},
-			summary: "lifecycle.triggers.on_value_change is not supported yet",
 		},
 	}
 

--- a/bundle/config/resources/job_run.go
+++ b/bundle/config/resources/job_run.go
@@ -14,16 +14,40 @@ import (
 )
 
 // JobRun is the bundle config for a triggered job run, described by the same
-// fields as the Jobs RunNow request (embedded). It re-triggers only when its own
-// config changes, not when the targeted job (stable job_id) changes.
+// fields as the Jobs RunNow request (embedded). Without lifecycle triggers it
+// re-fires only when its own config changes, not when the targeted job changes.
 type JobRun struct {
 	BaseResource
 	jobs.RunNow
+
+	// Lifecycle shadows BaseResource.Lifecycle so job_runs can set triggers.
+	Lifecycle *JobRunLifecycle `json:"lifecycle,omitempty"`
 
 	// ResolvedJobID holds the run's job_id loaded from state, used only to build
 	// the run URL. Keeping it separate from RunNow.JobId (a ${resources.jobs.*.id}
 	// reference) lets state loading preserve that reference and its plan dependency.
 	ResolvedJobID int64 `json:"resolved_job_id,omitempty" bundle:"internal"`
+}
+
+// GetLifecycle returns the job_runs lifecycle, including triggers.
+func (r *JobRun) GetLifecycle() LifecycleConfig {
+	if r.Lifecycle == nil {
+		return JobRunLifecycle{}
+	}
+	return *r.Lifecycle
+}
+
+// HasOnBundleDeploy reports whether any trigger re-fires on every deploy.
+func (r *JobRun) HasOnBundleDeploy() bool {
+	if r.Lifecycle == nil {
+		return false
+	}
+	for _, t := range r.Lifecycle.Triggers {
+		if t.OnBundleDeploy != nil && *t.OnBundleDeploy {
+			return true
+		}
+	}
+	return false
 }
 
 func (r *JobRun) UnmarshalJSON(b []byte) error {

--- a/bundle/config/resources/job_run.go
+++ b/bundle/config/resources/job_run.go
@@ -29,14 +29,6 @@ type JobRun struct {
 	ResolvedJobID int64 `json:"resolved_job_id,omitempty" bundle:"internal"`
 }
 
-// GetLifecycle returns the job_runs lifecycle, including triggers.
-func (r *JobRun) GetLifecycle() LifecycleConfig {
-	if r.Lifecycle == nil {
-		return JobRunLifecycle{}
-	}
-	return *r.Lifecycle
-}
-
 // HasOnBundleDeploy reports whether any trigger re-fires on every deploy.
 func (r *JobRun) HasOnBundleDeploy() bool {
 	if r.Lifecycle == nil {

--- a/bundle/config/resources/job_run.go
+++ b/bundle/config/resources/job_run.go
@@ -14,8 +14,8 @@ import (
 )
 
 // JobRun is the bundle config for a triggered job run, described by the same
-// fields as the Jobs RunNow request (embedded). Without lifecycle triggers it
-// re-fires only when its own config changes, not when the targeted job changes.
+// fields as the Jobs RunNow request (embedded). By default it re-fires when its
+// own configuration changes; lifecycle.triggers can add further conditions.
 type JobRun struct {
 	BaseResource
 	jobs.RunNow

--- a/bundle/config/resources/lifecycle.go
+++ b/bundle/config/resources/lifecycle.go
@@ -34,24 +34,7 @@ type JobRunLifecycle struct {
 	Triggers []JobRunTrigger `json:"triggers,omitempty"`
 }
 
-// JobRunTrigger is one lifecycle.triggers entry. Exactly one field must be set.
+// JobRunTrigger is one lifecycle.triggers entry.
 type JobRunTrigger struct {
-	OnBundleDeploy *bool  `json:"on_bundle_deploy,omitempty"`
-	OnFileChange   string `json:"on_file_change,omitempty"`
-	OnValueChange  string `json:"on_value_change,omitempty"`
-}
-
-// FieldCount returns how many trigger modes are set on this entry.
-func (t JobRunTrigger) FieldCount() int {
-	n := 0
-	if t.OnBundleDeploy != nil {
-		n++
-	}
-	if t.OnFileChange != "" {
-		n++
-	}
-	if t.OnValueChange != "" {
-		n++
-	}
-	return n
+	OnBundleDeploy *bool `json:"on_bundle_deploy,omitempty"`
 }

--- a/bundle/config/resources/lifecycle.go
+++ b/bundle/config/resources/lifecycle.go
@@ -26,11 +26,11 @@ type LifecycleWithStarted struct {
 	Started *bool `json:"started,omitempty"`
 }
 
-// JobRunLifecycle adds run-fire triggers; other resources keep base Lifecycle only.
+// JobRunLifecycle extends Lifecycle with run-fire triggers.
 type JobRunLifecycle struct {
 	Lifecycle
 
-	// Without triggers, the run re-fires only when its own config changes.
+	// Triggers that cause the run to re-fire (in addition to config changes).
 	Triggers []JobRunTrigger `json:"triggers,omitempty"`
 }
 

--- a/bundle/config/resources/lifecycle.go
+++ b/bundle/config/resources/lifecycle.go
@@ -25,3 +25,33 @@ type LifecycleWithStarted struct {
 	// Supported only for apps, clusters, and sql_warehouses.
 	Started *bool `json:"started,omitempty"`
 }
+
+// JobRunLifecycle adds run-fire triggers; other resources keep base Lifecycle only.
+type JobRunLifecycle struct {
+	Lifecycle
+
+	// Without triggers, the run re-fires only when its own config changes.
+	Triggers []JobRunTrigger `json:"triggers,omitempty"`
+}
+
+// JobRunTrigger is one lifecycle.triggers entry. Exactly one field must be set.
+type JobRunTrigger struct {
+	OnBundleDeploy *bool  `json:"on_bundle_deploy,omitempty"`
+	OnFileChange   string `json:"on_file_change,omitempty"`
+	OnValueChange  string `json:"on_value_change,omitempty"`
+}
+
+// FieldCount returns how many trigger modes are set on this entry.
+func (t JobRunTrigger) FieldCount() int {
+	n := 0
+	if t.OnBundleDeploy != nil {
+		n++
+	}
+	if t.OnFileChange != "" {
+		n++
+	}
+	if t.OnValueChange != "" {
+		n++
+	}
+	return n
+}

--- a/bundle/direct/dresources/job_run.go
+++ b/bundle/direct/dresources/job_run.go
@@ -28,8 +28,13 @@ const jobRunTimeout = 24 * time.Hour
 
 // JobRunTriggersState is the persisted fingerprint of lifecycle.triggers.
 type JobRunTriggersState struct {
-	// Fresh UUID each plan when on_bundle_deploy is set so Old!=New forces recreate.
+	// Fresh UUID each plan while armed so Old!=New forces recreate.
 	OnBundleDeploy string `json:"on_bundle_deploy,omitempty"`
+}
+
+// JobRunLifecycleState holds local-only lifecycle fields persisted in state.
+type JobRunLifecycleState struct {
+	Triggers *JobRunTriggersState `json:"triggers,omitempty"`
 }
 
 // JobRunState is the RunNow request plus the outcome required for planning.
@@ -39,8 +44,9 @@ type JobRunState struct {
 	// Always SUCCESS during planning and cleared before persistence.
 	ResultState jobs.RunResultState `json:"result_state,omitempty"`
 
-	// Local-only trigger fingerprints; listed in knownMissingInRemoteType.
-	Triggers *JobRunTriggersState `json:"triggers,omitempty"`
+	// Local-only; listed in knownMissingInRemoteType. Nested under lifecycle to
+	// mirror config and avoid colliding with a future Jobs API field.
+	Lifecycle *JobRunLifecycleState `json:"lifecycle,omitempty"`
 }
 
 func (s *JobRunState) UnmarshalJSON(b []byte) error {
@@ -91,10 +97,12 @@ func (*ResourceJobRun) PrepareState(input *resources.JobRun) *JobRunState {
 	state := &JobRunState{
 		RunNow:      input.RunNow,
 		ResultState: jobs.RunResultStateSuccess,
-		Triggers:    nil,
+		Lifecycle:   nil,
 	}
 	if input.HasOnBundleDeploy() {
-		state.Triggers = &JobRunTriggersState{OnBundleDeploy: uuid.NewString()}
+		state.Lifecycle = &JobRunLifecycleState{
+			Triggers: &JobRunTriggersState{OnBundleDeploy: uuid.NewString()},
+		}
 	}
 	return state
 }
@@ -175,8 +183,8 @@ func (*ResourceJobRun) RemapState(remote *JobRunRemote) *JobRunState {
 	return &JobRunState{
 		RunNow:      remote.RunNow,
 		ResultState: remote.ResultState,
-		// Local-only trigger fingerprints stay unset on the remapped remote.
-		Triggers: nil,
+		// Local-only lifecycle fingerprints stay unset on the remapped remote.
+		Lifecycle: nil,
 	}
 }
 
@@ -366,14 +374,29 @@ func (r *ResourceJobRun) DoUpdate(ctx context.Context, id string, config *JobRun
 // still going, so a run that may yet succeed is adopted and waited on. A run that
 // stopped without succeeding keeps its recreate. A SKIPPED run reports no
 // result_state either, so the lifecycle state is what tells the two apart.
+// Clearing the local-only trigger fingerprint is skipped so removing
+// on_bundle_deploy does not recreate the run.
 func (*ResourceJobRun) OverrideChangeDesc(_ context.Context, path *structpath.PathNode, change *ChangeDesc, remote *JobRunRemote) error {
-	// The planner passes no remote state when the run could not be read.
-	if path.String() != "result_state" || remote == nil || runIsTerminal(remote.State.LifeCycleState) {
+	switch path.String() {
+	case "lifecycle", "lifecycle.triggers", "lifecycle.triggers.on_bundle_deploy":
+		// PrepareState nils Lifecycle when the trigger is unset; structdiff may
+		// report that at lifecycle, lifecycle.triggers, or the leaf.
+		if change.New == nil || change.New == "" {
+			change.Action = deployplan.Skip
+			change.Reason = "trigger removed"
+		}
+		return nil
+	case "result_state":
+		// The planner passes no remote state when the run could not be read.
+		if remote == nil || runIsTerminal(remote.State.LifeCycleState) {
+			return nil
+		}
+		change.Action = deployplan.Update
+		change.Reason = "run in progress"
+		return nil
+	default:
 		return nil
 	}
-	change.Action = deployplan.Update
-	change.Reason = "run in progress"
-	return nil
 }
 
 // DoDelete deletes the run via jobs/runs/delete, on both destroy and the

--- a/bundle/direct/dresources/job_run.go
+++ b/bundle/direct/dresources/job_run.go
@@ -363,8 +363,15 @@ func reportRunLine(ctx context.Context, runID int64, msg string) {
 	}
 }
 
-// DoUpdate finishes the wait an interrupted deploy abandoned.
-func (r *ResourceJobRun) DoUpdate(ctx context.Context, id string, config *JobRunState, _ *PlanEntry) (*JobRunRemote, error) {
+// DoUpdate rewrites state after a cleared trigger (no API call) or finishes the
+// wait an interrupted deploy abandoned.
+func (r *ResourceJobRun) DoUpdate(ctx context.Context, id string, config *JobRunState, entry *PlanEntry) (*JobRunRemote, error) {
+	// Clearing a trigger only drops its local-only fingerprint from state; wait on
+	// the run only when some other field changed.
+	if !entry.Changes.HasChangeExcept("lifecycle", "lifecycle.triggers", "lifecycle.triggers.on_bundle_deploy") {
+		config.ResultState = ""
+		return nil, nil
+	}
 	remote, err := r.waitForRun(ctx, id)
 	config.ResultState = ""
 	return remote, err
@@ -374,15 +381,15 @@ func (r *ResourceJobRun) DoUpdate(ctx context.Context, id string, config *JobRun
 // still going, so a run that may yet succeed is adopted and waited on. A run that
 // stopped without succeeding keeps its recreate. A SKIPPED run reports no
 // result_state either, so the lifecycle state is what tells the two apart.
-// Clearing the local-only trigger fingerprint is skipped so removing
-// on_bundle_deploy does not recreate the run.
+// Clearing a trigger downgrades the recreate to a state-only update so the
+// fingerprint is dropped from state without re-firing the run.
 func (*ResourceJobRun) OverrideChangeDesc(_ context.Context, path *structpath.PathNode, change *ChangeDesc, remote *JobRunRemote) error {
 	switch path.String() {
 	case "lifecycle", "lifecycle.triggers", "lifecycle.triggers.on_bundle_deploy":
-		// PrepareState nils Lifecycle when the trigger is unset; structdiff may
-		// report that at lifecycle, lifecycle.triggers, or the leaf.
+		// A cleared trigger sets New empty; structdiff may report it at lifecycle,
+		// lifecycle.triggers, or the leaf. DoUpdate treats these paths as no-ops.
 		if change.New == nil || change.New == "" {
-			change.Action = deployplan.Skip
+			change.Action = deployplan.Update
 			change.Reason = "trigger removed"
 		}
 		return nil

--- a/bundle/direct/dresources/job_run.go
+++ b/bundle/direct/dresources/job_run.go
@@ -28,8 +28,7 @@ const jobRunTimeout = 24 * time.Hour
 
 // JobRunTriggersState is the persisted fingerprint of lifecycle.triggers.
 type JobRunTriggersState struct {
-	// Fresh UUID each plan when on_bundle_deploy is set; Old!=New forces recreate.
-	// A sticky true would be skipped as missing_in_remote when Old==New.
+	// Fresh UUID each plan when on_bundle_deploy is set so Old!=New forces recreate.
 	OnBundleDeploy string `json:"on_bundle_deploy,omitempty"`
 }
 
@@ -40,7 +39,7 @@ type JobRunState struct {
 	// Always SUCCESS during planning and cleared before persistence.
 	ResultState jobs.RunResultState `json:"result_state,omitempty"`
 
-	// Absent from RemoteType (knownMissingInRemoteType); local diff drives triggers.
+	// Local-only trigger fingerprints; listed in knownMissingInRemoteType.
 	Triggers *JobRunTriggersState `json:"triggers,omitempty"`
 }
 
@@ -176,7 +175,7 @@ func (*ResourceJobRun) RemapState(remote *JobRunRemote) *JobRunState {
 	return &JobRunState{
 		RunNow:      remote.RunNow,
 		ResultState: remote.ResultState,
-		// Triggers are local-only fingerprints; RemoteType has nothing to copy.
+		// Local-only trigger fingerprints stay unset on the remapped remote.
 		Triggers: nil,
 	}
 }
@@ -367,8 +366,7 @@ func (r *ResourceJobRun) DoUpdate(ctx context.Context, id string, config *JobRun
 // still going, so a run that may yet succeed is adopted and waited on. A run that
 // stopped without succeeding keeps its recreate. A SKIPPED run reports no
 // result_state either, so the lifecycle state is what tells the two apart.
-// Clearing triggers.on_bundle_deploy is skipped so removing the trigger does not
-// fire one last run.
+// Removing triggers.on_bundle_deploy is a no-op so the existing run stays in place.
 func (*ResourceJobRun) OverrideChangeDesc(_ context.Context, path *structpath.PathNode, change *ChangeDesc, remote *JobRunRemote) error {
 	switch path.String() {
 	case "triggers.on_bundle_deploy":

--- a/bundle/direct/dresources/job_run.go
+++ b/bundle/direct/dresources/job_run.go
@@ -26,12 +26,22 @@ import (
 // jobRunTimeout matches the timeout `bundle run` allows a run (bundle/run/job.go).
 const jobRunTimeout = 24 * time.Hour
 
+// JobRunTriggersState is the persisted fingerprint of lifecycle.triggers.
+type JobRunTriggersState struct {
+	// Fresh UUID each plan when on_bundle_deploy is set; Old!=New forces recreate.
+	// A sticky true would be skipped as missing_in_remote when Old==New.
+	OnBundleDeploy string `json:"on_bundle_deploy,omitempty"`
+}
+
 // JobRunState is the RunNow request plus the outcome required for planning.
 type JobRunState struct {
 	jobs.RunNow
 
 	// Always SUCCESS during planning and cleared before persistence.
 	ResultState jobs.RunResultState `json:"result_state,omitempty"`
+
+	// Absent from RemoteType (knownMissingInRemoteType); local diff drives triggers.
+	Triggers *JobRunTriggersState `json:"triggers,omitempty"`
 }
 
 func (s *JobRunState) UnmarshalJSON(b []byte) error {
@@ -79,10 +89,15 @@ func (*ResourceJobRun) New(client *databricks.WorkspaceClient) *ResourceJobRun {
 }
 
 func (*ResourceJobRun) PrepareState(input *resources.JobRun) *JobRunState {
-	return &JobRunState{
+	state := &JobRunState{
 		RunNow:      input.RunNow,
 		ResultState: jobs.RunResultStateSuccess,
+		Triggers:    nil,
 	}
+	if input.HasOnBundleDeploy() {
+		state.Triggers = &JobRunTriggersState{OnBundleDeploy: uuid.NewString()}
+	}
+	return state
 }
 
 // makeJobRunRemote maps the GetRun response into the RunNow-shaped remote: GET
@@ -158,7 +173,12 @@ func (r *ResourceJobRun) DoRead(ctx context.Context, id string) (*JobRunRemote, 
 // RemapState extracts the fields used for diffing: the RunNow request and the
 // outcome the run reached.
 func (*ResourceJobRun) RemapState(remote *JobRunRemote) *JobRunState {
-	return &JobRunState{RunNow: remote.RunNow, ResultState: remote.ResultState}
+	return &JobRunState{
+		RunNow:      remote.RunNow,
+		ResultState: remote.ResultState,
+		// Triggers are local-only fingerprints; RemoteType has nothing to copy.
+		Triggers: nil,
+	}
 }
 
 func (r *ResourceJobRun) DoCreate(ctx context.Context, config *JobRunState) (string, *JobRunRemote, error) {
@@ -347,14 +367,27 @@ func (r *ResourceJobRun) DoUpdate(ctx context.Context, id string, config *JobRun
 // still going, so a run that may yet succeed is adopted and waited on. A run that
 // stopped without succeeding keeps its recreate. A SKIPPED run reports no
 // result_state either, so the lifecycle state is what tells the two apart.
+// Clearing triggers.on_bundle_deploy is skipped so removing the trigger does not
+// fire one last run.
 func (*ResourceJobRun) OverrideChangeDesc(_ context.Context, path *structpath.PathNode, change *ChangeDesc, remote *JobRunRemote) error {
-	// The planner passes no remote state when the run could not be read.
-	if path.String() != "result_state" || remote == nil || runIsTerminal(remote.State.LifeCycleState) {
+	switch path.String() {
+	case "triggers.on_bundle_deploy":
+		if change.New == nil || change.New == "" {
+			change.Action = deployplan.Skip
+			change.Reason = "trigger removed"
+		}
+		return nil
+	case "result_state":
+		// The planner passes no remote state when the run could not be read.
+		if remote == nil || runIsTerminal(remote.State.LifeCycleState) {
+			return nil
+		}
+		change.Action = deployplan.Update
+		change.Reason = "run in progress"
+		return nil
+	default:
 		return nil
 	}
-	change.Action = deployplan.Update
-	change.Reason = "run in progress"
-	return nil
 }
 
 // DoDelete deletes the run via jobs/runs/delete, on both destroy and the

--- a/bundle/direct/dresources/job_run.go
+++ b/bundle/direct/dresources/job_run.go
@@ -366,26 +366,14 @@ func (r *ResourceJobRun) DoUpdate(ctx context.Context, id string, config *JobRun
 // still going, so a run that may yet succeed is adopted and waited on. A run that
 // stopped without succeeding keeps its recreate. A SKIPPED run reports no
 // result_state either, so the lifecycle state is what tells the two apart.
-// Removing triggers.on_bundle_deploy is a no-op so the existing run stays in place.
 func (*ResourceJobRun) OverrideChangeDesc(_ context.Context, path *structpath.PathNode, change *ChangeDesc, remote *JobRunRemote) error {
-	switch path.String() {
-	case "triggers.on_bundle_deploy":
-		if change.New == nil || change.New == "" {
-			change.Action = deployplan.Skip
-			change.Reason = "trigger removed"
-		}
-		return nil
-	case "result_state":
-		// The planner passes no remote state when the run could not be read.
-		if remote == nil || runIsTerminal(remote.State.LifeCycleState) {
-			return nil
-		}
-		change.Action = deployplan.Update
-		change.Reason = "run in progress"
-		return nil
-	default:
+	// The planner passes no remote state when the run could not be read.
+	if path.String() != "result_state" || remote == nil || runIsTerminal(remote.State.LifeCycleState) {
 		return nil
 	}
+	change.Action = deployplan.Update
+	change.Reason = "run in progress"
+	return nil
 }
 
 // DoDelete deletes the run via jobs/runs/delete, on both destroy and the

--- a/bundle/direct/dresources/job_run_test.go
+++ b/bundle/direct/dresources/job_run_test.go
@@ -342,6 +342,28 @@ func TestJobRunPrepareStateRequiresSuccess(t *testing.T) {
 	assert.Equal(t, jobs.RunResultStateSuccess, state.ResultState)
 }
 
+func TestJobRunPrepareStateOnBundleDeploy(t *testing.T) {
+	t.Run("unset", func(t *testing.T) {
+		state := (&ResourceJobRun{}).PrepareState(&resources.JobRun{})
+		assert.Nil(t, state.Triggers)
+	})
+
+	t.Run("armed", func(t *testing.T) {
+		on := true
+		input := &resources.JobRun{
+			Lifecycle: &resources.JobRunLifecycle{
+				Triggers: []resources.JobRunTrigger{{OnBundleDeploy: &on}},
+			},
+		}
+		first := (&ResourceJobRun{}).PrepareState(input)
+		require.NotNil(t, first.Triggers)
+		assert.NotEmpty(t, first.Triggers.OnBundleDeploy)
+
+		second := (&ResourceJobRun{}).PrepareState(input)
+		assert.NotEqual(t, first.Triggers.OnBundleDeploy, second.Triggers.OnBundleDeploy)
+	})
+}
+
 // The planner diffs RemapState(remote) against PrepareState(config), so a run
 // that did not end in SUCCESS has to surface as a difference on result_state.
 func TestJobRunRemapStateCarriesTheOutcome(t *testing.T) {

--- a/bundle/direct/dresources/job_run_test.go
+++ b/bundle/direct/dresources/job_run_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/databricks/cli/bundle/config/resources"
+	"github.com/databricks/cli/bundle/deployplan"
 	"github.com/databricks/cli/libs/structs/structpath"
 	"github.com/databricks/cli/libs/testserver"
 	"github.com/databricks/databricks-sdk-go"
@@ -345,7 +346,7 @@ func TestJobRunPrepareStateRequiresSuccess(t *testing.T) {
 func TestJobRunPrepareStateOnBundleDeploy(t *testing.T) {
 	t.Run("unset", func(t *testing.T) {
 		state := (&ResourceJobRun{}).PrepareState(&resources.JobRun{})
-		assert.Nil(t, state.Triggers)
+		assert.Nil(t, state.Lifecycle)
 	})
 
 	t.Run("armed", func(t *testing.T) {
@@ -356,11 +357,48 @@ func TestJobRunPrepareStateOnBundleDeploy(t *testing.T) {
 			},
 		}
 		first := (&ResourceJobRun{}).PrepareState(input)
-		require.NotNil(t, first.Triggers)
-		assert.NotEmpty(t, first.Triggers.OnBundleDeploy)
+		require.NotNil(t, first.Lifecycle)
+		require.NotNil(t, first.Lifecycle.Triggers)
+		assert.NotEmpty(t, first.Lifecycle.Triggers.OnBundleDeploy)
 
 		second := (&ResourceJobRun{}).PrepareState(input)
-		assert.NotEqual(t, first.Triggers.OnBundleDeploy, second.Triggers.OnBundleDeploy)
+		assert.NotEqual(t, first.Lifecycle.Triggers.OnBundleDeploy, second.Lifecycle.Triggers.OnBundleDeploy)
+	})
+}
+
+func TestJobRunOverrideChangeDescTriggerRemoved(t *testing.T) {
+	r := &ResourceJobRun{}
+
+	t.Run("clearing lifecycle skips recreate", func(t *testing.T) {
+		change := &ChangeDesc{
+			Action: deployplan.Recreate,
+			Old:    &JobRunLifecycleState{Triggers: &JobRunTriggersState{OnBundleDeploy: "old"}},
+			New:    nil,
+		}
+		require.NoError(t, r.OverrideChangeDesc(t.Context(), structpath.MustParsePath("lifecycle"), change, nil))
+		assert.Equal(t, deployplan.Skip, change.Action)
+		assert.Equal(t, "trigger removed", change.Reason)
+	})
+
+	t.Run("clearing on_bundle_deploy leaf skips recreate", func(t *testing.T) {
+		change := &ChangeDesc{
+			Action: deployplan.Recreate,
+			Old:    "old",
+			New:    "",
+		}
+		require.NoError(t, r.OverrideChangeDesc(t.Context(), structpath.MustParsePath("lifecycle.triggers.on_bundle_deploy"), change, nil))
+		assert.Equal(t, deployplan.Skip, change.Action)
+		assert.Equal(t, "trigger removed", change.Reason)
+	})
+
+	t.Run("fresh fingerprint still recreates", func(t *testing.T) {
+		change := &ChangeDesc{
+			Action: deployplan.Recreate,
+			Old:    "old",
+			New:    "new",
+		}
+		require.NoError(t, r.OverrideChangeDesc(t.Context(), structpath.MustParsePath("lifecycle.triggers.on_bundle_deploy"), change, nil))
+		assert.Equal(t, deployplan.Recreate, change.Action)
 	})
 }
 

--- a/bundle/direct/dresources/job_run_test.go
+++ b/bundle/direct/dresources/job_run_test.go
@@ -369,25 +369,25 @@ func TestJobRunPrepareStateOnBundleDeploy(t *testing.T) {
 func TestJobRunOverrideChangeDescTriggerRemoved(t *testing.T) {
 	r := &ResourceJobRun{}
 
-	t.Run("clearing lifecycle skips recreate", func(t *testing.T) {
+	t.Run("clearing lifecycle downgrades to update", func(t *testing.T) {
 		change := &ChangeDesc{
 			Action: deployplan.Recreate,
 			Old:    &JobRunLifecycleState{Triggers: &JobRunTriggersState{OnBundleDeploy: "old"}},
 			New:    nil,
 		}
 		require.NoError(t, r.OverrideChangeDesc(t.Context(), structpath.MustParsePath("lifecycle"), change, nil))
-		assert.Equal(t, deployplan.Skip, change.Action)
+		assert.Equal(t, deployplan.Update, change.Action)
 		assert.Equal(t, "trigger removed", change.Reason)
 	})
 
-	t.Run("clearing on_bundle_deploy leaf skips recreate", func(t *testing.T) {
+	t.Run("clearing on_bundle_deploy leaf downgrades to update", func(t *testing.T) {
 		change := &ChangeDesc{
 			Action: deployplan.Recreate,
 			Old:    "old",
 			New:    "",
 		}
 		require.NoError(t, r.OverrideChangeDesc(t.Context(), structpath.MustParsePath("lifecycle.triggers.on_bundle_deploy"), change, nil))
-		assert.Equal(t, deployplan.Skip, change.Action)
+		assert.Equal(t, deployplan.Update, change.Action)
 		assert.Equal(t, "trigger removed", change.Reason)
 	})
 

--- a/bundle/direct/dresources/type_test.go
+++ b/bundle/direct/dresources/type_test.go
@@ -56,6 +56,10 @@ var knownMissingInRemoteType = map[string][]string{
 	"vector_search_endpoints": {
 		"usage_policy_id",
 	},
+	"job_runs": {
+		// Local trigger fingerprints; the Jobs API has nothing corresponding.
+		"triggers",
+	},
 }
 
 // commonMissingInStateType lists fields that are commonly missing across all resource types.

--- a/bundle/direct/dresources/type_test.go
+++ b/bundle/direct/dresources/type_test.go
@@ -57,8 +57,8 @@ var knownMissingInRemoteType = map[string][]string{
 		"usage_policy_id",
 	},
 	"job_runs": {
-		// Local-only trigger fingerprints stored in state.
-		"triggers",
+		// Local-only trigger fingerprints under lifecycle.
+		"lifecycle",
 	},
 }
 
@@ -85,6 +85,11 @@ var knownMissingInStateType = map[string][]string{
 	},
 	"sql_warehouses": {
 		"lifecycle.prevent_destroy",
+	},
+	"job_runs": {
+		// State stores trigger fingerprints, not the config trigger list / prevent_destroy.
+		"lifecycle.prevent_destroy",
+		"lifecycle.triggers[*]",
 	},
 	"dashboards": {
 		"file_path",

--- a/bundle/direct/dresources/type_test.go
+++ b/bundle/direct/dresources/type_test.go
@@ -57,7 +57,7 @@ var knownMissingInRemoteType = map[string][]string{
 		"usage_policy_id",
 	},
 	"job_runs": {
-		// Local trigger fingerprints; the Jobs API has nothing corresponding.
+		// Local-only trigger fingerprints stored in state.
 		"triggers",
 	},
 }

--- a/bundle/internal/schema/annotations.yml
+++ b/bundle/internal/schema/annotations.yml
@@ -985,11 +985,11 @@ resources:
                 Lifecycle setting to prevent the resource from being destroyed.
             "triggers":
               "description": |-
-                Conditions that re-fire this job run. Without triggers, the run re-fires only when its own configuration changes.
+                Conditions that re-fire this job run (in addition to configuration changes).
               "$fields":
                 "on_bundle_deploy":
                   "description": |-
-                    If true, re-fire the run on every bundle deploy, even when the run configuration is unchanged.
+                    If true, re-fire the run on every bundle deploy.
         "python_named_params":
           "description": |-
             PLACEHOLDER

--- a/bundle/internal/schema/annotations.yml
+++ b/bundle/internal/schema/annotations.yml
@@ -989,7 +989,7 @@ resources:
               "$fields":
                 "on_bundle_deploy":
                   "description": |-
-                    If true, re-fire the run on every bundle deploy.
+                    If true, re-fire the run on every bundle deploy. Incompatible with lifecycle.prevent_destroy.
         "python_named_params":
           "description": |-
             PLACEHOLDER

--- a/bundle/internal/schema/annotations.yml
+++ b/bundle/internal/schema/annotations.yml
@@ -978,7 +978,24 @@ resources:
       "$fields":
         "lifecycle":
           "description": |-
-            Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.
+            Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed and when the run re-fires.
+          "$fields":
+            "prevent_destroy":
+              "description": |-
+                Lifecycle setting to prevent the resource from being destroyed.
+            "triggers":
+              "description": |-
+                Conditions that re-fire this job run. Without triggers, the run re-fires only when its own configuration changes.
+              "$fields":
+                "on_bundle_deploy":
+                  "description": |-
+                    If true, re-fire the run on every bundle deploy, even when the run configuration is unchanged.
+                "on_file_change":
+                  "description": |-
+                    Re-fire the run when the contents of files matching this glob change. Not yet supported.
+                "on_value_change":
+                  "description": |-
+                    Re-fire the run when this bundle value expression changes. Not yet supported.
         "python_named_params":
           "description": |-
             PLACEHOLDER

--- a/bundle/internal/schema/annotations.yml
+++ b/bundle/internal/schema/annotations.yml
@@ -990,12 +990,6 @@ resources:
                 "on_bundle_deploy":
                   "description": |-
                     If true, re-fire the run on every bundle deploy, even when the run configuration is unchanged.
-                "on_file_change":
-                  "description": |-
-                    Re-fire the run when the contents of files matching this glob change. Not yet supported.
-                "on_value_change":
-                  "description": |-
-                    Re-fire the run when this bundle value expression changes. Not yet supported.
         "python_named_params":
           "description": |-
             PLACEHOLDER

--- a/bundle/phases/initialize.go
+++ b/bundle/phases/initialize.go
@@ -188,6 +188,9 @@ func Initialize(ctx context.Context, b *bundle.Bundle) {
 		// Reject configured job_runs.idempotency_token; the CLI sets it on run-now.
 		validate.ValidateJobRunIdempotencyToken(),
 
+		// Reject invalid job_runs.lifecycle.triggers (empty, false, prevent_destroy).
+		mutator.ValidateJobRunTriggers(),
+
 		// Reads (dynamic): * (strings) (searches for ${resources.*} references)
 		// Warns (TF engine) or errors (direct engine) when a cross-resource reference
 		// points to a Terraform-only field with no DABs equivalent.

--- a/bundle/phases/plan.go
+++ b/bundle/phases/plan.go
@@ -29,6 +29,7 @@ func PreDeployChecks(ctx context.Context, b *bundle.Bundle, isPlan bool, engine 
 		mutator.ValidateDirectOnlyResources(engine),
 		mutator.ValidateLifecycleStarted(engine),
 		mutator.ValidateCascadeOnDestroy(engine),
+		mutator.ValidateJobRunTriggers(),
 		statemgmt.CheckRunningResource(engine),
 	)
 }

--- a/bundle/schema/jsonschema.json
+++ b/bundle/schema/jsonschema.json
@@ -1298,7 +1298,7 @@
                     "type": "object",
                     "properties": {
                       "on_bundle_deploy": {
-                        "description": "If true, re-fire the run on every bundle deploy.",
+                        "description": "If true, re-fire the run on every bundle deploy. Incompatible with lifecycle.prevent_destroy.",
                         "$ref": "#/$defs/bool"
                       }
                     },

--- a/bundle/schema/jsonschema.json
+++ b/bundle/schema/jsonschema.json
@@ -1280,7 +1280,7 @@
                         "$ref": "#/$defs/bool"
                       },
                       "triggers": {
-                        "description": "Conditions that re-fire this job run. Without triggers, the run re-fires only when its own configuration changes.",
+                        "description": "Conditions that re-fire this job run (in addition to configuration changes).",
                         "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.JobRunTrigger"
                       }
                     },
@@ -1298,7 +1298,7 @@
                     "type": "object",
                     "properties": {
                       "on_bundle_deploy": {
-                        "description": "If true, re-fire the run on every bundle deploy, even when the run configuration is unchanged.",
+                        "description": "If true, re-fire the run on every bundle deploy.",
                         "$ref": "#/$defs/bool"
                       }
                     },

--- a/bundle/schema/jsonschema.json
+++ b/bundle/schema/jsonschema.json
@@ -1199,8 +1199,8 @@
                         "$ref": "#/$defs/map/string"
                       },
                       "lifecycle": {
-                        "description": "Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.",
-                        "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.Lifecycle"
+                        "description": "Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed and when the run re-fires.",
+                        "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.JobRunLifecycle"
                       },
                       "notebook_params": {
                         "description": "[Private Preview] A map from keys to values for jobs with notebook task, for example `\"notebook_params\": {\"name\": \"john doe\", \"age\": \"35\"}`.\nThe map is passed to the notebook and is accessible through the [dbutils.widgets.get](https://docs.databricks.com/dev-tools/databricks-utils.html) function.\n\nIf not specified upon `run-now`, the triggered run uses the job’s base parameters.\n\nnotebook_params cannot be specified in conjunction with jar_params.\n\n⚠ **Deprecation note** Use [job parameters](https://docs.databricks.com/jobs/job-parameters.html#job-parameter-pushdown) to pass information down to tasks.\n\nThe JSON representation of this field (for example `{\"notebook_params\":{\"name\":\"john doe\",\"age\":\"35\"}}`) cannot exceed 10,000 bytes.",
@@ -1263,6 +1263,54 @@
                     "required": [
                       "job_id"
                     ]
+                  },
+                  {
+                    "type": "string",
+                    "pattern": "\\$\\{(var(\\.\\p{L}+([-_]*[\\p{L}\\p{N}]+)*(\\[[0-9]+\\])*)+)\\}"
+                  }
+                ]
+              },
+              "resources.JobRunLifecycle": {
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "prevent_destroy": {
+                        "description": "Lifecycle setting to prevent the resource from being destroyed.",
+                        "$ref": "#/$defs/bool"
+                      },
+                      "triggers": {
+                        "description": "Conditions that re-fire this job run. Without triggers, the run re-fires only when its own configuration changes.",
+                        "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.JobRunTrigger"
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "string",
+                    "pattern": "\\$\\{(var(\\.\\p{L}+([-_]*[\\p{L}\\p{N}]+)*(\\[[0-9]+\\])*)+)\\}"
+                  }
+                ]
+              },
+              "resources.JobRunTrigger": {
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "on_bundle_deploy": {
+                        "description": "If true, re-fire the run on every bundle deploy, even when the run configuration is unchanged.",
+                        "$ref": "#/$defs/bool"
+                      },
+                      "on_file_change": {
+                        "description": "Re-fire the run when the contents of files matching this glob change. Not yet supported.",
+                        "$ref": "#/$defs/string"
+                      },
+                      "on_value_change": {
+                        "description": "Re-fire the run when this bundle value expression changes. Not yet supported.",
+                        "$ref": "#/$defs/string"
+                      }
+                    },
+                    "additionalProperties": false
                   },
                   {
                     "type": "string",
@@ -15151,6 +15199,20 @@
                       "type": "array",
                       "items": {
                         "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.JobPermission"
+                      }
+                    },
+                    {
+                      "type": "string",
+                      "pattern": "\\$\\{(var(\\.\\p{L}+([-_]*[\\p{L}\\p{N}]+)*(\\[[0-9]+\\])*)+)\\}"
+                    }
+                  ]
+                },
+                "resources.JobRunTrigger": {
+                  "oneOf": [
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.JobRunTrigger"
                       }
                     },
                     {

--- a/bundle/schema/jsonschema.json
+++ b/bundle/schema/jsonschema.json
@@ -1300,14 +1300,6 @@
                       "on_bundle_deploy": {
                         "description": "If true, re-fire the run on every bundle deploy, even when the run configuration is unchanged.",
                         "$ref": "#/$defs/bool"
-                      },
-                      "on_file_change": {
-                        "description": "Re-fire the run when the contents of files matching this glob change. Not yet supported.",
-                        "$ref": "#/$defs/string"
-                      },
-                      "on_value_change": {
-                        "description": "Re-fire the run when this bundle value expression changes. Not yet supported.",
-                        "$ref": "#/$defs/string"
                       }
                     },
                     "additionalProperties": false


### PR DESCRIPTION
## Changes

Adds `lifecycle.triggers.on_bundle_deploy: true` for experimental `job_runs` (direct engine): re-fire the run on every bundle deploy.

- Config: `JobRunLifecycle.triggers` shadows `BaseResource.Lifecycle`.
- Planning: when armed, `PrepareState` stores a fresh UUID fingerprint under state `lifecycle.triggers.on_bundle_deploy` so the existing recreate rule fires every deploy.
- Removal: clearing the trigger becomes a state-only `Update` (`OverrideChangeDesc` + `DoUpdate` no-op on lifecycle paths) so the fingerprint is dropped from state without re-firing the run.
- Validation: `on_bundle_deploy` must be `true` when set; incompatible with `lifecycle.prevent_destroy`.

Without the trigger, behavior is unchanged.

## Why

Users need a declarative "run this every deploy" switch (migrations, seed jobs) without editing run config to force a recreate.

## Tests

- Unit: trigger validation; fingerprint only when armed; clear downgrades to state-only update, fresh fingerprint still recreates; `knownMissingInRemoteType` for local-only `lifecycle` state
- Acceptance: redeploy with unchanged config plans recreate and issues a second `run-now`; removing the trigger plans a state-only update with no `run-now`. Runs under `READPLAN=["", "1"]` so a `--plan` deploy also persists the fingerprint and still recreates
- Test config: direct-engine matrix and `RecordRequests` hoisted to parent `test.toml`s (upload-count shifts in three goldens are from dropping those files from the synced bundle)