### PR TITLE
acc: fix DBR failures in dashboards syncroot tests

### DIFF
--- a/acceptance/bundle/resources/dashboards/simple_outside_bundle_root/output.txt
+++ b/acceptance/bundle/resources/dashboards/simple_outside_bundle_root/output.txt
@@ -1,9 +1,5 @@
 
->>> [CLI] bundle deploy
-Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/deploy-dashboard-outside-bundle-root-[UNIQUE_NAME]/default/files...
-Created dashboards.dashboard1
-Files: 9 uploaded, 0 deleted
-Resources: 1 created, 0 changed, 0 deleted, 0 unchanged
+>>> [CLI] bundle deploy -qq
 
 >>> retry [CLI] lakeview get [DASHBOARD_ID]
 {

--- a/acceptance/bundle/resources/dashboards/simple_outside_bundle_root/script
+++ b/acceptance/bundle/resources/dashboards/simple_outside_bundle_root/script
@@ -12,7 +12,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-trace $CLI bundle deploy
+trace $CLI bundle deploy -qq
 DASHBOARD_ID=$($CLI bundle summary --output json | jq -r '.resources.dashboards.dashboard1.id')
 
 # Capture the dashboard ID as a replacement.

--- a/acceptance/bundle/resources/dashboards/simple_syncroot/output.txt
+++ b/acceptance/bundle/resources/dashboards/simple_syncroot/output.txt
@@ -1,9 +1,5 @@
 
->>> [CLI] bundle deploy
-Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/deploy-dashboard-test-[UNIQUE_NAME]/default/files...
-Created dashboards.dashboard1
-Files: 9 uploaded, 0 deleted
-Resources: 1 created, 0 changed, 0 deleted, 0 unchanged
+>>> [CLI] bundle deploy -qq
 
 >>> retry [CLI] lakeview get [DASHBOARD_ID]
 {

--- a/acceptance/bundle/resources/dashboards/simple_syncroot/script
+++ b/acceptance/bundle/resources/dashboards/simple_syncroot/script
@@ -13,7 +13,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-trace $CLI bundle deploy
+trace $CLI bundle deploy -qq
 DASHBOARD_ID=$($CLI bundle summary --output json | jq -r '.resources.dashboards.dashboard1.id')
 
 # Capture the dashboard ID as a replacement.


### PR DESCRIPTION
## Why
`dashboards/simple_syncroot` and `dashboards/simple_outside_bundle_root` set
`sync.paths` to one level above the bundle root, so they sync the acceptance tmpdir's
parent. Its contents differ per environment, so `Files: N uploaded` is not stable: the
golden says 9, DBR reports 6. Both tests pass in the six plain integration envs and fail
in the two `dbr` jobs, since https://github.com/databricks/cli/pull/5720 added the line.

## Changes
Add `-qq` to the deploy. The count is noise here — these tests assert dashboard path
resolution via `lakeview get`.