### PR TITLE
Mark tf deprecated in bundle.engine & update default value in annotation

### DIFF
--- a/bundle/internal/schema/annotations.yml
+++ b/bundle/internal/schema/annotations.yml
@@ -101,13 +101,18 @@ bundle:
                 Whether to force this lock if it is enabled.
     "engine":
       "description": |-
-        The deployment engine to use. Valid values are `terraform` and `direct`. Takes priority over `DATABRICKS_BUNDLE_ENGINE` environment variable. Default is "terraform".
+        The deployment engine to use. Valid values are `terraform` and `direct`. Takes priority over `DATABRICKS_BUNDLE_ENGINE` environment variable. Default is "direct".
       "$type":
         "enum":
           - |-
             terraform
           - |-
             direct
+        "x-databricks-enum-descriptions":
+          "direct": |-
+            Deploy by calling the Databricks APIs directly. This is the default.
+          "terraform": |-
+            Deploy through Terraform. Deprecated: Migrate to `direct`, see https://docs.databricks.com/aws/en/dev-tools/bundles/direct
     "git":
       "description": |-
         The Git version control details that are associated with your bundle.

--- a/bundle/schema/jsonschema.json
+++ b/bundle/schema/jsonschema.json
@@ -66,6 +66,10 @@
                     "enum": [
                       "terraform",
                       "direct"
+                    ],
+                    "enumDescriptions": [
+                      "Deploy through Terraform. Deprecated: Migrate to `direct`, see https://docs.databricks.com/aws/en/dev-tools/bundles/direct",
+                      "Deploy by calling the Databricks APIs directly. This is the default."
                     ]
                   },
                   {
@@ -3096,7 +3100,7 @@
                       "markdownDescription": "The definition of the bundle deployment. For supported attributes see [link](https://docs.databricks.com/dev-tools/bundles/deployment-modes.html)."
                     },
                     "engine": {
-                      "description": "The deployment engine to use. Valid values are `terraform` and `direct`. Takes priority over `DATABRICKS_BUNDLE_ENGINE` environment variable. Default is \"terraform\".",
+                      "description": "The deployment engine to use. Valid values are `terraform` and `direct`. Takes priority over `DATABRICKS_BUNDLE_ENGINE` environment variable. Default is \"direct\".",
                       "$ref": "#/$defs/github.com/databricks/cli/bundle/config/engine.EngineType"
                     },
                     "git": {


### PR DESCRIPTION
## Changes

Update `bundle.engine` annotation in jsonschema

## Why

Was missed earlier

## Tests

<img width="886" height="309" alt="Screenshot 2026-08-11 at 15 04 59" src="https://github.com/user-attachments/assets/6b4b421c-2dc1-4457-b34c-26481552b247" />
