### PR TITLE
configsync: don't sync backend-managed spark_env_vars, detect unwritable YAML parents by node kind

### DIFF
--- a/acceptance/bundle/config-remote-sync/job_fields/output.txt
+++ b/acceptance/bundle/config-remote-sync/job_fields/output.txt
@@ -102,6 +102,7 @@ Resource: resources.jobs.my_job
   ],
   "files_changed_count": 1,
   "files_written_count": 1,
+  "backend_default_skipped_count": 0,
   "state_serial": 1,
   "state_lineage": "[UUID]",
   "state_source": "local",

--- a/acceptance/bundle/config-remote-sync/policy_injected_cluster_fields/output.txt
+++ b/acceptance/bundle/config-remote-sync/policy_injected_cluster_fields/output.txt
@@ -3,11 +3,12 @@ Deploying resources...
 Updating deployment state...
 Deployment complete!
 
-=== Simulate a cluster policy injecting custom_tags and cluster_log_conf
+=== Simulate a cluster policy injecting custom_tags, cluster_log_conf and spark_env_vars
 These fields exist only remotely (the user never set them in config).
 A legitimate edit (max_concurrent_runs) is made too, to show real edits still sync.
 
 === Detect and save all changes
+Warn: Not syncing 6 field(s) managed outside the configuration (cluster policy or backend defaults): resources.jobs.job1.job_clusters[job_cluster_key='shared'].new_cluster.cluster_log_conf, resources.jobs.job1.job_clusters[job_cluster_key='shared'].new_cluster.custom_tags, resources.jobs.job1.job_clusters[job_cluster_key='shared'].new_cluster.spark_env_vars, resources.jobs.job1.tasks[task_key='own_cluster_task'].new_cluster.cluster_log_conf, resources.jobs.job1.tasks[task_key='own_cluster_task'].new_cluster.custom_tags, resources.jobs.job1.tasks[task_key='own_cluster_task'].new_cluster.spark_env_vars. Declare a field in the configuration to sync it from then on
 Detected changes in 1 resource(s):
 
 Resource: resources.jobs.job1

--- a/acceptance/bundle/config-remote-sync/policy_injected_cluster_fields/script
+++ b/acceptance/bundle/config-remote-sync/policy_injected_cluster_fields/script
@@ -10,7 +10,7 @@ trap cleanup EXIT
 $CLI bundle deploy
 job1_id="$(read_id.py job1)"
 
-title "Simulate a cluster policy injecting custom_tags and cluster_log_conf"
+title "Simulate a cluster policy injecting custom_tags, cluster_log_conf and spark_env_vars"
 echo
 echo "These fields exist only remotely (the user never set them in config)."
 echo "A legitimate edit (max_concurrent_runs) is made too, to show real edits still sync."
@@ -22,15 +22,19 @@ r["max_concurrent_runs"] = 5
 # field's value is irrelevant here — only that it exists remotely and not in config.
 policy_tags = {"CostCenter": "dev-1234", "Team": "finops"}
 policy_log_conf = {"dbfs": {"destination": "dbfs:/cluster-logs/dev"}}
+# spark_env_vars routinely carries credentials, so it must not be written to config.
+policy_env_vars = {"UV_INDEX_ACME_PASSWORD": "dev-secret"}
 
 for task in r.get("tasks", []):
     if "new_cluster" in task:
         task["new_cluster"]["custom_tags"] = dict(policy_tags)
         task["new_cluster"]["cluster_log_conf"] = dict(policy_log_conf)
+        task["new_cluster"]["spark_env_vars"] = dict(policy_env_vars)
 
 for jc in r.get("job_clusters", []):
     jc["new_cluster"]["custom_tags"] = dict(policy_tags)
     jc["new_cluster"]["cluster_log_conf"] = dict(policy_log_conf)
+    jc["new_cluster"]["spark_env_vars"] = dict(policy_env_vars)
 EOF
 
 title "Detect and save all changes"

--- a/acceptance/bundle/config-remote-sync/resolve_variables/output.txt
+++ b/acceptance/bundle/config-remote-sync/resolve_variables/output.txt
@@ -133,6 +133,7 @@ Resource: resources.pipelines.my_pipeline
   ],
   "files_changed_count": 1,
   "files_written_count": 1,
+  "backend_default_skipped_count": 0,
   "refs_retargeted": 1,
   "refs_from_siblings": 7,
   "state_serial": [SERIAL],

--- a/acceptance/bundle/telemetry/config-remote-sync-error/output.txt
+++ b/acceptance/bundle/telemetry/config-remote-sync-error/output.txt
@@ -7,6 +7,7 @@ Exit code: 1
 >>> cat out.requests.txt
 {
   "engine": "terraform",
+  "backend_default_skipped_count": 0,
   "state_source": "local",
   "states_available_count": 0,
   "error_message": "state snapshot not available: resources state snapshot not found remotely at resources-config-sync-snapshot.json: state snapshot not found",

--- a/acceptance/bundle/telemetry/config-remote-sync-recreate/output.txt
+++ b/acceptance/bundle/telemetry/config-remote-sync-recreate/output.txt
@@ -27,6 +27,7 @@ Resource: resources.pipelines.foo
     }
   ],
   "files_changed_count": 1,
+  "backend_default_skipped_count": 0,
   "state_serial": 1,
   "state_lineage": "[UUID]",
   "state_source": "local",

--- a/acceptance/bundle/telemetry/config-remote-sync-save/output.txt
+++ b/acceptance/bundle/telemetry/config-remote-sync-save/output.txt
@@ -29,6 +29,7 @@ Resource: resources.jobs.foo
   ],
   "files_changed_count": 1,
   "files_written_count": 1,
+  "backend_default_skipped_count": 0,
   "state_serial": 1,
   "state_lineage": "[UUID]",
   "state_source": "local",

--- a/acceptance/bundle/telemetry/config-remote-sync/output.txt
+++ b/acceptance/bundle/telemetry/config-remote-sync/output.txt
@@ -26,6 +26,7 @@ Resource: resources.jobs.foo
     }
   ],
   "files_changed_count": 1,
+  "backend_default_skipped_count": 0,
   "state_serial": 1,
   "state_lineage": "[UUID]",
   "state_source": "local",

--- a/bundle/configsync/defaults.go
+++ b/bundle/configsync/defaults.go
@@ -67,6 +67,15 @@ var serverSideDefaults = map[string]any{
 	// configsync filtering is migrated to the direct engine lifecycle metadata.
 	"resources.jobs.*.tasks[*].new_cluster.custom_tags":      backendDefault,
 	"resources.jobs.*.tasks[*].new_cluster.cluster_log_conf": backendDefault,
+	// spark_env_vars is filled in remotely from sources the config cannot see: a
+	// cluster policy can inject the map or pin a single variable, and a pipeline's
+	// deployment spec is merged into the cluster spec on the backend. The values
+	// also routinely carry credentials (uv's UV_INDEX_<name>_PASSWORD convention),
+	// which must never be written into config. Both patterns are needed: matchParts
+	// only matches equal segment counts, so a policy pinning one variable produces a
+	// ...spark_env_vars.<NAME> path that the bare pattern does not cover.
+	"resources.jobs.*.tasks[*].new_cluster.spark_env_vars":   backendDefault,
+	"resources.jobs.*.tasks[*].new_cluster.spark_env_vars.*": backendDefault,
 
 	// Cluster fields (job_clusters)
 	"resources.jobs.*.job_clusters[*].new_cluster.aws_attributes":      alwaysSkip,
@@ -77,6 +86,8 @@ var serverSideDefaults = map[string]any{
 	"resources.jobs.*.job_clusters[*].new_cluster.single_user_name":    alwaysSkip,
 	"resources.jobs.*.job_clusters[*].new_cluster.custom_tags":         backendDefault, // see tasks[*].new_cluster.custom_tags
 	"resources.jobs.*.job_clusters[*].new_cluster.cluster_log_conf":    backendDefault, // see tasks[*].new_cluster.cluster_log_conf
+	"resources.jobs.*.job_clusters[*].new_cluster.spark_env_vars":      backendDefault, // see tasks[*].new_cluster.spark_env_vars
+	"resources.jobs.*.job_clusters[*].new_cluster.spark_env_vars.*":    backendDefault, // see tasks[*].new_cluster.spark_env_vars
 
 	// Standalone cluster fields
 	"resources.clusters.*.aws_attributes":      alwaysSkip,
@@ -88,6 +99,8 @@ var serverSideDefaults = map[string]any{
 	"resources.clusters.*.single_user_name":    alwaysSkip,
 	"resources.clusters.*.custom_tags":         backendDefault, // see jobs.*.tasks[*].new_cluster.custom_tags
 	"resources.clusters.*.cluster_log_conf":    backendDefault, // see jobs.*.tasks[*].new_cluster.cluster_log_conf
+	"resources.clusters.*.spark_env_vars":      backendDefault, // see jobs.*.tasks[*].new_cluster.spark_env_vars
+	"resources.clusters.*.spark_env_vars.*":    backendDefault, // see jobs.*.tasks[*].new_cluster.spark_env_vars
 
 	// Experiment fields
 	"resources.experiments.*.artifact_location": alwaysSkip,
@@ -131,34 +144,60 @@ var serverSideDefaults = map[string]any{
 // field is not in config/state, matching the behavior of shouldSkipBackendDefault
 // in the direct deployment engine.
 func shouldSkipField(path string, value any, hasConfigValue bool) bool {
+	expected, ok := lookupSkipRule(path)
+	if !ok {
+		return false
+	}
+	if _, ok := expected.(skipAlways); ok {
+		return true
+	}
+	if hasConfigValue {
+		return false
+	}
+	if _, ok := expected.(skipBackendDefault); ok {
+		return true
+	}
+	if _, ok := expected.(skipIfZeroOrNil); ok {
+		return value == nil || value == int64(0)
+	}
+	if marker, ok := expected.(skipIfEmptyOrDefault); ok {
+		m, ok := value.(map[string]any)
+		if !ok {
+			return false
+		}
+		if len(m) == 0 {
+			return true
+		}
+		return reflect.DeepEqual(m, marker.defaults)
+	}
+	return reflect.DeepEqual(value, expected)
+}
+
+// lookupSkipRule returns the serverSideDefaults marker whose pattern matches path.
+func lookupSkipRule(path string) (any, bool) {
 	for pattern, expected := range serverSideDefaults {
 		if matchPattern(pattern, path) {
-			if _, ok := expected.(skipAlways); ok {
-				return true
-			}
-			if hasConfigValue {
-				return false
-			}
-			if _, ok := expected.(skipBackendDefault); ok {
-				return true
-			}
-			if _, ok := expected.(skipIfZeroOrNil); ok {
-				return value == nil || value == int64(0)
-			}
-			if marker, ok := expected.(skipIfEmptyOrDefault); ok {
-				m, ok := value.(map[string]any)
-				if !ok {
-					return false
-				}
-				if len(m) == 0 {
-					return true
-				}
-				return reflect.DeepEqual(m, marker.defaults)
-			}
-			return reflect.DeepEqual(value, expected)
+			return expected, true
 		}
 	}
-	return false
+	return nil, false
+}
+
+// isBackendManagedSkip reports whether path is skipped only because it is a
+// backend-managed field absent from config. These skips are the ones worth
+// telling the user about: the remote value is real, so it is silently not synced
+// back and the next deploy pushes the stale local value over it. The other
+// server-side defaults fire on every run and carry no such consequence.
+func isBackendManagedSkip(path string, hasConfigValue bool) bool {
+	if hasConfigValue {
+		return false
+	}
+	expected, ok := lookupSkipRule(path)
+	if !ok {
+		return false
+	}
+	_, ok = expected.(skipBackendDefault)
+	return ok
 }
 
 func matchPattern(pattern, path string) bool {

--- a/bundle/configsync/defaults_test.go
+++ b/bundle/configsync/defaults_test.go
@@ -1,0 +1,135 @@
+package configsync
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// spark_env_vars is skipped when it is absent from config, both as a whole map and
+// per key: a cluster policy can pin a single variable, which produces a per-key
+// change path.
+func TestShouldSkipFieldSparkEnvVars(t *testing.T) {
+	remote := map[string]any{"UV_INDEX_ACME_PASSWORD": "secret"}
+
+	tests := []struct {
+		name           string
+		path           string
+		value          any
+		hasConfigValue bool
+		want           bool
+	}{
+		{
+			name:  "task cluster whole map",
+			path:  "resources.jobs.my_job.tasks[0].new_cluster.spark_env_vars",
+			value: remote,
+			want:  true,
+		},
+		{
+			name:  "task cluster single key",
+			path:  "resources.jobs.my_job.tasks[0].new_cluster.spark_env_vars.UV_INDEX_ACME_PASSWORD",
+			value: "secret",
+			want:  true,
+		},
+		{
+			name:  "job cluster whole map",
+			path:  "resources.jobs.my_job.job_clusters[0].new_cluster.spark_env_vars",
+			value: remote,
+			want:  true,
+		},
+		{
+			name:  "job cluster single key",
+			path:  "resources.jobs.my_job.job_clusters[0].new_cluster.spark_env_vars.UV_INDEX_ACME_PASSWORD",
+			value: "secret",
+			want:  true,
+		},
+		{
+			name:  "standalone cluster whole map",
+			path:  "resources.clusters.my_cluster.spark_env_vars",
+			value: remote,
+			want:  true,
+		},
+		{
+			name:  "standalone cluster single key",
+			path:  "resources.clusters.my_cluster.spark_env_vars.UV_INDEX_ACME_PASSWORD",
+			value: "secret",
+			want:  true,
+		},
+		{
+			name:           "whole map present in config",
+			path:           "resources.jobs.my_job.job_clusters[0].new_cluster.spark_env_vars",
+			value:          remote,
+			hasConfigValue: true,
+			want:           false,
+		},
+		{
+			name:           "single key present in config",
+			path:           "resources.jobs.my_job.job_clusters[0].new_cluster.spark_env_vars.UV_INDEX_ACME_PASSWORD",
+			value:          "secret",
+			hasConfigValue: true,
+			want:           false,
+		},
+		{
+			// The scope mirrors the other new_cluster entries (custom_tags,
+			// cluster_log_conf), none of which cover for_each_task.
+			name:  "for_each_task cluster is not covered",
+			path:  "resources.jobs.my_job.tasks[0].for_each_task.task.new_cluster.spark_env_vars",
+			value: remote,
+			want:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, shouldSkipField(tt.path, tt.value, tt.hasConfigValue))
+		})
+	}
+}
+
+func TestIsBackendManagedSkip(t *testing.T) {
+	tests := []struct {
+		name           string
+		path           string
+		hasConfigValue bool
+		want           bool
+	}{
+		{
+			name: "backend default absent from config",
+			path: "resources.jobs.my_job.job_clusters[0].new_cluster.spark_env_vars.UV_INDEX_ACME_PASSWORD",
+			want: true,
+		},
+		{
+			name: "backend default map absent from config",
+			path: "resources.clusters.my_cluster.custom_tags",
+			want: true,
+		},
+		{
+			name:           "backend default present in config",
+			path:           "resources.clusters.my_cluster.custom_tags",
+			hasConfigValue: true,
+			want:           false,
+		},
+		{
+			// The other markers fire on every run, so surfacing them would be noise.
+			name: "always skipped field",
+			path: "resources.jobs.my_job.edit_mode",
+			want: false,
+		},
+		{
+			name: "value-compared default",
+			path: "resources.jobs.my_job.timeout_seconds",
+			want: false,
+		},
+		{
+			name: "field with no rule",
+			path: "resources.jobs.my_job.description",
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isBackendManagedSkip(tt.path, tt.hasConfigValue))
+		})
+	}
+}

--- a/bundle/configsync/diff.go
+++ b/bundle/configsync/diff.go
@@ -8,6 +8,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/databricks/cli/bundle"
@@ -170,9 +171,12 @@ func isPermissionsOrGrantsSubResource(resourceKey string) bool {
 }
 
 // ExtractChanges extracts the map of remote-vs-config changes from a deploy
-// plan. engine selects the LocalEdit comparison below.
-func ExtractChanges(ctx context.Context, b *bundle.Bundle, plan *deployplan.Plan, engine engine.EngineType) (Changes, error) {
+// plan. engine selects the LocalEdit comparison below. The second return value
+// counts the changes dropped as backend-managed fields absent from config, which
+// are reported to the user rather than applied.
+func ExtractChanges(ctx context.Context, b *bundle.Bundle, plan *deployplan.Plan, engine engine.EngineType) (Changes, int, error) {
 	changes := make(Changes)
+	var backendManaged []string
 
 	for resourceKey, entry := range plan.Plan {
 		// permissions and grants are emitted as their own plan keys
@@ -196,9 +200,12 @@ func ExtractChanges(ctx context.Context, b *bundle.Bundle, plan *deployplan.Plan
 				fullPath := resourceKey + "." + path
 				change, err := convertChangeDesc(fullPath, changeDesc)
 				if err != nil {
-					return nil, fmt.Errorf("failed to compute config change for path %s: %w", path, err)
+					return nil, 0, fmt.Errorf("failed to compute config change for path %s: %w", path, err)
 				}
 				if change.Operation == OperationSkip {
+					if isBackendManagedSkip(fullPath, changeDesc.New != nil) {
+						backendManaged = append(backendManaged, fullPath)
+					}
 					continue
 				}
 				// On the direct engine the state snapshot holds real per-field
@@ -221,7 +228,13 @@ func ExtractChanges(ctx context.Context, b *bundle.Bundle, plan *deployplan.Plan
 		log.Debugf(ctx, "Resource %s has %d changes", resourceKey, len(resourceChanges))
 	}
 
-	return changes, nil
+	if len(backendManaged) > 0 {
+		slices.Sort(backendManaged)
+		log.Warnf(ctx, "Not syncing %d field(s) managed outside the configuration (cluster policy or backend defaults): %s. Declare a field in the configuration to sync it from then on",
+			len(backendManaged), strings.Join(backendManaged, ", "))
+	}
+
+	return changes, len(backendManaged), nil
 }
 
 func ensureSnapshotAvailable(ctx context.Context, b *bundle.Bundle, engine engine.EngineType) error {

--- a/bundle/configsync/diff_test.go
+++ b/bundle/configsync/diff_test.go
@@ -285,8 +285,9 @@ func TestExtractChangesSkipsPermissionsAndGrants(t *testing.T) {
 
 	for _, eng := range []engine.EngineType{engine.EngineDirect, engine.EngineTerraform} {
 		t.Run(string(eng), func(t *testing.T) {
-			changes, err := ExtractChanges(ctx, &bundle.Bundle{}, plan, eng)
+			changes, backendManaged, err := ExtractChanges(ctx, &bundle.Bundle{}, plan, eng)
 			require.NoError(t, err)
+			require.Zero(t, backendManaged)
 
 			_, hasPerms := changes["resources.jobs.my_job.permissions"]
 			assert.False(t, hasPerms, "permissions sub-resource must be skipped")

--- a/bundle/configsync/patch.go
+++ b/bundle/configsync/patch.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/databricks/cli/bundle"
+	"github.com/databricks/cli/libs/dyn/dynvar"
 	"github.com/databricks/cli/libs/log"
 	"github.com/databricks/cli/libs/structs/structpath"
 	"github.com/palantir/pkg/yamlpatch/gopkgv3yamlpatcher"
@@ -20,11 +21,14 @@ import (
 	"go.yaml.in/yaml/v3"
 )
 
-// ApplyChangesToYAML generates YAML files for the given field changes.
-func ApplyChangesToYAML(ctx context.Context, b *bundle.Bundle, fieldChanges []FieldChange) ([]FileChange, error) {
+// ApplyChangesToYAML generates YAML files for the given field changes. The second
+// return value counts the changes left unapplied because their location in the
+// YAML cannot be written.
+func ApplyChangesToYAML(ctx context.Context, b *bundle.Bundle, fieldChanges []FieldChange) ([]FileChange, int, error) {
 	originalFiles := make(map[string][]byte)
 	modifiedFiles := make(map[string][]byte)
 	fileFieldChanges := make(map[string][]FieldChange)
+	skipped := 0
 
 	for _, fieldChange := range fieldChanges {
 		filePath := fieldChange.FilePath
@@ -32,7 +36,7 @@ func ApplyChangesToYAML(ctx context.Context, b *bundle.Bundle, fieldChanges []Fi
 		if _, exists := modifiedFiles[filePath]; !exists {
 			content, err := os.ReadFile(filePath)
 			if err != nil {
-				return nil, fmt.Errorf("failed to read file %s: %w", filePath, err)
+				return nil, 0, fmt.Errorf("failed to read file %s: %w", filePath, err)
 			}
 			originalFiles[filePath] = content
 			modifiedFiles[filePath] = preserveBlankLines(content)
@@ -40,7 +44,12 @@ func ApplyChangesToYAML(ctx context.Context, b *bundle.Bundle, fieldChanges []Fi
 
 		modifiedContent, err := applyChange(ctx, modifiedFiles[filePath], fieldChange)
 		if err != nil {
-			return nil, fmt.Errorf("failed to apply change to file %s for a field %s: %w", filePath, fieldChange.WritePath, err)
+			if errors.Is(err, errUnwritableParent) {
+				log.Debugf(ctx, "config-remote-sync: skipping %s in %s: %v", fieldChange.WritePath, filePath, err)
+				skipped++
+				continue
+			}
+			return nil, 0, fmt.Errorf("failed to apply change to file %s for a field %s: %w", filePath, fieldChange.WritePath, err)
 		}
 
 		modifiedFiles[filePath] = modifiedContent
@@ -48,13 +57,16 @@ func ApplyChangesToYAML(ctx context.Context, b *bundle.Bundle, fieldChanges []Fi
 	}
 
 	var result []FileChange
-	for filePath := range modifiedFiles {
+	// Iterating the applied changes rather than modifiedFiles leaves out a file
+	// whose every change was skipped: re-encoding it would report a modification
+	// that was never made.
+	for filePath, appliedChanges := range fileFieldChanges {
 		// TODO: A good alternative approach is to remove parent nodes during the Resolve phase,
 		// when all of their keys/items are removed, but this should be tested for edge cases.
 		// In this case flow style will never appear because empty nodes are never serialized and we won't need clearAddedFlowStyle
-		normalized, err := clearAddedFlowStyle(modifiedFiles[filePath], fileFieldChanges[filePath])
+		normalized, err := clearAddedFlowStyle(modifiedFiles[filePath], appliedChanges)
 		if err != nil {
-			return nil, fmt.Errorf("failed to normalize YAML style in %s: %w", filePath, err)
+			return nil, 0, fmt.Errorf("failed to normalize YAML style in %s: %w", filePath, err)
 		}
 		result = append(result, FileChange{
 			Path:            filePath,
@@ -67,12 +79,16 @@ func ApplyChangesToYAML(ctx context.Context, b *bundle.Bundle, fieldChanges []Fi
 		return cmp.Compare(a.Path, b.Path)
 	})
 
-	return result, nil
+	return result, skipped, nil
 }
 
+// parentNode records what stands between a change and its destination: path is
+// the change itself, ancestorPath the deepest node the walk reached, and kind how
+// that node has to be materialized before the change can be applied.
 type parentNode struct {
-	path        yamlpatch.Path
-	missingPath yamlpatch.Path
+	path         yamlpatch.Path
+	ancestorPath yamlpatch.Path
+	kind         parentKind
 }
 
 // applyChange applies a single field change to YAML content.
@@ -115,10 +131,21 @@ func applyChange(ctx context.Context, content []byte, fieldChange FieldChange) (
 				Value: fieldChange.Change.Value,
 			}})
 
-			// Collect parent path errors for later retry
-			if patchErr != nil && isParentPathError(patchErr) {
-				if missingPath, extractErr := extractMissingPath(patchErr); extractErr == nil {
-					parentNodesToCreate = append(parentNodesToCreate, parentNode{path, missingPath})
+			// Collect not-yet-writable parents for later retry. The patcher reports
+			// a missing parent, an empty "key:" placeholder and a ${...} reference as
+			// three differently-worded errors from a third-party package, so the
+			// target node is inspected directly instead of matching on that text.
+			if patchErr != nil {
+				kind, ancestorPath, inspectErr := resolveParentNode(content, path)
+				if inspectErr != nil {
+					return nil, fmt.Errorf("failed to inspect parent of %s: %w", jsonPointer, inspectErr)
+				}
+				switch kind {
+				case parentAbsent, parentNull, parentVariable:
+					parentNodesToCreate = append(parentNodesToCreate, parentNode{path, ancestorPath, kind})
+				default:
+					// parentContainer means the parent is writable and the patch failed
+					// for an unrelated reason; a plain scalar parent is a genuine error.
 				}
 			}
 		default:
@@ -139,28 +166,42 @@ func applyChange(ctx context.Context, content []byte, fieldChange FieldChange) (
 		}
 	}
 
-	// If all attempts failed with parent path errors, try creating nested structures
+	// If all attempts failed because the parent is not a container yet, materialize
+	// it and write the change into it.
 	if !success && len(parentNodesToCreate) > 0 {
 		for _, errInfo := range parentNodesToCreate {
-			nestedValue := buildNestedMaps(errInfo.path, errInfo.missingPath, fieldChange.Change.Value)
+			if errInfo.kind == parentVariable {
+				// The node's value is owned by a variable: overwriting it destroys the
+				// indirection for every target that shares this file.
+				return nil, fmt.Errorf("%w at %s", errUnwritableParent, errInfo.ancestorPath.String())
+			}
+
+			nestedValue := buildNestedMaps(errInfo.path, errInfo.ancestorPath, fieldChange.Change.Value)
+
+			// An empty "key:" is a null scalar rather than a mapping, so the
+			// placeholder is replaced instead of added to.
+			opType := yamlpatch.OperationAdd
+			if errInfo.kind == parentNull {
+				opType = yamlpatch.OperationReplace
+			}
 
 			patcher := gopkgv3yamlpatcher.New(gopkgv3yamlpatcher.IndentSpaces(2))
 			modifiedContent, patchErr := patcher.Apply(content, yamlpatch.Patch{yamlpatch.Operation{
-				Type:  yamlpatch.OperationAdd,
-				Path:  errInfo.missingPath,
+				Type:  opType,
+				Path:  errInfo.ancestorPath,
 				Value: nestedValue,
 			}})
 
 			if patchErr == nil {
 				content = modifiedContent
 				firstErr = nil
-				log.Debugf(ctx, "Created nested structure at %s", errInfo.missingPath.String())
+				log.Debugf(ctx, "Created nested structure at %s", errInfo.ancestorPath.String())
 				break
 			}
 			if firstErr == nil {
 				firstErr = patchErr
 			}
-			log.Debugf(ctx, "Failed to create nested structure at %s: %v", errInfo.missingPath.String(), patchErr)
+			log.Debugf(ctx, "Failed to create nested structure at %s: %v", errInfo.ancestorPath.String(), patchErr)
 		}
 	}
 
@@ -174,15 +215,6 @@ func applyChange(ctx context.Context, content []byte, fieldChange FieldChange) (
 	return content, nil
 }
 
-// isParentPathError checks if error indicates missing parent path.
-func isParentPathError(err error) bool {
-	if err == nil {
-		return false
-	}
-	msg := err.Error()
-	return strings.Contains(msg, "parent path") && strings.Contains(msg, "does not exist")
-}
-
 // isPathNotFoundError checks if error indicates the path itself does not exist.
 func isPathNotFoundError(err error) bool {
 	if err == nil {
@@ -192,24 +224,122 @@ func isPathNotFoundError(err error) bool {
 	return strings.Contains(msg, "does not exist")
 }
 
-// extractMissingPath extracts the missing path from error message like:
-// "op add /a/b/c/d: parent path /a/b does not exist"
-// Returns: "/a/b"
-func extractMissingPath(err error) (yamlpatch.Path, error) {
-	msg := err.Error()
-	start := strings.Index(msg, "parent path ")
-	if start == -1 {
-		return nil, errors.New("could not find 'parent path' in error message")
-	}
-	start += len("parent path ")
+// errUnwritableParent reports that a change's parent node holds a variable
+// reference, so the change has no location that can be written.
+var errUnwritableParent = errors.New("parent value is a variable reference")
 
-	end := strings.Index(msg[start:], " does not exist")
-	if end == -1 {
-		return nil, errors.New("could not find 'does not exist' in error message")
+// parentKind classifies the node a change's parent path resolves to, which decides
+// whether the change can be written and how.
+type parentKind int
+
+const (
+	// parentContainer is a mapping or a sequence: the change can be applied as-is.
+	parentContainer parentKind = iota
+	// parentAbsent means the walk stopped before reaching the parent, so the
+	// intermediate nodes have to be created.
+	parentAbsent
+	// parentNull is an empty "key:", which YAML parses as a null scalar rather than
+	// as the empty mapping "key: {}" produces.
+	parentNull
+	// parentVariable is a scalar holding a ${...} reference.
+	parentVariable
+	// parentScalar is any other scalar, which nothing can be written underneath.
+	parentScalar
+)
+
+// resolveParentNode walks path in content and reports the kind of the deepest node
+// the walk reached along with that node's path, mirroring how the patcher resolves
+// the same path: the last path segment is the key being written, so only its
+// ancestors are traversed, and an absent node is reported at the path the patcher
+// names in its "parent path %s does not exist" error.
+func resolveParentNode(content []byte, path yamlpatch.Path) (parentKind, yamlpatch.Path, error) {
+	var doc yaml.Node
+	if err := yaml.Unmarshal(content, &doc); err != nil {
+		return parentContainer, nil, fmt.Errorf("failed to parse YAML: %w", err)
 	}
 
-	pathStr := msg[start : start+end]
-	return yamlpatch.ParsePath(pathStr)
+	current := &doc
+	for i := range path {
+		if current == nil {
+			return parentAbsent, path[:i], nil
+		}
+		if kind := nodeKind(current); kind != parentContainer {
+			return kind, path[:i], nil
+		}
+		if i == len(path)-1 {
+			break
+		}
+		current = childNode(current, path[i])
+	}
+
+	return parentContainer, nil, nil
+}
+
+// nodeKind classifies a single node. Aliases are dereferenced because the patcher
+// does the same, so a change addressed through a YAML anchor stays writable.
+func nodeKind(node *yaml.Node) parentKind {
+	node = derefAlias(node)
+
+	switch node.Kind {
+	case yaml.DocumentNode:
+		// The patcher refuses a document that does not hold exactly one value.
+		if len(node.Content) != 1 {
+			return parentScalar
+		}
+		return parentContainer
+	case yaml.MappingNode, yaml.SequenceNode:
+		return parentContainer
+	case yaml.ScalarNode:
+		if node.Tag == "!!null" {
+			return parentNull
+		}
+		if dynvar.ContainsVariableReference(node.Value) {
+			return parentVariable
+		}
+		return parentScalar
+	default:
+		// Content that did not parse into a node at all (an empty file) is no more
+		// writable than a scalar; aliases are already dereferenced above.
+		return parentScalar
+	}
+}
+
+// childNode returns the node stored under key, or nil when the container has no
+// such child. It follows the lookup rules of the patcher's containers, including
+// reporting an empty document as an absent child rather than a null scalar.
+func childNode(node *yaml.Node, key string) *yaml.Node {
+	node = derefAlias(node)
+
+	switch node.Kind {
+	case yaml.DocumentNode:
+		if root := node.Content[0]; root.Kind != yaml.ScalarNode || root.Tag != "!!null" {
+			return root
+		}
+	case yaml.MappingNode:
+		// Content is [key1, val1, key2, val2, ...].
+		for i := 0; i+1 < len(node.Content); i += 2 {
+			if node.Content[i].Value == key {
+				return node.Content[i+1]
+			}
+		}
+	case yaml.SequenceNode:
+		// The "-" append marker and an out-of-range index both address an element
+		// that does not exist yet.
+		if idx, err := strconv.Atoi(key); err == nil && idx >= 0 && idx < len(node.Content) {
+			return node.Content[idx]
+		}
+	default:
+		// Only containers are walked into, so nothing else reaches this.
+	}
+
+	return nil
+}
+
+func derefAlias(node *yaml.Node) *yaml.Node {
+	for node != nil && node.Kind == yaml.AliasNode {
+		node = node.Alias
+	}
+	return node
 }
 
 // buildNestedMaps creates a nested map structure from targetPath to missingPath.

--- a/bundle/configsync/patch_test.go
+++ b/bundle/configsync/patch_test.go
@@ -1,6 +1,7 @@
 package configsync
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -54,8 +55,9 @@ resources:
 	require.NoError(t, err)
 	require.Empty(t, skipped)
 
-	fileChanges, err := ApplyChangesToYAML(ctx, b, fieldChanges)
+	fileChanges, unwritable, err := ApplyChangesToYAML(ctx, b, fieldChanges)
 	require.NoError(t, err)
+	require.Zero(t, unwritable)
 	require.Len(t, fileChanges, 1)
 
 	modified := fileChanges[0].ModifiedContent
@@ -415,6 +417,236 @@ resources:
         team: data-eng
 `)
 	assert.Equal(t, input, string(restoreBlankLines(preserveBlankLines([]byte(input)))))
+}
+
+// The classification decides whether a change is applied, has its parent
+// materialized first, or is left unapplied, so each node shape is asserted
+// directly rather than through the error the patcher happens to produce.
+func TestResolveParentNode(t *testing.T) {
+	content := nl(`
+resources:
+  jobs:
+    absent:
+      job_clusters:
+        - new_cluster:
+            num_workers: 1
+    null_placeholder:
+      job_clusters:
+        - new_cluster:
+            spark_env_vars:
+    reference:
+      job_clusters:
+        - new_cluster:
+            spark_env_vars: ${var.env_vars}
+    empty_mapping:
+      job_clusters:
+        - new_cluster:
+            spark_env_vars: {}
+    anchored:
+      job_clusters:
+        - new_cluster: &cluster
+            spark_env_vars:
+              FOO: bar
+    aliased:
+      job_clusters:
+        - new_cluster: *cluster
+    plain_scalar:
+      job_clusters:
+        - new_cluster:
+            spark_env_vars: disabled
+`)
+
+	tests := []struct {
+		name         string
+		job          string
+		wantKind     parentKind
+		wantAncestor string
+	}{
+		{
+			name:         "absent parent",
+			job:          "absent",
+			wantKind:     parentAbsent,
+			wantAncestor: "/resources/jobs/absent/job_clusters/0/new_cluster/spark_env_vars",
+		},
+		{
+			name:         "null placeholder",
+			job:          "null_placeholder",
+			wantKind:     parentNull,
+			wantAncestor: "/resources/jobs/null_placeholder/job_clusters/0/new_cluster/spark_env_vars",
+		},
+		{
+			name:         "variable reference",
+			job:          "reference",
+			wantKind:     parentVariable,
+			wantAncestor: "/resources/jobs/reference/job_clusters/0/new_cluster/spark_env_vars",
+		},
+		{
+			name:     "empty mapping",
+			job:      "empty_mapping",
+			wantKind: parentContainer,
+		},
+		{
+			name:     "mapping reached through an alias",
+			job:      "aliased",
+			wantKind: parentContainer,
+		},
+		{
+			name:         "plain scalar",
+			job:          "plain_scalar",
+			wantKind:     parentScalar,
+			wantAncestor: "/resources/jobs/plain_scalar/job_clusters/0/new_cluster/spark_env_vars",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path, err := yamlpatch.ParsePath("/resources/jobs/" + tt.job + "/job_clusters/0/new_cluster/spark_env_vars/MY_KEY")
+			require.NoError(t, err)
+
+			kind, ancestor, err := resolveParentNode([]byte(content), path)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantKind, kind)
+			assert.Equal(t, tt.wantAncestor, ancestor.String())
+		})
+	}
+}
+
+// A parent that is not a mapping is what config-remote-sync hits in production when
+// a cluster policy adds a spark_env_vars entry: the three "empty or not writable"
+// spellings must behave the way each of them means.
+func TestApplyChangesToYAML_ParentNotAMapping(t *testing.T) {
+	const wantAdded = `spark_env_vars:
+              MY_KEY: my-value`
+
+	tests := []struct {
+		name       string
+		envVars    string
+		want       string
+		unwritable int
+	}{
+		{
+			name:    "absent parent is created",
+			envVars: "",
+			want:    wantAdded,
+		},
+		{
+			name:    "empty mapping is filled in",
+			envVars: "            spark_env_vars: {}",
+			want:    wantAdded,
+		},
+		{
+			// "key:" parses as a null scalar rather than the empty mapping "key: {}"
+			// produces, so it needs materializing before anything can be added to it.
+			name:    "null placeholder is materialized",
+			envVars: "            spark_env_vars:",
+			want:    wantAdded,
+		},
+		{
+			// Overwriting the reference would resolve it to one target's value for
+			// every target that shares the file.
+			name:       "variable reference is left unapplied",
+			envVars:    "            spark_env_vars: ${var.env_vars}",
+			unwritable: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := logdiag.InitContext(t.Context())
+			tmpDir := t.TempDir()
+
+			content := fmt.Sprintf(nl(`
+resources:
+  jobs:
+    test_job:
+      job_clusters:
+        - job_cluster_key: shared
+          new_cluster:
+            num_workers: 1
+%s
+`), tt.envVars)
+
+			err := os.WriteFile(filepath.Join(tmpDir, "databricks.yml"), []byte(content), 0o644)
+			require.NoError(t, err)
+
+			b, err := bundle.Load(ctx, tmpDir)
+			require.NoError(t, err)
+			mutator.DefaultMutators(ctx, b)
+
+			changes := Changes{
+				"resources.jobs.test_job": ResourceChanges{
+					"job_clusters[0].new_cluster.spark_env_vars.MY_KEY": &ConfigChangeDesc{
+						Operation: OperationAdd,
+						Value:     "my-value",
+					},
+				},
+			}
+
+			fieldChanges, skipped, err := ResolveChanges(ctx, b, changes)
+			require.NoError(t, err)
+			require.Zero(t, skipped)
+
+			fileChanges, unwritable, err := ApplyChangesToYAML(ctx, b, fieldChanges)
+			require.NoError(t, err)
+			assert.Equal(t, tt.unwritable, unwritable)
+
+			if tt.want == "" {
+				assert.Empty(t, fileChanges)
+				return
+			}
+			require.Len(t, fileChanges, 1)
+			assert.Contains(t, fileChanges[0].ModifiedContent, tt.want)
+		})
+	}
+}
+
+// The patcher dereferences aliases, so a change addressed through one is written to
+// the anchored node instead of failing.
+func TestApplyChangesToYAML_AliasedParent(t *testing.T) {
+	ctx := logdiag.InitContext(t.Context())
+	tmpDir := t.TempDir()
+
+	content := nl(`
+resources:
+  jobs:
+    job_a:
+      job_clusters:
+        - job_cluster_key: shared
+          new_cluster: &cluster
+            num_workers: 1
+            spark_env_vars:
+              FOO: bar
+    job_b:
+      job_clusters:
+        - job_cluster_key: shared
+          new_cluster: *cluster
+`)
+
+	err := os.WriteFile(filepath.Join(tmpDir, "databricks.yml"), []byte(content), 0o644)
+	require.NoError(t, err)
+
+	b, err := bundle.Load(ctx, tmpDir)
+	require.NoError(t, err)
+	mutator.DefaultMutators(ctx, b)
+
+	changes := Changes{
+		"resources.jobs.job_b": ResourceChanges{
+			"job_clusters[0].new_cluster.spark_env_vars.MY_KEY": &ConfigChangeDesc{
+				Operation: OperationAdd,
+				Value:     "my-value",
+			},
+		},
+	}
+
+	fieldChanges, skipped, err := ResolveChanges(ctx, b, changes)
+	require.NoError(t, err)
+	require.Zero(t, skipped)
+
+	fileChanges, unwritable, err := ApplyChangesToYAML(ctx, b, fieldChanges)
+	require.NoError(t, err)
+	require.Zero(t, unwritable)
+	require.Len(t, fileChanges, 1)
+	assert.Contains(t, fileChanges[0].ModifiedContent, "MY_KEY: my-value")
 }
 
 func TestBuildNestedMaps(t *testing.T) {

--- a/bundle/configsync/telemetry.go
+++ b/bundle/configsync/telemetry.go
@@ -54,6 +54,10 @@ type Stats struct {
 	// could not be attributed to a single source location.
 	SkippedChangesCount int64
 
+	// Changes dropped during detection because the field is backend-managed and
+	// absent from config, so its remote value is never synced back.
+	BackendDefaultSkippedCount int64
+
 	Restore RestoreStats
 
 	// Identity of the resource state the run actually read. Without these, a
@@ -295,6 +299,8 @@ func (s *Stats) LogTelemetry(ctx context.Context) {
 			SelectedResourceIDs:    s.SelectedResourceIDs,
 			ErrorMessage:           s.ErrorMessage,
 			ErrorCategory:          s.ErrorCategory,
+
+			BackendDefaultSkippedCount: s.BackendDefaultSkippedCount,
 		},
 	})
 }

--- a/cmd/bundle/config_remote_sync.go
+++ b/cmd/bundle/config_remote_sync.go
@@ -96,11 +96,12 @@ Examples:
 					return fmt.Errorf("failed to detect changes: %w", err)
 				}
 
-				changes, err := configsync.ExtractChanges(ctx, b, plan, stateDesc.Engine)
+				changes, backendManaged, err := configsync.ExtractChanges(ctx, b, plan, stateDesc.Engine)
 				if err != nil {
 					stats.ErrorCategory = protos.BundleConfigRemoteSyncErrorCategoryDetectChangesFailed
 					return fmt.Errorf("failed to extract changes: %w", err)
 				}
+				stats.BackendDefaultSkippedCount = int64(backendManaged)
 				stats.CollectChangeStats(ctx, changes)
 
 				// Record the ids present in state and the ids requested: on failure
@@ -130,11 +131,12 @@ Examples:
 					log.Warnf(ctx, "variable restoration skipped: %v", err)
 				}
 
-				files, err := configsync.ApplyChangesToYAML(ctx, b, fieldChanges)
+				files, unwritable, err := configsync.ApplyChangesToYAML(ctx, b, fieldChanges)
 				if err != nil {
 					stats.ErrorCategory = protos.BundleConfigRemoteSyncErrorCategoryYamlApplyFailed
 					return fmt.Errorf("failed to generate YAML files: %w", err)
 				}
+				stats.SkippedChangesCount += int64(unwritable)
 				stats.FilesChangedCount = int64(len(files))
 
 				if save {

--- a/libs/telemetry/protos/bundle_config_remote_sync.go
+++ b/libs/telemetry/protos/bundle_config_remote_sync.go
@@ -56,11 +56,21 @@ type BundleConfigRemoteSyncEvent struct {
 
 	// Number of detected changes that were not written back because they could
 	// not be attributed to a single source location (e.g. a sequence element
-	// defined in both a top-level block and a target override). These are
+	// defined in both a top-level block and a target override) or because that
+	// location is not writable (a parent node holding a ${...} reference). These are
 	// counted in ChangesTotal: a nonzero value means the command reported
 	// changes it did not apply. Distinct from the "skip" operation filtered out
 	// during change detection, which never reaches ChangesTotal.
 	SkippedChangesCount int64 `json:"skipped_changes_count,omitempty"`
+
+	// Number of remote changes dropped during change detection because they land
+	// on a field the backend or a cluster policy manages (custom_tags,
+	// cluster_log_conf, spark_env_vars) and the field is absent from config.
+	// These never reach ChangesTotal. The count sizes how often a real remote
+	// value is deliberately not synced back, which is also how often the next
+	// deploy overwrites it with the local value. No omitempty: an explicit 0
+	// separates "nothing was dropped" from a CLI too old to report the field.
+	BackendDefaultSkippedCount int64 `json:"backend_default_skipped_count"`
 
 	// Variable-reference restoration counts for the two mechanisms that can
 	// write a current-target-scoped reference into a shared file (the source of


### PR DESCRIPTION
## Changes

Two related fixes for `bundle config-remote-sync`:

1. `spark_env_vars` is now treated as a backend-managed field (`backendDefault`) for `tasks[*].new_cluster`, `job_clusters[*].new_cluster` and `resources.clusters.*`, alongside the existing `custom_tags` / `cluster_log_conf` entries. Both the bare and the `.*` pattern are registered, because `matchParts` only matches equal segment counts and a policy pinning a single variable produces a `...spark_env_vars.<NAME>` path. Backend-managed skips are now surfaced in one warning (paths only, never values) and counted in a new `backend_default_skipped_count` telemetry field.

2. The missing-parent recovery in `patch.go` no longer detects its case by string-matching the yamlpatch package's error text. It inspects the target YAML node instead: an absent parent is created as before, an empty `key:` (null scalar) is materialized into a mapping, and a parent holding a `${...}` reference is skipped and counted rather than failing the command.

## Why

Production `config-remote-sync` runs fail with:

```
failed to apply change ... for a field resources.jobs.<name>.job_clusters[0].new_cluster.spark_env_vars.<KEY>:
op add ...: unexpected yaml node: scalar can not be a container
```

Two independent problems produce it.

`spark_env_vars` is filled in remotely from sources the config cannot see — a cluster policy can inject the map or pin one variable (`spark_env_vars.<name>: {type: fixed}`), and a pipeline's deployment spec is merged into the cluster spec on the backend. Those values routinely carry credentials (uv's `UV_INDEX_<name>_PASSWORD` convention), so syncing them back both leaks one environment's values into shared config and can write a secret into a file that gets committed. That is the same rationale already recorded for `custom_tags`. `backendDefault` (rather than `alwaysSkip`) keeps the legitimate case working: a field the user declares in config still syncs.

Separately, the recovery path that creates missing parents only engaged when the third-party error text contained "parent path ... does not exist". An empty `key:` and a `${...}` reference are the same class of problem — the parent is not a container — but the package words them differently, so recovery silently never ran and the whole command aborted, discarding every other change in the run. Branching on `err.Error()` is also against the repo guidelines. Note `key: {}` already worked, so the two spellings of "empty" behaving differently was a plain bug.

Known limitation: variable-owned parents are counted in the existing `skipped_changes_count` together with ambiguous-source-location skips, so the two causes are not distinguishable in telemetry yet. A per-reason breakdown is worth adding separately.

## Tests

Unit tests for the new patterns (whole-map and per-key, plus a field present in config still syncing), `isBackendManagedSkip`, and each parent-node case — absent, null scalar, `${var}` reference, `{}`, and an anchor/alias still resolving. Removing the null-materialization line makes the new test fail with the verbatim production error, so it pins the actual bug. The existing `policy_injected_cluster_fields` acceptance test was extended to inject `spark_env_vars` too; its golden shows the warning listing paths while the injected password never reaches YAML.

`go test ./bundle/configsync/... ./cmd/bundle/...` and the `bundle/(telemetry|config-remote-sync)` acceptance tests pass, goldens clean without `-update`.

This pull request and its description were written by Isaac.
