### PR TITLE
Verify the FIPS module in released binaries

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -124,6 +124,31 @@ jobs:
             echo
           done
 
+      - name: Verify FIPS module in binaries
+        run: |
+          shopt -s nullglob
+          count=0
+          for bin in dist/*/databricks dist/*/databricks.exe; do
+            count=$((count + 1))
+            stamp=$(go version -m "$bin" | grep -E 'GOFIPS140|DefaultGODEBUG|-tags=fips140' || true)
+            echo "=== $bin"
+            echo "$stamp"
+            [[ "$stamp" == *"GOFIPS140=v1.0.0"* ]] || {
+              echo "ERROR: $bin is not built against the validated FIPS module" >&2
+              exit 1
+            }
+            [[ "$stamp" == *"DefaultGODEBUG=fips140=on"* ]] || {
+              echo "ERROR: $bin does not enable FIPS mode by default" >&2
+              exit 1
+            }
+          done
+          # Without this the loop is a no-op when the glob matches nothing.
+          if [ "$count" -eq 0 ]; then
+            echo "ERROR: no binaries found under dist/" >&2
+            exit 1
+          fi
+          echo "verified $count binaries"
+
       - name: Stage bundle JSON schema for upload
         run: cp bundle/schema/jsonschema.json dist/
 


### PR DESCRIPTION
## Changes

Adds a `Verify FIPS module in binaries` step to the release build. It reads each binary's build info and fails the release if any is missing the validated cryptographic module or does not default to FIPS mode.

Runs after signing, so it checks the artifacts that actually get published.

**Merge after #6262**, which is what sets `GOFIPS140` in `.goreleaser.yaml`.

## Why

#6262 makes releases FIPS builds, but nothing checks that the variable reached the artifacts. If it were dropped, the release would silently ship non-FIPS binaries, and the test suite could not catch it because tests build their own binary rather than inspecting `dist/`.

`go version -m` reads build info rather than the symbol table, so it works on stripped binaries and on the darwin/windows builds from the linux release runner.

## Tests

Ran the script against real linux, windows and darwin binaries built with `GOFIPS140=v1.0.0 -s -w -trimpath` — all verified from a linux host. Swapping in a non-FIPS build fails with the offending path named, and the empty-`dist/` guard fires so the loop cannot pass vacuously.

_This PR was written by Claude Code._
