### PR TITLE
acc: drop the stale Local key from the cascade destroy tests

### DIFF
--- a/acceptance/pipelines/destroy/cascade-on-destroy-terraform-error/out.test.toml
+++ b/acceptance/pipelines/destroy/cascade-on-destroy-terraform-error/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform"]

--- a/acceptance/pipelines/destroy/cascade-on-destroy-terraform-error/test.toml
+++ b/acceptance/pipelines/destroy/cascade-on-destroy-terraform-error/test.toml
@@ -1,4 +1,3 @@
-Local = true
 RecordRequests = false
 
 # Static validation only; no need to run on cloud.

--- a/acceptance/pipelines/destroy/destroy-pipeline-cascade-state-divergence/out.test.toml
+++ b/acceptance/pipelines/destroy/destroy-pipeline-cascade-state-divergence/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/pipelines/destroy/destroy-pipeline-cascade/out.test.toml
+++ b/acceptance/pipelines/destroy/destroy-pipeline-cascade/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]


### PR DESCRIPTION
## Summary
Drop stale `Local = true` left by #5846 after #6196 removed the field from `TestConfig`. Unblocks `task test-pipelines` on main.