### PR TITLE
libs/git: read git metadata from Repos API for DABs in the workspace

### DIFF
--- a/libs/git/info.go
+++ b/libs/git/info.go
@@ -28,11 +28,12 @@ type RepositoryInfo struct {
 	WorktreeRoot string
 }
 
+// gitInfo holds the fields we read from get-status's git_info. Only id and path
+// are reliable: branch/commit/url are absent for git-in-data-plane folders (and
+// deprecated on the workspace API), so those are read from the Repos API by id.
 type gitInfo struct {
-	Branch       string `json:"branch"`
-	HeadCommitID string `json:"head_commit_id"`
-	Path         string `json:"path"`
-	URL          string `json:"url"`
+	ID   int64  `json:"id"`
+	Path string `json:"path"`
 }
 
 type response struct {
@@ -100,17 +101,25 @@ func fetchRepositoryInfoAPI(ctx context.Context, path string, w *databricks.Work
 		return result, err
 	}
 
-	// Check if GitInfo is present and extract relevant fields
 	gi := response.GitInfo
-	if gi != nil {
-		fixedPath := ensureWorkspacePrefix(gi.Path)
-		result.OriginURL = gi.URL
-		result.LatestCommit = gi.HeadCommitID
-		result.CurrentBranch = gi.Branch
-		result.WorktreeRoot = fixedPath
-	} else {
+	if gi == nil {
 		log.Infof(ctx, "Failed to load git info from %s", apiEndpoint)
+		return result, nil
 	}
+	result.WorktreeRoot = ensureWorkspacePrefix(gi.Path)
+
+	// get-status omits branch/commit/url for git-in-data-plane folders; only
+	// classic Repos return them inline, and those fields are being deprecated on
+	// the workspace API. Read them from the Repos API by id, which is
+	// authoritative for both folder types.
+	repo, err := w.Repos.GetByRepoId(ctx, gi.ID)
+	if err != nil {
+		log.Warnf(ctx, "failed to load git metadata from Repos API for %s: %s", result.WorktreeRoot, err)
+		return result, nil
+	}
+	result.OriginURL = repo.Url
+	result.LatestCommit = repo.HeadCommitId
+	result.CurrentBranch = repo.Branch
 
 	return result, nil
 }

--- a/libs/git/info_test.go
+++ b/libs/git/info_test.go
@@ -1,0 +1,70 @@
+package git
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/databricks/databricks-sdk-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFetchRepositoryInfoAPIReadsMetadataFromReposAPI(t *testing.T) {
+	// git-in-data-plane folders: get-status returns only id+path in git_info, so
+	// branch/commit/url must be recovered from the Repos API by id.
+	var statusPath string
+	reposCalled := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/2.0/workspace/get-status":
+			statusPath = r.URL.Query().Get("path")
+			_, _ = w.Write([]byte(`{"object_type":"DIRECTORY","git_info":{"id":123,"path":"/Repos/alice/proj"}}`))
+		case "/api/2.0/repos/123":
+			reposCalled = true
+			_, _ = w.Write([]byte(`{"id":123,"branch":"main","head_commit_id":"abc123","url":"https://github.com/databricks/bundle-examples"}`))
+		default:
+			http.Error(w, "unexpected path: "+r.URL.Path, http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	w := databricks.Must(databricks.NewWorkspaceClient(&databricks.Config{Host: srv.URL, Token: "dummy"}))
+
+	info, err := fetchRepositoryInfoAPI(t.Context(), "/Workspace/Repos/alice/proj/sub/dir", w)
+	require.NoError(t, err)
+
+	assert.Equal(t, "/Workspace/Repos/alice/proj/sub/dir", statusPath)
+	assert.True(t, reposCalled, "Repos API should be called to load git metadata")
+	assert.Equal(t, "/Workspace/Repos/alice/proj", info.WorktreeRoot)
+	assert.Equal(t, "main", info.CurrentBranch)
+	assert.Equal(t, "abc123", info.LatestCommit)
+	assert.Equal(t, "https://github.com/databricks/bundle-examples", info.OriginURL)
+}
+
+func TestFetchRepositoryInfoAPINotAGitFolder(t *testing.T) {
+	// Outside any git folder get-status returns no git_info, so the result is
+	// empty and the Repos API is never called.
+	reposCalled := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/api/2.0/repos/") {
+			reposCalled = true
+		}
+		if r.URL.Path == "/api/2.0/workspace/get-status" {
+			_, _ = w.Write([]byte(`{"object_type":"DIRECTORY"}`))
+			return
+		}
+		// Ignore the SDK's host-metadata probe and anything else.
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	w := databricks.Must(databricks.NewWorkspaceClient(&databricks.Config{Host: srv.URL, Token: "dummy"}))
+
+	info, err := fetchRepositoryInfoAPI(t.Context(), "/Workspace/Users/alice/notebook", w)
+	require.NoError(t, err)
+
+	assert.False(t, reposCalled, "Repos API should not be called when the path is not a git folder")
+	assert.Equal(t, RepositoryInfo{}, info)
+}


### PR DESCRIPTION
## Problem

`databricks bundle` commands running **inside a Databricks workspace** (on DBR, bundle root under `/Workspace/`) read the bundle's git branch/commit/origin from:

```
GET /api/2.0/workspace/get-status?path=...&return_git_info=true
```

For **git-in-data-plane folders** (`object_type: DIRECTORY`), this response returns a `git_info` with only `id` and `path` — `branch`, `head_commit_id`, and `url` are missing. Only classic Repos (`object_type: REPO`) still return them inline. The Repos team has confirmed they do not store git attributes for git-in-DP folders and are **deprecating the `git_info` metadata fields on the workspace API**; the Repos API should be called for git metadata instead.

The data itself exists — `GET /api/2.0/repos/{id}` returns full `branch`/`head_commit_id`/`url` for the same folder.

Result: bundles in such folders get empty `bundle.git.branch` / `commit` / `origin_url`. This also fails the integration test `TestFetchRepositoryInfoAPI_FromRepo` across AWS + Azure test workspaces (it passes on dogfood, which still serves classic Repos inline).

## Fix

Use `get-status` only to resolve the input path to its enclosing git folder (`id` + root path — both still returned reliably, including for subdirectories), then read `branch`/`head_commit_id`/`url` from the Repos API by id (`Repos.GetByRepoId`), which is authoritative for both git-in-DP folders and classic Repos.

`WorktreeRoot` is still resolved from `get-status` and the best-effort contract is unchanged: if the Repos lookup fails, the worktree root is still returned and a warning is logged.

## Test

Added `libs/git/info_test.go` with a mock-server regression test: `get-status` returns only `id`+`path`, and the CLI recovers full git metadata via the Repos API. A second case covers a non-git-folder path (empty result, no Repos call). The existing integration test `TestFetchRepositoryInfoAPI_FromRepo` remains the live-workspace guard and should now pass on the affected test envs.

This pull request and its description were written by Isaac.
