### PR TITLE
acceptance: repro deploy with workspace_id=none sentinel

### DIFF
--- a/acceptance/bundle/deploy/workspace-id-none/databricks.yml.tmpl
+++ b/acceptance/bundle/deploy/workspace-id-none/databricks.yml.tmpl
@@ -1,0 +1,2 @@
+bundle:
+  name: test-bundle-$UNIQUE_NAME

--- a/acceptance/bundle/deploy/workspace-id-none/out.test.toml
+++ b/acceptance/bundle/deploy/workspace-id-none/out.test.toml
@@ -1,0 +1,2 @@
+Cloud = true
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/deploy/workspace-id-none/output.txt
+++ b/acceptance/bundle/deploy/workspace-id-none/output.txt
@@ -1,0 +1,11 @@
+
+>>> [CLI] bundle deploy
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle-[UNIQUE_NAME]/default/files...
+Deploying resources...
+Deployment complete!
+
+>>> [CLI] bundle destroy --auto-approve
+All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/test-bundle-[UNIQUE_NAME]/default
+
+Deleting files...
+Destroy complete!

--- a/acceptance/bundle/deploy/workspace-id-none/script
+++ b/acceptance/bundle/deploy/workspace-id-none/script
@@ -1,0 +1,7 @@
+envsubst < databricks.yml.tmpl > databricks.yml
+cleanup() {
+    trace $CLI bundle destroy --auto-approve
+}
+trap cleanup EXIT
+
+trace $CLI bundle deploy

--- a/acceptance/bundle/deploy/workspace-id-none/test.toml
+++ b/acceptance/bundle/deploy/workspace-id-none/test.toml
@@ -1,0 +1,10 @@
+# Deploys with workspace_id=none, the sentinel `auth login --skip-workspace`
+# persists. Non-filer SDK calls (e.g. the populate_current_user /Me request)
+# still send it as X-Databricks-Workspace-Id: none. The local testserver ignores
+# the header so the deploy succeeds; this test runs on a real workspace (Cloud)
+# to reveal whether the sentinel actually breaks routing there.
+Cloud = true
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]
+
+[Env]
+DATABRICKS_WORKSPACE_ID = "none"


### PR DESCRIPTION
## What

Diagnostic-only acceptance test. It deploys a minimal bundle with `DATABRICKS_WORKSPACE_ID=none` — the sentinel `databricks auth login --skip-workspace` persists to `.databrickscfg`.

## Why

We're evaluating whether the `none` workspace-id sentinel needs to be normalized centrally (in `bundle/config/workspace.go`) rather than only in the workspace filer. Only the filer strips `none` today; non-filer SDK calls in a deploy — e.g. the `populate_current_user` `/Me` request — still send `X-Databricks-Workspace-Id: none` because the generated SDK methods use a bare `cfg.WorkspaceID != ""` check.

The local testserver ignores the routing header, so this test **passes locally**. The purpose is to run it on **Cloud CI** against a real workspace to see whether the sentinel actually breaks routing there. If the cloud run fails, the `none`-on-non-filer-calls behavior is a real issue and warrants the central fix; if it passes, the sentinel is benign on that host.

This is on a branch off `main` (not on the workspace-import-migration PR) so it isolates the pre-existing `/Me` behavior from the upload migration.

## Not for merge

This PR exists to observe cloud CI behavior. Do not merge as-is.

This pull request and its description were written by Isaac.