### PR TITLE
air: show environment for AI Runtime runs in `air get`

### DIFF
--- a/.nextchanges/cli/air-get-environment.md
+++ b/.nextchanges/cli/air-get-environment.md
@@ -1,0 +1,1 @@
+`experimental air get` now shows the training environment (version or docker image) for AI Runtime runs, reading it from the run's config; previously it always displayed `N/A`.

--- a/AIR_BUGBASH.md
+++ b/AIR_BUGBASH.md
@@ -1,0 +1,204 @@
+# `air` CLI (Go port) bug bash
+
+The `air` CLI has been ported from Python to Go, and now ships inside the
+Databricks CLI as `databricks experimental air`. Same commands you know — `run`,
+`get`, `list`, `logs`, `cancel`, `register-image` — reimplemented. We want to know
+where the port diverges from what you'd expect.
+
+## Prerequisites
+
+- Access to a workspace with **serverless GPU compute** enabled, e.g.
+  go/e2-dogfood, go/azure-dogfood, go/df1
+- Go 1.26.x and git
+
+## Setup
+
+```sh
+# 1. Clone the Databricks CLI and build (~2 min). `air` is on main — no branch needed.
+git clone https://github.com/databricks/cli.git ~/databricks-cli
+cd ~/databricks-cli && ./task build
+
+# 2. Install as `databricks` on your PATH.
+mkdir -p ~/bin && cp ./cli ~/bin/databricks && export PATH="$HOME/bin:$PATH"
+
+# 3. Authenticate (opens browser).
+databricks auth login --profile air-bugbash
+export DATABRICKS_CONFIG_PROFILE=air-bugbash
+
+# 4. Test installation.
+databricks experimental air --help
+```
+
+Optional: `docker login <registry>` if you want to test `register-image` with a
+private image.
+
+Handy alias, used throughout this doc: `alias air='databricks experimental air'`
+
+### A minimal config to start from
+
+```yaml
+# ~/train.yaml — the sleep keeps the run alive long enough to test logs and cancel
+experiment_name: my-air-bugbash-run
+compute: {accelerator_type: GPU_1xA10, num_accelerators: 1}
+command: echo "hello AIR"; sleep 300
+```
+
+Then `air run -f ~/train.yaml`. Start with `--dry-run` if you want to check a config
+before spending GPU time on it.
+
+---
+
+## CUJs
+
+**When you pick up a CUJ, add your name to the feedback table at the bottom.**
+
+Throughout: most commands take `-o json` as well as the default text output. Please
+try both — a broken JSON envelope is as much a bug as broken text, and the error
+paths matter most (stdout should stay valid JSON even when something fails).
+
+### CUJ 1: Submit a run and watch it
+
+Start with the minimal config above and just `air run -f ~/train.yaml`. Then start
+layering on the flags: `--dry-run` to validate without submitting (it makes no
+workspace calls at all, so it should work even with credentials unset),
+`--override compute.num_accelerators=8` to patch a field from the command line
+without editing YAML (repeatable), and `--idempotency-key <something>` to make a
+resubmission return the *existing* run instead of starting a second one — run it
+twice with the same key and confirm you get one run, not two.
+
+The interesting one is `--watch`, which submits and then streams logs until the run
+finishes. Check that the exit code reflects the run's actual outcome, and that
+Ctrl-C partway through exits cleanly rather than hanging or dumping a stack trace.
+
+Then try to break the config. Bad values should be rejected clearly and early, with
+a message that tells you what to fix: 3 accelerators on a `GPU_8xH100` (not a
+multiple of 8), the same name in both `env_variables` and `secrets`, a missing
+`command`, `max_retries: -1`, `timeout_minutes: 0`, an `mlflow_experiment_directory`
+that doesn't start with `/Workspace`, both `usage_policy_name` and
+`usage_policy_id` set at once, or `environment.version` alongside a
+`dependencies:` file path (the file carries its own version, so setting both is
+contradictory).
+
+### CUJ 2: Ship real code with `code_source`
+
+Point a run at a local directory and confirm the code actually arrives:
+
+```yaml
+code_source:
+  type: snapshot
+  snapshot:
+    root_path: .
+    include_paths: [train.py]     # omit to include everything
+```
+
+Worth poking at: `include_paths` should genuinely exclude what you left out (drop a
+large junk file in the directory and confirm it isn't uploaded), `git: {commit: <sha>}`
+should pin the snapshot to that revision rather than archiving your working tree,
+and `remote_volume: /Volumes/...` should upload there instead of the default
+location. Resubmitting at the same pinned commit is supposed to reuse a cached
+tarball — see whether the second submit is noticeably faster.
+
+Also try dependencies both ways: an inline list (`dependencies: [numpy, torch==2.3.0]`)
+and a path to a `requirements.yaml`. Both should end up installed in the run.
+
+### CUJ 3: Multi-node
+
+Anything with `num_accelerators` spanning more than one node — e.g. 16 on
+`GPU_8xH100` — exercises a lot of code that single-node runs never touch. Submit
+one, then use `air get` and `air logs --node N` against it, and cross-check the
+Jobs page and MLflow page in the UI against what the CLI reports.
+
+### CUJ 4: `list`, `get`, `logs`, `cancel`
+
+Test out the 4 core commands with multiple active runs. Specific flags to test out:
+
+**`air list`** — interactive table in a terminal; prints once when piped or under `NO_COLOR=1`.
+- Navigate with `j`/`k` or arrows, `g`/`G` for top/bottom, left/right to page, `enter` to open a run, `q` to quit. Page back through older runs and watch for responsiveness.
+- `--limit N` — caps the rows, and switches off the TUI.
+- `--all-status` — include finished runs, not just active ones.
+- `--all-users` — everyone's runs, not just yours.
+- `--filter KEY=VALUE` — repeatable and ANDed. Keys: `experiment` (glob, e.g. `'foo*'`), `accelerator_type` (substring, e.g. `H100`), `num_accelerators` (exact), `user` (email).
+- Run it twice — the second should be faster, since finished runs cache to disk.
+
+**`air get <run-id>`** — one run in detail.
+- Cross-check status, duration, accelerators, and environment against the Jobs/MLflow UI.
+- Click the run ID and MLflow hyperlinks.
+- On a sweep (`foreach`) run, expect a per-iteration breakdown instead of the single-run view.
+
+**`air logs <run-id>`** — new backend, so give this the most attention.
+- No flags: stream a run producing lots of output and see whether it keeps up.
+- `--lines N` — tail the last N lines of a finished run.
+- `--minutes N` — only the last N minutes.
+- `--node N` — isolate one node of a multi-node run.
+- `--retry N` — read an earlier attempt of a retried run.
+- `--download-to <dir>` — brand new; pulls every node's logs to disk in parallel, one file per node. Check the files are complete and in order, and that one unavailable node warns you rather than silently returning a truncated log.
+- Rejections should be explicit, not silent: `--download-to` with `--lines`/`--minutes`, `--lines` with `--minutes`, `--node 5` on a 2-node run.
+- Edge cases: a run that produced no logs, and Ctrl-C mid-stream and mid-download.
+
+**`air cancel <run-id>`** — prompts first.
+- `-y` skips the confirmation.
+- Several run IDs in one call.
+- `--all` — every one of *your* active runs, across all pages, and nobody else's.
+- Errors: IDs combined with `--all`, and neither one given.
+
+### CUJ 5: Custom images — `register-image`
+
+Walk the whole path once with a private image and judge how it reads:
+
+```sh
+docker login <registry>
+air register-image <registry>/<repo>:<tag>   # prints digest + a config snippet
+# paste that snippet into ~/train.yaml, then:
+air run -f ~/train.yaml --dry-run
+```
+
+Credentials should be picked up from your local Docker config with no flags to pass,
+the printed snippet should paste in and validate as-is, and re-registering should
+report cached-vs-updated truthfully. Failures should say whether retrying helps, and
+the replication wait should show progress rather than looking like a hang.
+
+> **Known gap:** `air run` ignores `environment.docker_image` at submit — that DCS
+> wiring is on an unmerged branch, so don't file it. Do file anything misleading
+> along the way, like a snippet the config parser rejects or a success message for
+> an image that isn't ready.
+
+### CUJ 6: Chain them together
+
+The seams between commands are where bugs hide. A few chains worth walking:
+
+- `air run` → `air get` → `air logs` → `air cancel` → `air get` again and confirm
+  it shows as cancelled.
+- `air run --watch` in one terminal, `air cancel <id> -y` in another. The watching
+  process should notice and exit cleanly with a sensible code.
+- Submit a few runs → find them in `air list` → narrow with `--filter` →
+  `air cancel --all -y` → confirm `air list` is empty but `--all-status` still
+  shows them.
+- Run the same run ID through every command with `-o json` and pipe each to `jq`.
+
+---
+
+## Known issues — please don't file these
+
+- `air run` doesn't use a registered Docker image yet (pending proto change).
+- `air logs --review` reports "not implemented yet" (hidden flag).
+- Interactive `air list` caps its page size to the terminal height, so a short
+  window shows only a few runs. Fix exists, not on this build.
+- `air run -h config` prints ordinary command help — the inline config-schema
+  reference is still on an unmerged branch (`air-config-help`, needs a rebase).
+- `--tag-policy` on `register-image` is deprecated and ignored.
+
+## Filing bugs
+
+Include the command verbatim, the config YAML, the output in both text and
+`-o json`, the run ID, and `git rev-parse HEAD` from your checkout.
+
+## BugBash feedback
+
+| CUJ | Name | Findings |
+| --- | --- | --- |
+| 1: Submit and watch | | |
+| 2: code_source | | |
+| 3: Multi-node | | |
+| 4: list/get/logs/cancel | | |
+| 5: register-image | | |
+| 6: Chains | | |

--- a/acceptance/experimental/air/get-ai-runtime/output.txt
+++ b/acceptance/experimental/air/get-ai-runtime/output.txt
@@ -8,6 +8,10 @@
 │  compute:                                                      │
 │    accelerator_type: a10                                       │
 │    num_accelerators: 1                                         │
+│  environment:                                                  │
+│    version: 5                                                  │
+│    dependencies:                                               │
+│      - torch==2.3.0                                            │
 │  command: |-                                                   │
 │    for i in $(seq 1 10); do                                    │
 │      echo "step $i"                                            │
@@ -27,7 +31,7 @@
 │  MLflow Run    my-run                                          │
 │  User          user@example.com                                │
 │  Accelerators  1x A10                                          │
-│  Environment   N/A                                             │
+│  Environment   5                                               │
 │                                                                │
 ╰────────────────────────────────────────────────────────────────╯
 

--- a/acceptance/experimental/air/get-ai-runtime/training_config.yaml
+++ b/acceptance/experimental/air/get-ai-runtime/training_config.yaml
@@ -2,6 +2,10 @@ experiment_name: my-exp
 compute:
   accelerator_type: a10
   num_accelerators: 1
+environment:
+  version: 5
+  dependencies:
+    - torch==2.3.0
 command: |-
   for i in $(seq 1 10); do
     echo "step $i"

--- a/experimental/air/cmd/format.go
+++ b/experimental/air/cmd/format.go
@@ -298,6 +298,31 @@ func environment(run *jobs.Run) string {
 	return task.DlRuntimeImage
 }
 
+// environmentFromConfig extracts the training environment for the Environment
+// cell from a run's config YAML: the docker image URL when the config pins one,
+// otherwise the environment version. Returns "" when the config declares no
+// environment or cannot be parsed. This is the only source of the environment
+// for ai_runtime runs, whose GetRun response carries no environment field (the
+// gen_ai_compute path reads the image from the run response via environment()).
+func environmentFromConfig(configYAML string) string {
+	if configYAML == "" {
+		return ""
+	}
+	var cfg struct {
+		Environment *environmentConfig `yaml:"environment"`
+	}
+	if err := yaml.Unmarshal([]byte(configYAML), &cfg); err != nil || cfg.Environment == nil {
+		return ""
+	}
+	if cfg.Environment.DockerImage != nil {
+		return cfg.Environment.DockerImage.URL
+	}
+	if cfg.Environment.Version.set {
+		return cfg.Environment.Version.raw
+	}
+	return ""
+}
+
 // maxRetries returns the configured retry limit for the run's latest task as a
 // display string: "unlimited" for the backend's -1, otherwise the count.
 func maxRetries(run *jobs.Run) string {

--- a/experimental/air/cmd/format_test.go
+++ b/experimental/air/cmd/format_test.go
@@ -230,6 +230,30 @@ func TestAcceleratorLabel(t *testing.T) {
 	assert.Equal(t, "8x", acceleratorLabel("", 8))
 }
 
+func TestEnvironmentFromConfig(t *testing.T) {
+	tests := []struct {
+		name       string
+		configYAML string
+		want       string
+	}{
+		{"empty", "", ""},
+		{"no environment", "experiment_name: my-exp\ncompute:\n  accelerator_type: a10", ""},
+		{"version int", "environment:\n  version: 5\n  dependencies:\n    - torch", "5"},
+		{"version string", "environment:\n  version: \"5\"\n  dependencies:\n    - torch", "5"},
+		// docker_image wins over version (they are mutually exclusive in a valid config).
+		{"docker image", "environment:\n  docker_image:\n    url: org/repo:tag", "org/repo:tag"},
+		// dependencies without a pinned version resolve the version at launch, so
+		// there is nothing to show here.
+		{"dependencies only", "environment:\n  dependencies:\n    - torch", ""},
+		{"malformed", "environment: [not-a-map", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, environmentFromConfig(tt.configYAML))
+		})
+	}
+}
+
 func TestStatusWord(t *testing.T) {
 	assert.Equal(t, "SUCCESS", statusWord("TERMINATED", "SUCCESS")) // result wins
 	assert.Equal(t, "RUNNING", statusWord("RUNNING", ""))           // falls back to lifecycle

--- a/experimental/air/cmd/render.go
+++ b/experimental/air/cmd/render.go
@@ -91,6 +91,15 @@ func renderRunText(ctx context.Context, out io.Writer, w *databricks.WorkspaceCl
 	renderer, colorOn := cmdio.NewRenderer(ctx, out)
 	p := newPalette(renderer)
 
+	// Resolve the training config once: it renders the Configuration box, and for
+	// ai_runtime runs it is the only source of the Environment cell (the run
+	// response carries the runtime image for gen_ai_compute runs, but no
+	// environment field for ai_runtime runs, leaving EnvironmentDisplay at "N/A").
+	configYAML := resolveConfigYAML(ctx, w, run, data)
+	if data.EnvironmentDisplay == na {
+		data.EnvironmentDisplay = orNA(environmentFromConfig(configYAML))
+	}
+
 	view := runView{
 		runID:        data.RunID,
 		dashboardURL: data.DashboardURL,
@@ -112,7 +121,7 @@ func renderRunText(ctx context.Context, out io.Writer, w *databricks.WorkspaceCl
 	}
 
 	var sections []string
-	if body := colorizeConfig(p, resolveConfigYAML(ctx, w, run, data)); body != "" {
+	if body := colorizeConfig(p, configYAML); body != "" {
 		sections = append(sections, renderBox(p, configBoxTitle, body))
 	}
 	sections = append(sections, renderBox(p, metadataBoxTitle, renderFields(p, colorOn, view)))

--- a/test_air_cancel.sh
+++ b/test_air_cancel.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+#
+# Manual / e2e smoke test for `air cancel` against a REAL workspace.
+# Run from ~/cli-wt-air-cancel (branch air-cancel-port = m2-3 + cancel).
+#
+#   PROFILE=riddhi.bhagwat ./test_air_cancel.sh
+#
+# Optional, opt-in (these ACTUALLY CANCEL runs):
+#   RUN_ID=<jobRunId> [RUN_ID2=<jobRunId>] PROFILE=... ./test_air_cancel.sh
+#   ALLOW_CANCEL_ALL=1 PROFILE=... ./test_air_cancel.sh
+#
+# What runs unconditionally is non-destructive:
+#   - argument validation (no API call)
+#   - invalid id / not-found (the cancel just fails)
+#   - `--all` preview then ABORT (answers "n", cancels nothing)
+#
+# set -e is intentionally OFF: most cases are expected to exit non-zero and we
+# assert on that.
+set -u
+
+PROFILE="${PROFILE:-riddhi.bhagwat}"
+CLI="${CLI:-./cli}"
+BOGUS_ID="999999999999999"   # a syntactically valid id that should not exist
+
+pass=0 fail=0
+hr(){ printf -- '------------------------------------------------------------\n'; }
+section(){ printf '\n=========================  %s  =========================\n' "$1"; }
+
+# check "<desc>" <expected_exit|any> "<expected_substr|>" -- cmd...
+check(){
+  local desc="$1" expcode="$2" substr="$3"; shift 3; [ "$1" = "--" ] && shift
+  hr; printf '· %s\n$ %s\n' "$desc" "$*"
+  local out code ok=1
+  out="$("$@" 2>&1)"; code=$?
+  printf '%s\n' "$out"
+  if [ "$expcode" != "any" ] && [ "$code" -ne "$expcode" ]; then
+    printf '  \xE2\x9C\x97 exit %s (expected %s)\n' "$code" "$expcode"; ok=0
+  fi
+  if [ -n "$substr" ] && ! grep -qF -- "$substr" <<<"$out"; then
+    printf '  \xE2\x9C\x97 missing text: %s\n' "$substr"; ok=0
+  fi
+  if [ "$ok" = 1 ]; then printf '  \xE2\x9C\x93 PASS (exit %s)\n' "$code"; pass=$((pass+1));
+  else fail=$((fail+1)); fi
+}
+
+# ----------------------------------------------------------------------------
+section "0. preflight"
+if [ ! -x "$CLI" ]; then
+  echo "Building CLI binary..."; go build -o "$CLI" . || { echo "build failed"; exit 1; }
+fi
+echo "CLI:     $CLI"
+echo "PROFILE: $PROFILE"
+echo "Active runs in this workspace (for picking RUN_IDs):"
+preflight="$("$CLI" experimental air list --active -p "$PROFILE" 2>&1)"; printf '%s\n' "$preflight"
+if grep -qiE "refresh token is invalid|auth login|could not be retrieved|default auth" <<<"$preflight"; then
+  hr
+  echo "*** Authentication failed for profile '$PROFILE'. Re-authenticate, then re-run this script: ***"
+  echo "    databricks auth login --profile $PROFILE"
+  exit 1
+fi
+
+# ----------------------------------------------------------------------------
+section "1. argument validation (no API call)"
+check "no args -> error"                 1 "provide at least one JOB_RUN_ID, or use --all" -- "$CLI" experimental air cancel -p "$PROFILE"
+check "ids + --all -> error"             1 "cannot combine JOB_RUN_ID arguments with --all" -- "$CLI" experimental air cancel 123 --all -p "$PROFILE"
+check "--help -> usage, no error"        0 "Cancel one or more runs" -- "$CLI" experimental air cancel --help
+
+# ----------------------------------------------------------------------------
+section "2. invalid / not-found (cancels nothing)"
+check "non-numeric id"                   1 "invalid run ID" -- "$CLI" experimental air cancel abc -p "$PROFILE"
+check "zero id"                          1 "invalid run ID" -- "$CLI" experimental air cancel 0 -p "$PROFILE"
+check "not-found (text)"                 1 "not found" -- "$CLI" experimental air cancel "$BOGUS_ID" -p "$PROFILE"
+check "not-found summary"                1 "1 run(s) failed to cancel." -- "$CLI" experimental air cancel "$BOGUS_ID" -p "$PROFILE"
+check "not-found (json) has failed"      1 '"failed"' -- "$CLI" experimental air cancel "$BOGUS_ID" -o json -p "$PROFILE"
+
+# ----------------------------------------------------------------------------
+section "3. --all preview + ABORT (answers 'n', cancels nothing)"
+hr; printf '· --all then answer n (preview shown, then aborted)\n$ printf "n\\n" | %s experimental air cancel --all -p %s\n' "$CLI" "$PROFILE"
+out="$(printf 'n\n' | "$CLI" experimental air cancel --all -p "$PROFILE" 2>&1)"; code=$?
+printf '%s\n' "$out"
+if grep -qF "Cancellation aborted." <<<"$out" || grep -qF "No active runs found." <<<"$out"; then
+  printf '  \xE2\x9C\x93 PASS (exit %s)\n' "$code"; pass=$((pass+1))
+else
+  printf '  \xE2\x9C\x97 expected "Cancellation aborted." or "No active runs found."\n'; fail=$((fail+1))
+fi
+
+# ----------------------------------------------------------------------------
+section "4. by-id cancellation (opt-in: set RUN_ID / RUN_ID2)  *** DESTRUCTIVE ***"
+if [ -n "${RUN_ID:-}" ]; then
+  check "cancel single (text)"           0 "Successfully requested cancellation for run ${RUN_ID}" -- "$CLI" experimental air cancel "$RUN_ID" -p "$PROFILE"
+  check "cancel single (json)"           0 '"cancelled"' -- "$CLI" experimental air cancel "$RUN_ID" -o json -p "$PROFILE"
+  check "valid + bogus -> partial fail"  1 "1 run(s) failed to cancel." -- "$CLI" experimental air cancel "$RUN_ID" "$BOGUS_ID" -p "$PROFILE"
+  if [ -n "${RUN_ID2:-}" ]; then
+    check "cancel two -> count summary"  0 "Successfully requested cancellation for 2 run(s)." -- "$CLI" experimental air cancel "$RUN_ID" "$RUN_ID2" -p "$PROFILE"
+  fi
+else
+  echo "skipped (set RUN_ID=<id> [RUN_ID2=<id>] to enable)"
+fi
+
+# ----------------------------------------------------------------------------
+section "5. --all -y cancellation (opt-in: ALLOW_CANCEL_ALL=1)  *** DESTRUCTIVE ***"
+if [ "${ALLOW_CANCEL_ALL:-0}" = "1" ]; then
+  check "--all -y (text)"                any "" -- "$CLI" experimental air cancel --all -y -p "$PROFILE"
+  check "--all -y (json) all:true"       any '"all"' -- "$CLI" experimental air cancel --all -y -o json -p "$PROFILE"
+else
+  echo "skipped (set ALLOW_CANCEL_ALL=1 to enable — this cancels every active run you own)"
+fi
+
+# ----------------------------------------------------------------------------
+hr; printf 'SUMMARY: %s passed, %s failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/train.yaml
+++ b/train.yaml
@@ -1,0 +1,6 @@
+experiment_name: llama-fine-tune          # <=100 chars, [A-Za-z0-9_-] only
+compute:
+  accelerator_type: GPU_1xA10              # A10 = 1 GPU/node, so count 1 is a valid multiple
+  num_accelerators: 1
+command: |
+  python train.py --epochs 3


### PR DESCRIPTION
## Summary

`experimental air get` showed `Environment N/A` for every AI Runtime (serverless) run.

The `Environment` cell is populated by `environment(run)`, which reads the runtime image only from a run's `gen_ai_compute_task` (`DlRuntimeImage`). AI Runtime runs — the ones `air run` submits — have no `gen_ai_compute_task`, and the `jobs/runs/get` response carries no environment field for them (the environment version/image is submitted on the run's `environments` spec but not echoed back on a read). So the cell always fell back to `N/A`.

This derives the environment for AI Runtime runs from the run's training config, which `air get` already downloads to render the Configuration box — no extra API call. It shows the docker image URL when the config pins one, otherwise the `environment.version`. The `gen_ai_compute` path is unchanged.

## Changes

- `experimental/air/cmd/format.go`: new `environmentFromConfig` helper that parses `environment.docker_image.url` / `environment.version` out of the run config, reusing the existing `environmentConfig` schema type.
- `experimental/air/cmd/render.go`: resolve the training config once in `renderRunText` (it already downloaded it for the box), and fill the `Environment` cell from it when the run response left it at `N/A`.

## Testing

- Unit test `TestEnvironmentFromConfig` covers version (int/string), docker image, dependencies-only (no pinned version), no-environment, and malformed input.
- Acceptance test `experimental/air/get-ai-runtime` now includes an `environment` block and asserts the cell renders `5` instead of `N/A`.
- `go test ./experimental/air/...` and `go test ./acceptance -run TestAccept/experimental/air` pass; package lints clean.

This pull request and its description were written by Isaac.