### PR TITLE
WIP: Add challenge-premise red-team review prompt

### DIFF
--- a/.agent/prompts/challenge-premise.md
+++ b/.agent/prompts/challenge-premise.md
@@ -1,0 +1,10 @@
+Use this prompt to red-team a change that rests on a load-bearing assumption — a claim about how a tool, API, the repo, or the codebase behaves. Run it alongside the normal correctness review, not instead of it.
+
+Your job is to argue this PR should NOT be merged. Assume the implementation is correct; do not re-check it. Instead:
+
+- State the change's load-bearing assumption explicitly: the one claim that, if false, makes the change unnecessary or wrong.
+- Try to disprove that assumption with evidence — the repo's config, symlinks, file layout, existing rules, and official tool or library docs. Cite what you find.
+- Explain what makes the change redundant, unnecessary, or worse than the status quo.
+- Identify the simplest alternative, and check whether the repo already solves this another way.
+
+If the premise holds after investigation and the change is worth merging, say so plainly instead of manufacturing objections.


### PR DESCRIPTION
## Summary

Adds `.agent/prompts/challenge-premise.md` — a reusable prompt for **red-teaming a change that rests on a load-bearing assumption** (a claim about how a tool, API, the repo, or the codebase behaves).

### Why

Content-focused reviews verify that a change is *built correctly* but rarely question whether its *premise* is true. A recent change was proposed on the assumption that "Claude Code can't discover `.agent/rules/`" — every correctness reviewer approved it, yet the premise was false (the repo already wires those rules to Claude via a `.claude/rules` symlink). A red-team prompt run with this framing caught it in one pass. This codifies that prompt so it's reusable instead of retyped.

### What

The prompt asks the reviewer to assume the implementation is correct and instead: state the load-bearing assumption, try to disprove it with repo config/docs, explain what makes the change redundant or worse than the status quo, and identify the simplest alternative.

Matches the existing `.agent/prompts/outdated-agent-rules.md` style (plain prose, no frontmatter). Prompts are invoked on demand, so no `.claude/rules` or `.cursor/rules` symlink is needed.

### Notes

- Docs-only addition to AI-assistant tooling; no CLI behavior change, so no `.nextchanges/` fragment.

This pull request and its description were written by Isaac.