### PR TITLE
Add changelog fragment when bumping the Go toolchain

### DIFF
--- a/.github/workflows/bump-go-toolchain.yml
+++ b/.github/workflows/bump-go-toolchain.yml
@@ -87,6 +87,14 @@ jobs:
             fi
           done < <(git ls-files '**/go.mod' 'go.mod')
 
+      - name: Add changelog fragment
+        if: steps.check.outputs.needed == 'true'
+        env:
+          TOOLCHAIN: ${{ steps.latest.outputs.toolchain }}
+        run: |
+          echo "Bump Go toolchain to ${TOOLCHAIN}." \
+            > ".nextchanges/dependency-updates/go-toolchain-${TOOLCHAIN}.md"
+
       - name: Show diff
         if: steps.check.outputs.needed == 'true'
         run: git diff

--- a/.github/workflows/bump-go-toolchain.yml
+++ b/.github/workflows/bump-go-toolchain.yml
@@ -92,7 +92,7 @@ jobs:
         env:
           TOOLCHAIN: ${{ steps.latest.outputs.toolchain }}
         run: |
-          echo "Bump Go toolchain to ${TOOLCHAIN}." \
+          echo "Bump Go toolchain to ${TOOLCHAIN#go}." \
             > ".nextchanges/dependency-updates/go-toolchain-${TOOLCHAIN}.md"
 
       - name: Show diff

--- a/.github/workflows/bump-go-toolchain.yml
+++ b/.github/workflows/bump-go-toolchain.yml
@@ -115,7 +115,7 @@ jobs:
           TOOLCHAIN: ${{ steps.latest.outputs.toolchain }}
           BRANCH: ${{ steps.cpr.outputs.pull-request-branch }}
           PR: ${{ steps.cpr.outputs.pull-request-number }}
-        run: |
+        run: |-
           git fetch origin "$BRANCH"
           git checkout -f -B "$BRANCH" FETCH_HEAD
           fragment=".nextchanges/dependency-updates/go-toolchain-${TOOLCHAIN}.md"

--- a/.github/workflows/bump-go-toolchain.yml
+++ b/.github/workflows/bump-go-toolchain.yml
@@ -87,19 +87,12 @@ jobs:
             fi
           done < <(git ls-files '**/go.mod' 'go.mod')
 
-      - name: Add changelog fragment
-        if: steps.check.outputs.needed == 'true'
-        env:
-          TOOLCHAIN: ${{ steps.latest.outputs.toolchain }}
-        run: |
-          echo "Bump Go toolchain to ${TOOLCHAIN#go}." \
-            > ".nextchanges/dependency-updates/go-toolchain-${TOOLCHAIN}.md"
-
       - name: Show diff
         if: steps.check.outputs.needed == 'true'
         run: git diff
 
       - name: Create pull request
+        id: cpr
         if: steps.check.outputs.needed == 'true' && inputs.version == ''
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
@@ -112,3 +105,23 @@ jobs:
             Release notes: https://go.dev/doc/devel/release#${{ steps.latest.outputs.toolchain }}
           reviewers: simonfaltum,andrewnester,anton-107,denik,janniklasrose,pietern,shreyas-goenka
           labels: dependencies
+
+      # Add the changelog fragment as a follow-up commit on the PR branch: the
+      # fragment references the PR number, which only exists once the PR above
+      # has been created.
+      - name: Add changelog fragment
+        if: steps.cpr.outputs.pull-request-number
+        env:
+          TOOLCHAIN: ${{ steps.latest.outputs.toolchain }}
+          BRANCH: ${{ steps.cpr.outputs.pull-request-branch }}
+          PR: ${{ steps.cpr.outputs.pull-request-number }}
+        run: |
+          git fetch origin "$BRANCH"
+          git checkout -f -B "$BRANCH" FETCH_HEAD
+          fragment=".nextchanges/dependency-updates/go-toolchain-${TOOLCHAIN}.md"
+          echo "Bump Go toolchain to ${TOOLCHAIN#go} ([#${PR}](https://github.com/databricks/cli/pull/${PR}))." > "$fragment"
+          git add "$fragment"
+          git -c user.name='github-actions[bot]' \
+              -c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
+              commit -m "Add changelog fragment"
+          git push origin "HEAD:$BRANCH"

--- a/.nextchanges/dependency-updates/go-toolchain-go1.26.6.md
+++ b/.nextchanges/dependency-updates/go-toolchain-go1.26.6.md
@@ -1,0 +1,1 @@
+Bump Go toolchain to go1.26.6.

--- a/.nextchanges/dependency-updates/go-toolchain-go1.26.6.md
+++ b/.nextchanges/dependency-updates/go-toolchain-go1.26.6.md
@@ -1,1 +1,1 @@
-Bump Go toolchain to go1.26.6.
+Bump Go toolchain to 1.26.6.

--- a/.nextchanges/dependency-updates/go-toolchain-go1.26.6.md
+++ b/.nextchanges/dependency-updates/go-toolchain-go1.26.6.md
@@ -1,1 +1,1 @@
-Bump Go toolchain to 1.26.6.
+Bump Go toolchain to 1.26.6 ([#6266](https://github.com/databricks/cli/pull/6266)).


### PR DESCRIPTION
The most recent Go toolchain bump (#6266) merged without a changelog entry, because the `bump-go-toolchain` workflow never emitted one and no one added it by hand.

- Add the missing fragment for `go1.26.6`, with the PR link expanded.
- Update the workflow to write a version-named fragment on every bump. The fragment is added as a follow-up commit after the PR is created, so it can reference the new PR number (`([#N](.../pull/N))`) — this is why it runs after `Create pull request` rather than before, and it keeps the entry ready for the planned lint that requires a PR link on fragments.

This pull request and its description were written by Isaac.