### PR TITLE
acc: fix Windows failures in prevent-destroy and shell/cmd

### DIFF
--- a/acceptance/bundle/artifacts/shell/cmd/output.txt
+++ b/acceptance/bundle/artifacts/shell/cmd/output.txt
@@ -1,6 +1,2 @@
 
->>> [CLI] bundle deploy
-Building my_artifact...
-Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/shell-cmd/default/files...
-Files: 6 uploaded, 0 deleted
-Resources: 0 created, 0 changed, 0 deleted, 0 unchanged
+>>> [CLI] bundle deploy -qq

--- a/acceptance/bundle/artifacts/shell/cmd/script
+++ b/acceptance/bundle/artifacts/shell/cmd/script
@@ -1,1 +1,1 @@
-trace $CLI bundle deploy
+trace $CLI bundle deploy -qq

--- a/acceptance/bundle/lifecycle/prevent-destroy/out.direct.txt
+++ b/acceptance/bundle/lifecycle/prevent-destroy/out.direct.txt
@@ -9,11 +9,9 @@ recreate pipelines.my_pipelines
 
 Plan: 1 to add, 0 to change, 1 to delete, 1 unchanged
 
->>> musterr [CLI] bundle deploy
-Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/prevent-destroy/default/files...
+>>> musterr [CLI] bundle deploy -qq
 Error: resources.pipelines.my_pipelines has lifecycle.prevent_destroy set, but the plan calls for this resource to be recreated or destroyed. To avoid this error, disable lifecycle.prevent_destroy for resources.pipelines.my_pipelines
 
-Files: 3 uploaded, 0 deleted
 
 >>> errcode [CLI] bundle plan
 recreate pipelines.my_pipelines
@@ -21,12 +19,10 @@ recreate schemas.my_schema
 
 Plan: 2 to add, 0 to change, 2 to delete, 0 unchanged
 
->>> musterr [CLI] bundle deploy
-Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/prevent-destroy/default/files...
+>>> musterr [CLI] bundle deploy -qq
 Error: resources.pipelines.my_pipelines has lifecycle.prevent_destroy set, but the plan calls for this resource to be recreated or destroyed. To avoid this error, disable lifecycle.prevent_destroy for resources.pipelines.my_pipelines
 resources.schemas.my_schema has lifecycle.prevent_destroy set, but the plan calls for this resource to be recreated or destroyed. To avoid this error, disable lifecycle.prevent_destroy for resources.schemas.my_schema
 
-Files: 2 uploaded, 0 deleted
 
 >>> errcode [CLI] bundle plan
 recreate pipelines.my_pipelines

--- a/acceptance/bundle/lifecycle/prevent-destroy/out.terraform.txt
+++ b/acceptance/bundle/lifecycle/prevent-destroy/out.terraform.txt
@@ -41,8 +41,7 @@ the scope of the plan using the -target flag.
 
 Exit code: 1
 
->>> musterr [CLI] bundle deploy
-Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/prevent-destroy/default/files...
+>>> musterr [CLI] bundle deploy -qq
 Error: exit status 1
 
 Error: Instance cannot be destroyed
@@ -56,7 +55,6 @@ continue with the plan, either disable lifecycle.prevent_destroy or reduce
 the scope of the plan using the -target flag.
 
 
-Files: 3 uploaded, 0 deleted
 
 >>> errcode [CLI] bundle plan
 Error: exit status 1
@@ -85,8 +83,7 @@ the scope of the plan using the -target flag.
 
 Exit code: 1
 
->>> musterr [CLI] bundle deploy
-Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/prevent-destroy/default/files...
+>>> musterr [CLI] bundle deploy -qq
 Error: exit status 1
 
 Error: Instance cannot be destroyed
@@ -110,7 +107,6 @@ continue with the plan, either disable lifecycle.prevent_destroy or reduce
 the scope of the plan using the -target flag.
 
 
-Files: 2 uploaded, 0 deleted
 
 >>> errcode [CLI] bundle plan
 recreate pipelines.my_pipelines

--- a/acceptance/bundle/lifecycle/prevent-destroy/script
+++ b/acceptance/bundle/lifecycle/prevent-destroy/script
@@ -10,12 +10,12 @@ trace musterr $CLI bundle destroy --auto-approve >>out.$DATABRICKS_BUNDLE_ENGINE
 # Changing from catalog to storage, deploy must fail because pipeline will be recreated
 update_file.py resources/pipeline.yml '      catalog: main' '      storage: "dbfs:/my-storage"'
 trace errcode $CLI bundle plan >>out.$DATABRICKS_BUNDLE_ENGINE.txt 2>&1
-trace musterr $CLI bundle deploy >>out.$DATABRICKS_BUNDLE_ENGINE.txt 2>&1
+trace musterr $CLI bundle deploy -qq >>out.$DATABRICKS_BUNDLE_ENGINE.txt 2>&1
 
 # Changing the schema name, deploy must fail because schema will be recreated
 update_file.py resources/schema.yml 'name: test-schema' 'name: test-schema-new'
 trace errcode $CLI bundle plan >>out.$DATABRICKS_BUNDLE_ENGINE.txt 2>&1
-trace musterr $CLI bundle deploy >>out.$DATABRICKS_BUNDLE_ENGINE.txt 2>&1
+trace musterr $CLI bundle deploy -qq >>out.$DATABRICKS_BUNDLE_ENGINE.txt 2>&1
 
 # Removing the prevent_destroy, deploy must succeed
 update_file.py resources/pipeline.yml 'prevent_destroy: true' 'prevent_destroy: false'


### PR DESCRIPTION
## Why
Two tests assert `Files: N uploaded`, which is not stable on Windows:

- `bundle/lifecycle/prevent-destroy` is the only test that redirects `bundle deploy`
  output away from `output.txt`, so nothing writes to `output.txt` between the two
  deploys. Its mtime stays put on Linux and macOS, but on Windows the last-write-time
  update on the still-open handle lands late and the file looks modified, giving
  `Files: 3` instead of `2`. Deterministic, both engines.
- `bundle/artifacts/shell/cmd` only runs on Windows, so `-update` elsewhere skips it.
  https://github.com/databricks/cli/pull/6264 took repls.json out of the synced tree
  and moved the four sibling shell tests from 6 to 5, leaving this one stale at 6.

## Changes
Add `-qq` to those deploys. The count is noise in both: prevent-destroy asserts the
`prevent_destroy` error, and shell/cmd asserts which shell ran the build via
`out.shell.txt`.