### PR TITLE
AIR CLI Integration: show environment for AI Runtime runs in `air get`

### DIFF
--- a/acceptance/experimental/air/get-ai-runtime/output.txt
+++ b/acceptance/experimental/air/get-ai-runtime/output.txt
@@ -8,6 +8,10 @@
 │  compute:                                                      │
 │    accelerator_type: a10                                       │
 │    num_accelerators: 1                                         │
+│  environment:                                                  │
+│    version: 5                                                  │
+│    dependencies:                                               │
+│      - torch==2.3.0                                            │
 │  command: |-                                                   │
 │    for i in $(seq 1 10); do                                    │
 │      echo "step $i"                                            │
@@ -27,7 +31,7 @@
 │  MLflow Run    my-run                                          │
 │  User          user@example.com                                │
 │  Accelerators  1x A10                                          │
-│  Environment   N/A                                             │
+│  Environment   5                                               │
 │                                                                │
 ╰────────────────────────────────────────────────────────────────╯
 

--- a/acceptance/experimental/air/get-ai-runtime/training_config.yaml
+++ b/acceptance/experimental/air/get-ai-runtime/training_config.yaml
@@ -2,6 +2,10 @@ experiment_name: my-exp
 compute:
   accelerator_type: a10
   num_accelerators: 1
+environment:
+  version: 5
+  dependencies:
+    - torch==2.3.0
 command: |-
   for i in $(seq 1 10); do
     echo "step $i"

--- a/experimental/air/cmd/format.go
+++ b/experimental/air/cmd/format.go
@@ -298,6 +298,31 @@ func environment(run *jobs.Run) string {
 	return task.DlRuntimeImage
 }
 
+// environmentFromConfig extracts the training environment for the Environment
+// cell from a run's config YAML: the docker image URL when the config pins one,
+// otherwise the environment version. Returns "" when the config declares no
+// environment or cannot be parsed. This is the only source of the environment
+// for ai_runtime runs, whose GetRun response carries no environment field (the
+// gen_ai_compute path reads the image from the run response via environment()).
+func environmentFromConfig(configYAML string) string {
+	if configYAML == "" {
+		return ""
+	}
+	var cfg struct {
+		Environment *environmentConfig `yaml:"environment"`
+	}
+	if err := yaml.Unmarshal([]byte(configYAML), &cfg); err != nil || cfg.Environment == nil {
+		return ""
+	}
+	if cfg.Environment.DockerImage != nil {
+		return cfg.Environment.DockerImage.URL
+	}
+	if cfg.Environment.Version.set {
+		return cfg.Environment.Version.raw
+	}
+	return ""
+}
+
 // maxRetries returns the configured retry limit for the run's latest task as a
 // display string: "unlimited" for the backend's -1, otherwise the count.
 func maxRetries(run *jobs.Run) string {

--- a/experimental/air/cmd/format_test.go
+++ b/experimental/air/cmd/format_test.go
@@ -230,6 +230,30 @@ func TestAcceleratorLabel(t *testing.T) {
 	assert.Equal(t, "8x", acceleratorLabel("", 8))
 }
 
+func TestEnvironmentFromConfig(t *testing.T) {
+	tests := []struct {
+		name       string
+		configYAML string
+		want       string
+	}{
+		{"empty", "", ""},
+		{"no environment", "experiment_name: my-exp\ncompute:\n  accelerator_type: a10", ""},
+		{"version int", "environment:\n  version: 5\n  dependencies:\n    - torch", "5"},
+		{"version string", "environment:\n  version: \"5\"\n  dependencies:\n    - torch", "5"},
+		// docker_image wins over version (they are mutually exclusive in a valid config).
+		{"docker image", "environment:\n  docker_image:\n    url: org/repo:tag", "org/repo:tag"},
+		// dependencies without a pinned version resolve the version at launch, so
+		// there is nothing to show here.
+		{"dependencies only", "environment:\n  dependencies:\n    - torch", ""},
+		{"malformed", "environment: [not-a-map", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, environmentFromConfig(tt.configYAML))
+		})
+	}
+}
+
 func TestStatusWord(t *testing.T) {
 	assert.Equal(t, "SUCCESS", statusWord("TERMINATED", "SUCCESS")) // result wins
 	assert.Equal(t, "RUNNING", statusWord("RUNNING", ""))           // falls back to lifecycle

--- a/experimental/air/cmd/render.go
+++ b/experimental/air/cmd/render.go
@@ -91,6 +91,15 @@ func renderRunText(ctx context.Context, out io.Writer, w *databricks.WorkspaceCl
 	renderer, colorOn := cmdio.NewRenderer(ctx, out)
 	p := newPalette(renderer)
 
+	// Resolve the training config once: it renders the Configuration box, and for
+	// ai_runtime runs it is the only source of the Environment cell (the run
+	// response carries the runtime image for gen_ai_compute runs, but no
+	// environment field for ai_runtime runs, leaving EnvironmentDisplay at "N/A").
+	configYAML := resolveConfigYAML(ctx, w, run, data)
+	if data.EnvironmentDisplay == na {
+		data.EnvironmentDisplay = orNA(environmentFromConfig(configYAML))
+	}
+
 	view := runView{
 		runID:        data.RunID,
 		dashboardURL: data.DashboardURL,
@@ -112,7 +121,7 @@ func renderRunText(ctx context.Context, out io.Writer, w *databricks.WorkspaceCl
 	}
 
 	var sections []string
-	if body := colorizeConfig(p, resolveConfigYAML(ctx, w, run, data)); body != "" {
+	if body := colorizeConfig(p, configYAML); body != "" {
 		sections = append(sections, renderBox(p, configBoxTitle, body))
 	}
 	sections = append(sections, renderBox(p, metadataBoxTitle, renderFields(p, colorOn, view)))


### PR DESCRIPTION
## Summary

`experimental air get` showed `Environment N/A` for every AI Runtime (serverless) run.

The `Environment` cell is populated by `environment(run)`, which reads the runtime image only from a run's `gen_ai_compute_task` (`DlRuntimeImage`). AI Runtime runs — the ones `air run` submits — have no `gen_ai_compute_task`, and the `jobs/runs/get` response carries no environment field for them (the environment version/image is submitted on the run's `environments` spec but not echoed back on a read). So the cell always fell back to `N/A`.

This derives the environment for AI Runtime runs from the run's training config, which `air get` already downloads to render the Configuration box — no extra API call. It shows the docker image URL when the config pins one, otherwise the `environment.version`. The `gen_ai_compute` path is unchanged.

## Changes

- `experimental/air/cmd/format.go`: new `environmentFromConfig` helper that parses `environment.docker_image.url` / `environment.version` out of the run config, reusing the existing `environmentConfig` schema type.
- `experimental/air/cmd/render.go`: resolve the training config once in `renderRunText` (it already downloaded it for the box), and fill the `Environment` cell from it when the run response left it at `N/A`.

## Testing

- Unit test `TestEnvironmentFromConfig` covers version (int/string), docker image, dependencies-only (no pinned version), no-environment, and malformed input.
- Acceptance test `experimental/air/get-ai-runtime` now includes an `environment` block and asserts the cell renders `5` instead of `N/A`.
- `go test ./experimental/air/...` and `go test ./acceptance -run TestAccept/experimental/air` pass; package lints clean.

This pull request and its description were written by Isaac.