### PR TITLE
Consolidate comment rules into .agent/rules/comments.md

### DIFF
--- a/.agent/rules/comments.md
+++ b/.agent/rules/comments.md
@@ -1,0 +1,62 @@
+---
+description: Comment conventions for source files
+globs:
+  - "**/*.go"
+  - "**/*.py"
+  - "**/*.pyi"
+  - "**/*.sh"
+  - "**/*.scala"
+  - "**/*.js"
+  - "**/*.java"
+  - "**/*.sql"
+  - "**/*.r"
+  - "**/*.yml"
+  - "**/*.yaml"
+paths:
+  - "**/*.go"
+  - "**/*.py"
+  - "**/*.pyi"
+  - "**/*.sh"
+  - "**/*.scala"
+  - "**/*.js"
+  - "**/*.java"
+  - "**/*.sql"
+  - "**/*.r"
+  - "**/*.yml"
+  - "**/*.yaml"
+---
+
+# Comment conventions
+
+**RULE: Do not modify or remove existing comments in code you didn't write.** Comments often encode non-obvious context (a bug reference, a workaround, a reason the code is shaped a certain way) that is lost if rewritten. Leave them alone unless the user explicitly asks for a change.
+
+**RULE: Comments should explain "why", not "what".** Reviewers consistently reject comments that merely restate the code.
+
+**RULE: Keep comments concise, and avoid redundant or verbose ones.** Say only what the code cannot, then stop — only add a comment if it complements the code rather than repeating it or its signature. A doc comment gives the caller the contract and any surprising behavior, not a line-by-line re-spec. AI-generated comments trend long and explanatory, so tighten them before committing.
+
+**RULE: When code relies on a non-obvious invariant, workaround, or backend quirk, add a short comment stating the reason.** The inverse of the rule above: noise comments are bad, but missing comments are the single most common thing reviewers catch. Triggers include: API quirks (PATCH-like semantics, no get-by-name, stripped prefixes), fields intentionally included or excluded (output-only, etag, `ForceSendFields`), branches that look dead but are kept as guards, and tests where the expectation isn't obvious from the assertions.
+
+GOOD:
+
+```go
+// The Workspace API strips the "/Workspace" prefix from parent_path on GET,
+// so we re-add it here to match the local configuration.
+parentPath = "/Workspace" + parentPath
+```
+
+BAD:
+
+```go
+parentPath = "/Workspace" + parentPath
+```
+
+**RULE: In Go, document functions with a doc comment that starts with the function name and ends with a period.**
+
+```go
+// SomeFunc does something.
+func SomeFunc() {
+	...
+}
+```
+
+**RULE: When integrating external tools or detecting environment variables, include source reference URLs as comments.** This lets future readers trace where the behavior came from.

--- a/.agent/rules/style-guide-go.md
+++ b/.agent/rules/style-guide-go.md
@@ -11,17 +11,6 @@ paths:
 
 Code you author should be consistent with the codebase and concise. The code should be self-documenting based on its function and variable names.
 
-**RULE: Document functions with a doc comment that starts with the function name and ends with a period.**
-
-```go
-// SomeFunc does something.
-func SomeFunc() {
-	...
-}
-```
-
-**RULE: Avoid redundant and verbose comments.** Only add a comment if it complements the code rather than repeating it.
-
 **RULE: Focus on making implementations as small and elegant as possible.** Avoid unnecessary loops and allocations. If dropping or relaxing a requirement would simplify things, ask the user about the trade-off.
 
 **RULE: Do not declare inline function closures just to name a repeated operation.** Extract it as a regular named function instead. Closures that capture local variables hide their dependencies, complicate reading, and can't be tested in isolation.
@@ -49,8 +38,6 @@ type myKeyType int
 ```
 
 **RULE: Define magic strings as named constants at the top of the file.** When a value is used in more than one place, define a package-level constant even if the literal is short. If a related value already has a constant in the same package, follow the existing pattern instead of introducing a parallel literal.
-
-**RULE: When integrating external tools or detecting environment variables, include source reference URLs as comments.** This lets future readers trace where the behavior came from.
 
 ### Control flow
 

--- a/.agent/rules/style-guide-py.md
+++ b/.agent/rules/style-guide-py.md
@@ -19,8 +19,6 @@ Python in this codebase is written as scripts. Bias for conciseness.
 
 **RULE: Do not catch exceptions just to add a nicer message.** Only catch if you can add critical information the caller can't produce.
 
-**RULE: Avoid redundant comments.**
-
 **RULE: Keep code small and minimize abstractions.**
 
 **RULE: Format with `ruff format -n <path>` before committing.**

--- a/.cursor/rules/comments.mdc
+++ b/.cursor/rules/comments.mdc
@@ -1,0 +1,1 @@
+../../.agent/rules/comments.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,8 +10,6 @@ This is the Databricks CLI, a command-line interface for interacting with Databr
 
 **RULE: When moving code from one place to another, don't unnecessarily change or omit parts.** Keep refactors separate from content changes so reviewers can tell them apart.
 
-**RULE: Do not modify or remove existing comments in code you didn't write.** Comments often encode non-obvious context (a bug reference, a workaround, a reason the code is shaped a certain way) that is lost if rewritten. Leave them alone unless the user explicitly asks for a change.
-
 **RULE: Prefer simplicity over cleverness. Avoid speculative fallbacks and default values.** If you catch yourself adding a fallback branch "just in case," identify the correct path and use only that one. Reviewers in this repo reject speculative flexibility.
 
 **RULE: Keep each PR focused on one change.** If you notice an unrelated cleanup, bug fix, or refactor while making your primary change, leave it alone or put it in a separate PR. Reviewers consistently ask to split mixed PRs, especially when a dependency bump or schema diff rides along with a feature change.
@@ -92,24 +90,6 @@ GIT_EDITOR=true GIT_SEQUENCE_EDITOR=true VISUAL=true GIT_PAGER=cat git rebase or
 
 - Use `./task test-update` to regenerate acceptance test outputs after changes.
 - The CLI binary supports both `databricks` and `pipelines` command modes based on executable name.
-
-**RULE: Comments should explain "why", not "what".** Reviewers consistently reject comments that merely restate the code.
-
-**RULE: When code relies on a non-obvious invariant, workaround, or backend quirk, add a short comment stating the reason.** The inverse of the rule above: noise comments are bad, but missing comments are the single most common thing reviewers catch. Triggers include: API quirks (PATCH-like semantics, no get-by-name, stripped prefixes), fields intentionally included or excluded (output-only, etag, `ForceSendFields`), branches that look dead but are kept as guards, and tests where the expectation isn't obvious from the assertions.
-
-GOOD:
-
-```go
-// The Workspace API strips the "/Workspace" prefix from parent_path on GET,
-// so we re-add it here to match the local configuration.
-parentPath = "/Workspace" + parentPath
-```
-
-BAD:
-
-```go
-parentPath = "/Workspace" + parentPath
-```
 
 # Common Mistakes
 


### PR DESCRIPTION
## Summary

Consolidates **all** comment-related rules into a single path-scoped rule file, `.agent/rules/comments.md`, and removes them from `AGENTS.md`, `.agent/rules/style-guide-go.md`, and `.agent/rules/style-guide-py.md`. Adds a `.cursor/rules/comments.mdc` symlink so Cursor picks it up (Claude Code discovers it via the existing `.claude/rules → ../.agent/rules` symlink).

Previously, comment guidance was scattered across three files. This gives it one canonical home.

### What moved into `comments.md`

- From `AGENTS.md`: don't-modify-others'-comments; "why not what"; add-a-comment-for-non-obvious-invariant (with its GOOD/BAD example).
- From `style-guide-go.md`: the godoc doc-comment format (now prefixed "In Go,"); avoid-redundant/verbose comments; source-reference-URL comments.
- From `style-guide-py.md`: avoid-redundant-comments.

The two "avoid redundant/verbose" rules are merged into one concise-comments rule that also covers doc-comment-as-contract and trimming AI-generated comments.

### Scope

Path-scoped (`paths:`/`globs:`) to source and config file types present in the repo: `.go`, `.py`, `.pyi`, `.sh`, `.scala`, `.js`, `.java`, `.sql`, `.r`, `.yml`, `.yaml`. The rule loads when an agent works on a matching file.

### Notes

- Docs-only change to AI-assistant instruction files; no CLI behavior change, so no `.nextchanges/` fragment.
- `CLAUDE.md` is a symlink to `AGENTS.md`, so it stays in sync automatically.

This pull request and its description were written by Isaac.