### PR TITLE
AIR CLI: attach docker_image_url to the run (follow-up to #6165)

### DIFF
--- a/experimental/air/cmd/runsubmit.go
+++ b/experimental/air/cmd/runsubmit.go
@@ -80,11 +80,8 @@ func buildSubmitPayload(cfg *runConfig, commandPath, dlImage, usagePolicyID stri
 			},
 		}},
 		CodeSourcePath: snap.CodeSourcePath,
-		// NOTE: docker_image_url is intentionally not set here yet. The field was
-		// added to jobs.AiRuntimeTask in databricks-sdk-go after v0.170.0, which the
-		// CLI has not bumped to. prepareDockerImage already verifies the image is
-		// registered; passing it on the task lands in the follow-up PR once the SDK
-		// bump + codegen is in.
+		// Verified as registered by prepareDockerImage.
+		DockerImageUrl: cfg.dockerImageURL(),
 	}
 	if cfg.MLflowRunName != nil {
 		task.MlflowRun = *cfg.MLflowRunName

--- a/experimental/air/cmd/runsubmit_test.go
+++ b/experimental/air/cmd/runsubmit_test.go
@@ -71,6 +71,37 @@ func TestBuildSubmitPayload(t *testing.T) {
 	assert.Equal(t, jobs.ComputeSpec{AcceleratorType: jobs.ComputeSpecAcceleratorTypeGpu8xH100, AcceleratorCount: 16}, at.Deployments[0].Compute)
 }
 
+func TestBuildSubmitPayloadDockerImage(t *testing.T) {
+	cfg := &runConfig{
+		ExperimentName: "exp",
+		Command:        new("x"),
+		Compute:        &computeConfig{AcceleratorType: "GPU_1xH100", NumAccelerators: 1},
+		Environment: &environmentConfig{
+			DockerImage: &dockerImageConfig{URL: "nvcr.io/org/img:1.0"},
+		},
+	}
+
+	p := buildSubmitPayload(cfg, "/d/command.sh", "5", "", snapshotResult{}, nil)
+	require.Len(t, p.Tasks, 1)
+	require.NotNil(t, p.Tasks[0].AiRuntimeTask)
+	assert.Equal(t, "nvcr.io/org/img:1.0", p.Tasks[0].AiRuntimeTask.DockerImageUrl)
+}
+
+func TestBuildSubmitPayloadNoDockerImage(t *testing.T) {
+	// Without an environment.docker_image block the field stays empty (omitempty),
+	// so the runtime-managed environment is used.
+	cfg := &runConfig{
+		ExperimentName: "exp",
+		Command:        new("x"),
+		Compute:        &computeConfig{AcceleratorType: "GPU_1xH100", NumAccelerators: 1},
+	}
+
+	p := buildSubmitPayload(cfg, "/d/command.sh", "5", "", snapshotResult{}, nil)
+	require.Len(t, p.Tasks, 1)
+	require.NotNil(t, p.Tasks[0].AiRuntimeTask)
+	assert.Empty(t, p.Tasks[0].AiRuntimeTask.DockerImageUrl)
+}
+
 func TestBuildSubmitPayloadDefaultRetries(t *testing.T) {
 	// max_retries unset defaults to 3 (matching the Python native path), so both
 	// retry fields are sent.


### PR DESCRIPTION
## Changes
Sets `ai_runtime_task.docker_image_url` from `environment.docker_image.url` in `buildSubmitPayload`, so a registered custom image is actually attached to the run — the last step of the docker-image wiring. Re-adds the two `buildSubmitPayload` tests (field set / field omitted).

## Why
The parent work (#6165, now merged to `main`) verifies the image (config parse + `prepareDockerImage` preflight) but intentionally does **not** attach it to the submit payload, because the `docker_image_url` field on `jobs.AiRuntimeTask` was added to `databricks-sdk-go` **after v0.170.0** and `main` is pinned to **v0.166.0**. Setting the field there would break the build, so it was split into this follow-up.

This one-line change is that deferred step. It has a hard dependency the parent did not:

> [!IMPORTANT]
> **Blocked on an SDK bump. Do not merge until `main`'s `databricks-sdk-go` is bumped to a release that includes `AiRuntimeTask.docker_image_url`** (the field is on SDK `main` via databricks/databricks-sdk-go#1800, pending a release tag). That bump is its own PR (it also regenerates command stubs). Until it lands, this branch does not compile against the pinned SDK and CI will be red — expected.
>
> Verified green (`go test`, `golangci-lint`, `gofmt`) against the SDK commit that has the field. Once the SDK bump merges, rebase this branch and it goes green with no further changes.

## Tests
`TestBuildSubmitPayloadDockerImage` (field set from config) and `TestBuildSubmitPayloadNoDockerImage` (empty when no image) — both pass against the SDK that has the field; they cannot compile until the bump.

## Base
Rebased onto `main` (the parent #6165 has merged).

This pull request and its description were written by Isaac.
