### PR TITLE
Add CODE_CONVENTIONS.md and reference it from AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,10 @@
 This file provides guidance to AI assistants when working with code in this repository.
 
-Rules prefixed `**RULE:**` are mandatory. `GOOD:` and `BAD:` labels on code snippets mark patterns to follow and patterns to avoid. This convention is a common best practice for AI-assistant rule files and is used consistently across `AGENTS.md` and `.agent/rules/*.md`.
+Rules prefixed `**RULE:**` are mandatory. `GOOD:` and `BAD:` labels on code snippets mark patterns to follow and patterns to avoid. This convention is a common best practice for AI-assistant rule files and is used consistently across `AGENTS.md`, `CODE_CONVENTIONS.md`, and `.agent/rules/*.md`.
+
+# Code Conventions
+
+Read [CODE_CONVENTIONS.md](CODE_CONVENTIONS.md) before you write or change code. It holds the comment conventions that apply in every language, and points to the language- and domain-specific rule files under `.agent/rules/` so you can read the ones relevant to your change.
 
 # Project Overview
 
@@ -9,8 +13,6 @@ This is the Databricks CLI, a command-line interface for interacting with Databr
 # General Rules
 
 **RULE: When moving code from one place to another, don't unnecessarily change or omit parts.** Keep refactors separate from content changes so reviewers can tell them apart.
-
-**RULE: Do not modify or remove existing comments in code you didn't write.** Comments often encode non-obvious context (a bug reference, a workaround, a reason the code is shaped a certain way) that is lost if rewritten. Leave them alone unless the user explicitly asks for a change.
 
 **RULE: Prefer simplicity over cleverness. Avoid speculative fallbacks and default values.** If you catch yourself adding a fallback branch "just in case," identify the correct path and use only that one. Reviewers in this repo reject speculative flexibility.
 
@@ -92,24 +94,6 @@ GIT_EDITOR=true GIT_SEQUENCE_EDITOR=true VISUAL=true GIT_PAGER=cat git rebase or
 
 - Use `./task test-update` to regenerate acceptance test outputs after changes.
 - The CLI binary supports both `databricks` and `pipelines` command modes based on executable name.
-
-**RULE: Comments should explain "why", not "what".** Reviewers consistently reject comments that merely restate the code.
-
-**RULE: When code relies on a non-obvious invariant, workaround, or backend quirk, add a short comment stating the reason.** The inverse of the rule above: noise comments are bad, but missing comments are the single most common thing reviewers catch. Triggers include: API quirks (PATCH-like semantics, no get-by-name, stripped prefixes), fields intentionally included or excluded (output-only, etag, `ForceSendFields`), branches that look dead but are kept as guards, and tests where the expectation isn't obvious from the assertions.
-
-GOOD:
-
-```go
-// The Workspace API strips the "/Workspace" prefix from parent_path on GET,
-// so we re-add it here to match the local configuration.
-parentPath = "/Workspace" + parentPath
-```
-
-BAD:
-
-```go
-parentPath = "/Workspace" + parentPath
-```
 
 # Common Mistakes
 

--- a/CODE_CONVENTIONS.md
+++ b/CODE_CONVENTIONS.md
@@ -1,4 +1,4 @@
-# Code conventions
+# Code Conventions
 
 Conventions that apply across the whole repository, regardless of language. Read this before you write or change code.
 
@@ -28,15 +28,15 @@ parentPath = "/Workspace" + parentPath
 
 ## Language- and domain-specific rules
 
-The rules above apply everywhere. Before touching files in these areas, also read the matching rule file under `.agent/rules/`. These are the source of the per-file rules that Cursor auto-attaches by glob; other agents (Claude Code included) don't auto-load them, so read them directly when your change falls in scope.
+The rules above apply everywhere. Before touching files in these areas, also read the matching rule file under `.agent/rules/`. These are the source of the per-file rules that Cursor auto-attaches by glob; other agents (Claude Code included) don't auto-load them, so read them directly when your change falls in scope. The paths below are representative — each rule file's `globs:`/`paths:` front matter is the authoritative list of what it covers, so consult it when unsure.
 
 | When you work on… | Read |
 | --- | --- |
 | Go code (`**/*.go`) | [.agent/rules/style-guide-go.md](.agent/rules/style-guide-go.md) |
 | Python code (`**/*.py`) | [.agent/rules/style-guide-py.md](.agent/rules/style-guide-py.md) |
 | Tests (`**/*_test.go`, `acceptance/**`, `integration/**`) | [.agent/rules/testing.md](.agent/rules/testing.md) |
-| Deploy telemetry (`libs/telemetry/**`, `bundle/metrics/**`, `bundle/phases/telemetry.go`) | [.agent/rules/telemetry.md](.agent/rules/telemetry.md) |
+| Deploy telemetry (`libs/telemetry/**`, `bundle/metrics/**`, `bundle/phases/telemetry.go`, `bundle/phases/resources_metadata.go`) | [.agent/rules/telemetry.md](.agent/rules/telemetry.md) |
 | Direct-engine resources (`bundle/direct/dresources/**/*.go`) | [.agent/rules/dresources.md](.agent/rules/dresources.md) |
 | Changelog entries (`CHANGELOG.md`, `.nextchanges/**`) | [.agent/rules/changelog.md](.agent/rules/changelog.md) |
-| Auto-generated files (`cmd/workspace/**`, `cmd/account/**`, `internal/mocks/**`, generated schemas) | [.agent/rules/auto-generated-files.md](.agent/rules/auto-generated-files.md) |
+| Auto-generated files (`cmd/workspace/**`, `cmd/account/**`, `internal/mocks/**`, acceptance test outputs under `acceptance/**`, generated schemas such as `.codegen/openapi.json`, generated Python under `python/databricks/bundles/**`) | [.agent/rules/auto-generated-files.md](.agent/rules/auto-generated-files.md) |
 | Template schema (`**/databricks_template_schema.json`) | [.agent/rules/databricks-template-schema-json.md](.agent/rules/databricks-template-schema-json.md) |

--- a/CODE_CONVENTIONS.md
+++ b/CODE_CONVENTIONS.md
@@ -1,0 +1,42 @@
+# Code conventions
+
+Conventions that apply across the whole repository, regardless of language. Read this before you write or change code.
+
+Rules prefixed `**RULE:**` are mandatory. `GOOD:` and `BAD:` labels on code snippets mark patterns to follow and patterns to avoid.
+
+## Comments
+
+**RULE: Do not modify or remove existing comments in code you didn't write.** Comments often encode non-obvious context (a bug reference, a workaround, a reason the code is shaped a certain way) that is lost if rewritten. Leave them alone unless the user explicitly asks for a change.
+
+**RULE: Comments should explain "why", not "what".** Reviewers consistently reject comments that merely restate the code.
+
+**RULE: When code relies on a non-obvious invariant, workaround, or backend quirk, add a short comment stating the reason.** The inverse of the rule above: noise comments are bad, but missing comments are the single most common thing reviewers catch. Triggers include: API quirks (PATCH-like semantics, no get-by-name, stripped prefixes), fields intentionally included or excluded (output-only, etag, `ForceSendFields`), branches that look dead but are kept as guards, and tests where the expectation isn't obvious from the assertions.
+
+GOOD:
+
+```go
+// The Workspace API strips the "/Workspace" prefix from parent_path on GET,
+// so we re-add it here to match the local configuration.
+parentPath = "/Workspace" + parentPath
+```
+
+BAD:
+
+```go
+parentPath = "/Workspace" + parentPath
+```
+
+## Language- and domain-specific rules
+
+The rules above apply everywhere. Before touching files in these areas, also read the matching rule file under `.agent/rules/`. These are the source of the per-file rules that Cursor auto-attaches by glob; other agents (Claude Code included) don't auto-load them, so read them directly when your change falls in scope.
+
+| When you work on… | Read |
+| --- | --- |
+| Go code (`**/*.go`) | [.agent/rules/style-guide-go.md](.agent/rules/style-guide-go.md) |
+| Python code (`**/*.py`) | [.agent/rules/style-guide-py.md](.agent/rules/style-guide-py.md) |
+| Tests (`**/*_test.go`, `acceptance/**`, `integration/**`) | [.agent/rules/testing.md](.agent/rules/testing.md) |
+| Deploy telemetry (`libs/telemetry/**`, `bundle/metrics/**`, `bundle/phases/telemetry.go`) | [.agent/rules/telemetry.md](.agent/rules/telemetry.md) |
+| Direct-engine resources (`bundle/direct/dresources/**/*.go`) | [.agent/rules/dresources.md](.agent/rules/dresources.md) |
+| Changelog entries (`CHANGELOG.md`, `.nextchanges/**`) | [.agent/rules/changelog.md](.agent/rules/changelog.md) |
+| Auto-generated files (`cmd/workspace/**`, `cmd/account/**`, `internal/mocks/**`, generated schemas) | [.agent/rules/auto-generated-files.md](.agent/rules/auto-generated-files.md) |
+| Template schema (`**/databricks_template_schema.json`) | [.agent/rules/databricks-template-schema-json.md](.agent/rules/databricks-template-schema-json.md) |


### PR DESCRIPTION
## Summary

Consolidates the repo's language-agnostic comment rules into a new `CODE_CONVENTIONS.md` at the repo root and adds a prose pointer from `AGENTS.md` telling agents to read it before writing code.

### Why

- The comment rules previously lived scattered in `AGENTS.md` (`# General Rules` and `# Development Tips`).
- The per-language / per-domain rules under `.agent/rules/*.md` are discovered **only** by Cursor's glob mechanism (`globs:`/`paths:` frontmatter). Other agents — including Claude Code, which reads `AGENTS.md`/`CLAUDE.md` but does not auto-load `.agent/rules/` — never see them unless they happen to open the files.

### What

- **New `CODE_CONVENTIONS.md`**: a `## Comments` section (the three comment rules, moved verbatim, including the GOOD/BAD block) plus a `## Language- and domain-specific rules` trigger table pointing to each `.agent/rules/*.md` file.
- **`AGENTS.md`**: adds a `# Code Conventions` section with a plain-prose "Read `CODE_CONVENTIONS.md` before you write or change code" pointer (no `@import`, so it works for every agent that reads `AGENTS.md`, not just Claude Code), and removes the three now-migrated comment rules to avoid duplication.

Net effect: the comment rules and the `.agent/rules/` files are now reachable by any agent via a single prose reference, without depending on Cursor's glob attachment.

### Notes

- Docs-only change to AI-assistant instruction files; no CLI behavior changes, so no `.nextchanges/` fragment.
- `CLAUDE.md` is a symlink to `AGENTS.md`, so it picks up the pointer automatically.

This pull request and its description were written by Isaac.