### PR TITLE
acc: stabilize prevent-destroy Files: counts on Windows

### DIFF
--- a/acceptance/bin/update_file.py
+++ b/acceptance/bin/update_file.py
@@ -20,9 +20,8 @@ filename, old, new = sys.argv[1:]
 # call update_file.py on that file.
 assert filename != "output.txt"
 
-# newline="" preserves the file's existing line endings. Plain text mode on
-# Windows rewrites LF to CRLF, which makes sync treat the file as changed and
-# inflates "Files: N uploaded" counts in acceptance goldens.
+# newline="" keeps existing endings; text mode on Windows rewrites LF→CRLF
+# and makes sync treat the file as changed.
 with open(filename, newline="") as fobj:
     data = fobj.read()
 newdata = data.replace(old, new)

--- a/acceptance/bin/update_file.py
+++ b/acceptance/bin/update_file.py
@@ -20,9 +20,13 @@ filename, old, new = sys.argv[1:]
 # call update_file.py on that file.
 assert filename != "output.txt"
 
-data = open(filename).read()
+# newline="" preserves the file's existing line endings. Plain text mode on
+# Windows rewrites LF to CRLF, which makes sync treat the file as changed and
+# inflates "Files: N uploaded" counts in acceptance goldens.
+with open(filename, newline="") as fobj:
+    data = fobj.read()
 newdata = data.replace(old, new)
 if newdata == data:
     sys.exit(f"{old=} not found in {filename=}\n{data}")
-with open(filename, "w") as fobj:
+with open(filename, "w", newline="") as fobj:
     fobj.write(newdata)

--- a/acceptance/bundle/lifecycle/prevent-destroy/databricks.yml
+++ b/acceptance/bundle/lifecycle/prevent-destroy/databricks.yml
@@ -4,9 +4,7 @@ bundle:
 include:
   - resources/*.yml
 
-# Keep harness/generated files out of the sync so "Files: N uploaded" stays
-# stable across OSes (out.* grows during the script; script/test.toml are not
-# part of the bundle under test).
+# Exclude harness files so Files: upload counts stay OS-stable.
 sync:
   exclude:
     - "out*"

--- a/acceptance/bundle/lifecycle/prevent-destroy/databricks.yml
+++ b/acceptance/bundle/lifecycle/prevent-destroy/databricks.yml
@@ -3,3 +3,12 @@ bundle:
 
 include:
   - resources/*.yml
+
+# Keep harness/generated files out of the sync so "Files: N uploaded" stays
+# stable across OSes (out.* grows during the script; script/test.toml are not
+# part of the bundle under test).
+sync:
+  exclude:
+    - "out*"
+    - "script"
+    - "test.toml"

--- a/acceptance/bundle/lifecycle/prevent-destroy/out.direct.txt
+++ b/acceptance/bundle/lifecycle/prevent-destroy/out.direct.txt
@@ -13,7 +13,7 @@ Plan: 1 to add, 0 to change, 1 to delete, 1 unchanged
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/prevent-destroy/default/files...
 Error: resources.pipelines.my_pipelines has lifecycle.prevent_destroy set, but the plan calls for this resource to be recreated or destroyed. To avoid this error, disable lifecycle.prevent_destroy for resources.pipelines.my_pipelines
 
-Files: 3 uploaded, 0 deleted
+Files: 1 uploaded, 0 deleted
 
 >>> errcode [CLI] bundle plan
 recreate pipelines.my_pipelines
@@ -26,7 +26,7 @@ Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/prevent-destroy/de
 Error: resources.pipelines.my_pipelines has lifecycle.prevent_destroy set, but the plan calls for this resource to be recreated or destroyed. To avoid this error, disable lifecycle.prevent_destroy for resources.pipelines.my_pipelines
 resources.schemas.my_schema has lifecycle.prevent_destroy set, but the plan calls for this resource to be recreated or destroyed. To avoid this error, disable lifecycle.prevent_destroy for resources.schemas.my_schema
 
-Files: 2 uploaded, 0 deleted
+Files: 1 uploaded, 0 deleted
 
 >>> errcode [CLI] bundle plan
 recreate pipelines.my_pipelines
@@ -47,7 +47,7 @@ properties such as the 'catalog' or 'storage' are changed:
   recreate resources.pipelines.my_pipelines
 Recreated pipelines.my_pipelines
 Recreated schemas.my_schema
-Files: 3 uploaded, 0 deleted
+Files: 2 uploaded, 0 deleted
 Resources: 2 created, 0 changed, 2 deleted, 0 unchanged
 
 >>> errcode [CLI] bundle plan
@@ -69,5 +69,5 @@ properties such as the 'catalog' or 'storage' are changed:
   delete resources.pipelines.my_pipelines
 Deleted pipelines.my_pipelines
 Deleted schemas.my_schema
-Files: 1 uploaded, 2 deleted
+Files: 0 uploaded, 2 deleted
 Resources: 0 created, 0 changed, 2 deleted, 0 unchanged

--- a/acceptance/bundle/lifecycle/prevent-destroy/out.terraform.txt
+++ b/acceptance/bundle/lifecycle/prevent-destroy/out.terraform.txt
@@ -56,7 +56,7 @@ continue with the plan, either disable lifecycle.prevent_destroy or reduce
 the scope of the plan using the -target flag.
 
 
-Files: 3 uploaded, 0 deleted
+Files: 1 uploaded, 0 deleted
 
 >>> errcode [CLI] bundle plan
 Error: exit status 1
@@ -110,7 +110,7 @@ continue with the plan, either disable lifecycle.prevent_destroy or reduce
 the scope of the plan using the -target flag.
 
 
-Files: 2 uploaded, 0 deleted
+Files: 1 uploaded, 0 deleted
 
 >>> errcode [CLI] bundle plan
 recreate pipelines.my_pipelines
@@ -131,7 +131,7 @@ properties such as the 'catalog' or 'storage' are changed:
   recreate resources.pipelines.my_pipelines
 Recreated pipelines.my_pipelines
 Recreated schemas.my_schema
-Files: 3 uploaded, 0 deleted
+Files: 2 uploaded, 0 deleted
 Resources: 2 created, 0 changed, 2 deleted, 0 unchanged
 
 >>> errcode [CLI] bundle plan
@@ -153,5 +153,5 @@ properties such as the 'catalog' or 'storage' are changed:
   delete resources.pipelines.my_pipelines
 Deleted pipelines.my_pipelines
 Deleted schemas.my_schema
-Files: 1 uploaded, 2 deleted
+Files: 0 uploaded, 2 deleted
 Resources: 0 created, 0 changed, 2 deleted, 0 unchanged

--- a/acceptance/bundle/lifecycle/prevent-destroy/output.txt
+++ b/acceptance/bundle/lifecycle/prevent-destroy/output.txt
@@ -12,7 +12,7 @@ Validation OK!
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/prevent-destroy/default/files...
 Created pipelines.my_pipelines
 Created schemas.my_schema
-Files: 8 uploaded, 0 deleted
+Files: 5 uploaded, 0 deleted
 Resources: 2 created, 0 changed, 0 deleted, 0 unchanged
 
 >>> errcode [CLI] bundle plan


### PR DESCRIPTION
Preserve line endings in update_file.py and exclude harness files from sync so deploy file-count goldens match across OSes after #5720.
