### PR TITLE
Fix main after cascade deletion in DABs (#5846)

### DIFF
--- a/acceptance/bundle/config-remote-sync/split/positional/output.txt
+++ b/acceptance/bundle/config-remote-sync/split/positional/output.txt
@@ -65,7 +65,7 @@ The following resources will be deleted:
   delete resources.pipelines.split_pipeline
 
 This action will result in the deletion of the following Lakeflow Spark Declarative Pipelines along with the
-Streaming Tables (STs) and Materialized Views (MVs) managed by them:
+Streaming Tables (STs) and Materialized Views (MVs) managed by them. Set 'cascade_on_destroy: false' on a pipeline to retain datasets on pipeline deletion:
   delete resources.pipelines.split_pipeline
 
 All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/test-bundle-[UNIQUE_NAME]/dev

--- a/acceptance/pipelines/destroy/cascade-on-destroy-terraform-error/out.test.toml
+++ b/acceptance/pipelines/destroy/cascade-on-destroy-terraform-error/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform"]

--- a/acceptance/pipelines/destroy/cascade-on-destroy-terraform-error/test.toml
+++ b/acceptance/pipelines/destroy/cascade-on-destroy-terraform-error/test.toml
@@ -1,4 +1,3 @@
-Local = true
 RecordRequests = false
 
 # Static validation only; no need to run on cloud.

--- a/acceptance/pipelines/destroy/destroy-pipeline-cascade-state-divergence/out.test.toml
+++ b/acceptance/pipelines/destroy/destroy-pipeline-cascade-state-divergence/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/pipelines/destroy/destroy-pipeline-cascade/out.test.toml
+++ b/acceptance/pipelines/destroy/destroy-pipeline-cascade/out.test.toml
@@ -1,3 +1,2 @@
-Local = true
 Cloud = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/python/databricks/bundles/pipelines/_models/pipeline.py
+++ b/python/databricks/bundles/pipelines/_models/pipeline.py
@@ -73,6 +73,11 @@ class Pipeline(Resource):
     [Public Preview] Budget policy of this pipeline.
     """
 
+    cascade_on_destroy: VariableOrOptional[bool] = None
+    """
+    Whether destroying the pipeline also deletes its datasets (MVs, STs, Views). Defaults to true (the server default). Set to false to retain the datasets when the pipeline is deleted. Only affects the delete operation.
+    """
+
     catalog: VariableOrOptional[str] = None
     """
     A catalog in Unity Catalog to publish data from this pipeline to. If `target` is specified, tables in this pipeline are published to a `target` schema inside `catalog` (for example, `catalog`.`target`.`table`). If `target` is not specified, no data is published to Unity Catalog.
@@ -257,6 +262,11 @@ class PipelineDict(TypedDict, total=False):
     budget_policy_id: VariableOrOptional[str]
     """
     [Public Preview] Budget policy of this pipeline.
+    """
+
+    cascade_on_destroy: VariableOrOptional[bool]
+    """
+    Whether destroying the pipeline also deletes its datasets (MVs, STs, Views). Defaults to true (the server default). Set to false to retain the datasets when the pipeline is deleted. Only affects the delete operation.
     """
 
     catalog: VariableOrOptional[str]


### PR DESCRIPTION
Three leftovers from [#5846](https://github.com/databricks/cli/pull/5846) fail on `main`:

- `test.toml` sets `Local`, which [#6196](https://github.com/databricks/cli/pull/6196) removed from the
  acceptance config, so the parent test fails with `Undecoded key ... Local` while its subtest passes.
- The destroy prompt gained a `cascade_on_destroy` hint, but the `config-remote-sync` golden was not
  regenerated.
- The pipelines schema gained `cascade_on_destroy`, but the generated pydabs model was not
  regenerated, so `validate-generated` fails.

Regenerated with `./task generate-check` and `-update`; no hand edits.