### PR TITLE
Fix flaky TestLogStreamerTailBufferFlushes

### DIFF
--- a/libs/apps/logstream/streamer_test.go
+++ b/libs/apps/logstream/streamer_test.go
@@ -31,19 +31,22 @@ func TestLogStreamerTailBufferFlushes(t *testing.T) {
 		for i := 1; i <= 3; i++ {
 			require.NoError(t, sendEntry(conn, float64(i), fmt.Sprintf("msg%d", i)))
 		}
-		time.Sleep(50 * time.Millisecond)
 		_ = conn.WriteControl(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""), time.Now().Add(time.Second))
 	})
 	defer server.Close()
 
 	buf := &bytes.Buffer{}
 	streamer := &logStreamer{
-		dialer:    &websocket.Dialer{},
-		url:       toWebSocketURL(server.URL),
-		token:     "test",
-		tail:      2,
-		follow:    false,
-		prefetch:  25 * time.Millisecond,
+		dialer: &websocket.Dialer{},
+		url:    toWebSocketURL(server.URL),
+		token:  "test",
+		tail:   2,
+		follow: false,
+		// No prefetch: the tail flushes deterministically on the clean connection
+		// close. A wall-clock prefetch timer races message delivery and flushes a
+		// partial buffer on a loaded runner (the prefetch-timer path is covered by
+		// TestLogStreamerTailFlushesWithoutFollow).
+		prefetch:  0,
 		writer:    buf,
 		formatter: newLogFormatter(false, flags.OutputText),
 	}

--- a/libs/apps/logstream/streamer_test.go
+++ b/libs/apps/logstream/streamer_test.go
@@ -363,6 +363,7 @@ func (f *flakyDialer) DialContext(ctx context.Context, urlStr string, requestHea
 func newTestLogServer(t *testing.T, handler func(int, *websocket.Conn)) *httptest.Server {
 	upgrader := websocket.Upgrader{}
 	var connCount atomic.Int32
+	var handlers sync.WaitGroup
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		id := int(connCount.Add(1))
@@ -371,12 +372,22 @@ func newTestLogServer(t *testing.T, handler func(int, *websocket.Conn)) *httptes
 			t.Errorf("failed to upgrade connection: %v", err)
 			return
 		}
-		go handler(id, conn)
+		handlers.Add(1)
+		go func() {
+			defer handlers.Done()
+			handler(id, conn)
+		}()
 	}))
 
 	t.Cleanup(func() {
+		// Close connections first so handlers blocked on the socket unblock, then
+		// wait for every handler goroutine to finish. Handlers assert with require
+		// on the *testing.T; without this wait a handler could call an assertion
+		// after the test completed, which panics the whole package test binary
+		// instead of failing the one test.
 		server.CloseClientConnections()
 		server.Close()
+		handlers.Wait()
 	})
 	return server
 }

--- a/libs/apps/logstream/streamer_test.go
+++ b/libs/apps/logstream/streamer_test.go
@@ -372,11 +372,9 @@ func newTestLogServer(t *testing.T, handler func(int, *websocket.Conn)) *httptes
 			t.Errorf("failed to upgrade connection: %v", err)
 			return
 		}
-		handlers.Add(1)
-		go func() {
-			defer handlers.Done()
+		handlers.Go(func() {
 			handler(id, conn)
-		}()
+		})
 	}))
 
 	t.Cleanup(func() {


### PR DESCRIPTION
## Changes

- `TestLogStreamerTailBufferFlushes` assumed three log messages would arrive within a 25ms prefetch window; on a loaded runner the timer fired first and flushed a partial tail, so the flush now happens deterministically on the clean connection close (no prefetch timer).
- `newTestLogServer` ran each connection handler in a detached goroutine that could `require`-assert after the test finished and panic the whole package binary; cleanup now waits for handler goroutines to finish so such failures stay clean, single-test failures.

## Why

Flaky failure in CI: https://github.com/databricks/cli/actions/runs/31780075934/job/94703824583

## Tests

Existing package tests; ran the fixed test 500× under CPU load with no failures.

This pull request and its description were written by Isaac, an AI coding agent.