### PR TITLE
Bump Terraform provider from v1.125.0 to v1.126.0

### DIFF
--- a/.nextchanges/dependency-updates/bump-tf-1.125.0.md
+++ b/.nextchanges/dependency-updates/bump-tf-1.125.0.md
@@ -1,1 +1,0 @@
-Bump Terraform provider from v1.124.0 to v1.125.0.

--- a/.nextchanges/dependency-updates/bump-tf-1.126.0.md
+++ b/.nextchanges/dependency-updates/bump-tf-1.126.0.md
@@ -1,1 +1,1 @@
-Bump Terraform provider from v1.125.0 to v1.126.0.
+Bump Terraform provider from v1.124.0 to v1.126.0 ([#6250](https://github.com/databricks/cli/pull/6250)).

--- a/.nextchanges/dependency-updates/bump-tf-1.126.0.md
+++ b/.nextchanges/dependency-updates/bump-tf-1.126.0.md
@@ -1,0 +1,1 @@
+Bump Terraform provider from v1.125.0 to v1.126.0.

--- a/bundle/internal/tf/codegen/schema/version.go
+++ b/bundle/internal/tf/codegen/schema/version.go
@@ -1,4 +1,4 @@
 package schema
 
 // ProviderVersion is the version of the Databricks Terraform provider used for codegen.
-const ProviderVersion = "1.125.0"
+const ProviderVersion = "1.126.0"

--- a/bundle/internal/tf/schema/root.go
+++ b/bundle/internal/tf/schema/root.go
@@ -22,9 +22,9 @@ type Root struct {
 const (
 	ProviderHost               = "registry.terraform.io"
 	ProviderSource             = "databricks/databricks"
-	ProviderVersion            = "1.125.0"
-	ProviderChecksumLinuxAmd64 = "00ff9f7bc1aafd50ea385f6c1ebdfc711f0f9b8f9861cd6ba118578c58deafb8"
-	ProviderChecksumLinuxArm64 = "19754134f13531ab69dad72e43979ee194a38a7972ba7e20f8be21b679e2182c"
+	ProviderVersion            = "1.126.0"
+	ProviderChecksumLinuxAmd64 = "b5f9c459ed08141e739dc689d166acc35418947100182b83a72e3b6e47967a46"
+	ProviderChecksumLinuxArm64 = "4150d152404ebdfb7ffea573180848d8521e61c65425457ae9892e2b19468de4"
 )
 
 func NewRoot() *Root {


### PR DESCRIPTION
## Changes

Bump the pinned Databricks Terraform provider from v1.125.0 to v1.126.0.

The v1.126.0 release contains no bundle-relevant resource or field schema changes; only the pinned provider version and archive checksums in the generated schema change.

## Why

Keep the CLI's pinned Terraform provider current; v1.126.0 was released 2026-08-12.

## Tests

Acceptance goldens regenerated via `./task test-update` — no golden changes. Full acceptance suite passes locally on both engines.

_This PR was written by Claude Code._