### PR TITLE
Make `clusters start` succeed when the cluster is already running

### DIFF
--- a/.nextchanges/cli/clusters-start-already-running.md
+++ b/.nextchanges/cli/clusters-start-already-running.md
@@ -1,0 +1,1 @@
+Fixed `databricks clusters start` failing with `Cluster <id> is in unexpected state Running.` when the cluster is already running. The command is documented as a no-op for a cluster that is not terminated, so it now reports success and prints the cluster instead of erroring. ([#6288](https://github.com/databricks/cli/pull/6288))

--- a/acceptance/cmd/workspace/clusters-start/out.test.toml
+++ b/acceptance/cmd/workspace/clusters-start/out.test.toml
@@ -1,0 +1,2 @@
+Cloud = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/cmd/workspace/clusters-start/output.txt
+++ b/acceptance/cmd/workspace/clusters-start/output.txt
@@ -1,0 +1,16 @@
+
+=== Starting a cluster that is already running is a no-op, not an error
+
+>>> [CLI] clusters start [CLUSTER_ID]
+{
+  "cluster_id": "[CLUSTER_ID]",
+  "state": "RUNNING"
+}
+
+=== Starting a terminated cluster starts it
+
+>>> [CLI] clusters start [CLUSTER_ID]
+{
+  "cluster_id": "[CLUSTER_ID]",
+  "state": "RUNNING"
+}

--- a/acceptance/cmd/workspace/clusters-start/script
+++ b/acceptance/cmd/workspace/clusters-start/script
@@ -1,0 +1,9 @@
+CLUSTER_ID=$($CLI clusters create --json '{"cluster_name": "test-cluster", "spark_version": "13.3.x-scala2.12", "node_type_id": "i3.xlarge", "num_workers": 1}' | jq -r '.cluster_id')
+echo "$CLUSTER_ID:CLUSTER_ID" >> ACC_REPLS
+
+title "Starting a cluster that is already running is a no-op, not an error\n"
+trace $CLI clusters start "$CLUSTER_ID" | jq '{cluster_id, state}'
+
+title "Starting a terminated cluster starts it\n"
+$CLI clusters delete "$CLUSTER_ID" > /dev/null
+trace $CLI clusters start "$CLUSTER_ID" | jq '{cluster_id, state}'

--- a/acceptance/cmd/workspace/clusters-start/test.toml
+++ b/acceptance/cmd/workspace/clusters-start/test.toml
@@ -1,0 +1,2 @@
+# Cluster commands are not bundle-aware; run them once instead of per-engine.
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/cmd/workspace/clusters/overrides.go
+++ b/cmd/workspace/clusters/overrides.go
@@ -1,9 +1,12 @@
 package clusters
 
 import (
+	"errors"
 	"strings"
 
+	"github.com/databricks/cli/libs/cmdctx"
 	"github.com/databricks/cli/libs/cmdio"
+	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/databricks-sdk-go/service/compute"
 	"github.com/spf13/cobra"
 )
@@ -93,8 +96,36 @@ func sparkVersionsOverride(sparkVersionsCmd *cobra.Command) {
 	`)
 }
 
+func startOverride(startCmd *cobra.Command, startReq *compute.StartCluster) {
+	start := startCmd.RunE
+	startCmd.RunE = func(cmd *cobra.Command, args []string) error {
+		err := start(cmd, args)
+		if err == nil {
+			return nil
+		}
+
+		// The API rejects a cluster that is not TERMINATED with INVALID_STATE, even though this
+		// command is documented as a no-op in that case ("If the cluster is not currently in a
+		// TERMINATED state, nothing will happen"). Report success if the cluster is already
+		// running, so that starting a running cluster is idempotent.
+		apiErr, ok := errors.AsType[*apierr.APIError](err)
+		if !ok || apiErr.ErrorCode != "INVALID_STATE" {
+			return err
+		}
+
+		ctx := cmd.Context()
+		cluster, getErr := cmdctx.WorkspaceClient(ctx).Clusters.GetByClusterId(ctx, startReq.ClusterId)
+		if getErr != nil || cluster.State != compute.StateRunning {
+			return err
+		}
+
+		return cmdio.Render(ctx, cluster)
+	}
+}
+
 func init() {
 	listOverrides = append(listOverrides, listOverride)
 	listNodeTypesOverrides = append(listNodeTypesOverrides, listNodeTypesOverride)
 	sparkVersionsOverrides = append(sparkVersionsOverrides, sparkVersionsOverride)
+	startOverrides = append(startOverrides, startOverride)
 }

--- a/libs/testserver/clusters.go
+++ b/libs/testserver/clusters.go
@@ -216,6 +216,19 @@ func (s *FakeWorkspace) ClustersStart(req Request) any {
 		return Response{StatusCode: 404}
 	}
 
+	// Only terminated clusters can be started; match the real API behavior, which rejects
+	// any other state with INVALID_STATE (it title-cases the state in the message, e.g.
+	// "Cluster 0308-101010-abcdefgh is in unexpected state Running.").
+	if cluster.State != compute.StateTerminated {
+		return Response{
+			StatusCode: 400,
+			Body: map[string]string{
+				"error_code": "INVALID_STATE",
+				"message":    fmt.Sprintf("Cluster %s is in unexpected state %s.", request.ClusterId, cluster.State),
+			},
+		}
+	}
+
 	cluster.State = compute.StateRunning
 	s.Clusters[request.ClusterId] = cluster
 


### PR DESCRIPTION
## Changes

`databricks clusters start` on a cluster that is already running now reports success and prints the cluster, instead of failing with `Cluster <id> is in unexpected state Running.`. Any other `INVALID_STATE` rejection (a terminating cluster, for example) is still returned unchanged.

The test server now models the API's `INVALID_STATE` rejection of `clusters/start` for a cluster that is not terminated; it previously accepted the call in any state.

Fixes #1372.

## Why

The command's own help text states "If the cluster is not currently in a TERMINATED state, nothing will happen", but the API rejects the request, so a script that just wants the cluster up has to match on the error message. The direct engine already treats an already-running cluster as a no-op (`bundle/direct/dresources/cluster.go`), so this aligns the standalone command with both the documented contract and bundle behavior.

The check is deliberately narrow: it re-reads the cluster after `INVALID_STATE` and only swallows the error when the state is `RUNNING`. A cluster that is `PENDING` or `RESTARTING` still errors out, because succeeding there would mean waiting for a state transition rather than reporting a no-op.

## Tests

New acceptance test `acceptance/cmd/workspace/clusters-start`, covering both an already-running cluster and a terminated one. Reverting only the `cmd/workspace/clusters` change makes it fail with the exact error from the issue:

```
>>> [CLI] clusters start [CLUSTER_ID]
Error: Cluster [CLUSTER_ID] is in unexpected state RUNNING.

Exit code: 1
```

`./task fmt`, `./task checks` and `./task lint` are clean. `./task test` passes locally except for `bundle/templates-machinery/supported-url`, which fails the same way on an unmodified `origin/main` checkout here because my network path answers the intentionally invalid host with a proxy error instead of a DNS failure.

_This PR was written by Claude Code, then reviewed and tested by me._
