### PR TITLE
maintainer-approval: count only each reviewer's latest review state

### DIFF
--- a/.github/workflows/maintainer-approval.js
+++ b/.github/workflows/maintainer-approval.js
@@ -37,6 +37,25 @@ async function isTeamMember(github, org, teamSlug, login, core) {
 }
 
 /**
+ * Reduce a PR's review history to each reviewer's current standing.
+ *
+ * The API returns every review ever submitted, in chronological order, so a
+ * reviewer who approves and later requests changes appears twice. Only their
+ * last review counts. COMMENTED reviews carry no approval state and leave the
+ * previous standing intact, matching how GitHub itself resolves the reviewers
+ * list.
+ */
+function latestReviews(reviews) {
+  const byReviewer = new Map();
+  for (const review of reviews) {
+    const login = review.user?.login;
+    if (!login || review.state === "COMMENTED") continue;
+    byReviewer.set(login.toLowerCase(), review);
+  }
+  return Array.from(byReviewer.values());
+}
+
+/**
  * Find which approver (if any) satisfies a group's ownership requirement.
  * Returns the login of the first matching approver, or null.
  */
@@ -461,11 +480,12 @@ module.exports = async ({ github, context, core }) => {
     name: STATUS_CONTEXT,
   };
 
-  const reviews = await github.paginate(github.rest.pulls.listReviews, {
+  const reviewHistory = await github.paginate(github.rest.pulls.listReviews, {
     owner: context.repo.owner,
     repo: context.repo.repo,
     pull_number: context.issue.number,
   });
+  const reviews = latestReviews(reviewHistory);
 
   // Maintainer approval -> success with simple comment
   const maintainerApproval = reviews.find(

--- a/.github/workflows/maintainer-approval.test.js
+++ b/.github/workflows/maintainer-approval.test.js
@@ -334,6 +334,88 @@ describe("maintainer-approval", () => {
     assert.equal(github._checkRuns.length, 0);
   });
 
+  it("owner who approved then requested changes no longer approves", async () => {
+    const github = makeGithub({
+      reviews: [
+        { state: "APPROVED", user: { login: "jefferycheng1" } },
+        { state: "CHANGES_REQUESTED", user: { login: "jefferycheng1" } },
+      ],
+      files: [{ filename: "cmd/pipelines/foo.go" }],
+    });
+    const core = makeCore();
+    const context = makeContext();
+
+    await runModule({ github, context, core });
+
+    assert.equal(github._checkRuns.length, 0);
+  });
+
+  it("maintainer who approved then requested changes no longer approves", async () => {
+    const github = makeGithub({
+      reviews: [
+        { state: "APPROVED", user: { login: "maintainer1" } },
+        { state: "CHANGES_REQUESTED", user: { login: "maintainer1" } },
+      ],
+      files: [{ filename: "cmd/pipelines/foo.go" }],
+    });
+    const core = makeCore();
+    const context = makeContext();
+
+    await runModule({ github, context, core });
+
+    assert.equal(github._checkRuns.length, 0);
+  });
+
+  it("owner who requested changes then approved counts as approval", async () => {
+    const github = makeGithub({
+      reviews: [
+        { state: "CHANGES_REQUESTED", user: { login: "jefferycheng1" } },
+        { state: "APPROVED", user: { login: "jefferycheng1" } },
+      ],
+      files: [{ filename: "cmd/pipelines/foo.go" }],
+    });
+    const core = makeCore();
+    const context = makeContext();
+
+    await runModule({ github, context, core });
+
+    assert.equal(github._checkRuns.length, 1);
+    assert.equal(github._checkRuns[0].conclusion, "success");
+  });
+
+  it("COMMENTED review after an approval leaves the approval standing", async () => {
+    const github = makeGithub({
+      reviews: [
+        { state: "APPROVED", user: { login: "jefferycheng1" } },
+        { state: "COMMENTED", user: { login: "jefferycheng1" } },
+      ],
+      files: [{ filename: "cmd/pipelines/foo.go" }],
+    });
+    const core = makeCore();
+    const context = makeContext();
+
+    await runModule({ github, context, core });
+
+    assert.equal(github._checkRuns.length, 1);
+    assert.equal(github._checkRuns[0].conclusion, "success");
+  });
+
+  it("dismissed approval no longer counts", async () => {
+    const github = makeGithub({
+      reviews: [
+        { state: "APPROVED", user: { login: "jefferycheng1" } },
+        { state: "DISMISSED", user: { login: "jefferycheng1" } },
+      ],
+      files: [{ filename: "cmd/pipelines/foo.go" }],
+    });
+    const core = makeCore();
+    const context = makeContext();
+
+    await runModule({ github, context, core });
+
+    assert.equal(github._checkRuns.length, 0);
+  });
+
   it("self-approval by PR author is excluded", async () => {
     const github = makeGithub({
       reviews: [


### PR DESCRIPTION
## Changes

`maintainer-approval` treated approval as "has this reviewer ever left an
`APPROVED` review" rather than "is this reviewer's current review state
`APPROVED`". An approval that the same reviewer later replaced with
`CHANGES_REQUESTED`, or that was dismissed, kept satisfying the check.

This collapses the review history to each reviewer's most recent review
before the three places that evaluate it — maintainer approval,
maintainer-authored PR approval, and the per-path `approverLogins` list.
All three read the same `reviews` binding, so the fix is one helper plus
one reassignment.

`COMMENTED` reviews are skipped rather than counted as the latest state.
They carry no approval state, so a reviewer who approves and then leaves a
plain comment keeps their approval — the same way GitHub resolves its own
reviewers list. Treating them as the latest review would silently revoke
approvals instead.

Fixes #5322.

## Why

The gate is supposed to reflect current approval state. Today a reviewer
who approves, spots a problem, and switches to `CHANGES_REQUESTED` cannot
actually withdraw the approval — the workflow still finds the historical
`APPROVED` record and reports success. Dismissing the review does not help
either, for the same reason.

The behaviour dates back to the original workflow in #4912 and was carried
over when per-path approval was added in #4918. #4918 added a test that
`CHANGES_REQUESTED` does not count as approval, but it covers only a PR
with a single `CHANGES_REQUESTED` review, which passes either way. The
approve-then-request-changes sequence was never covered.

## Tests

`node --test .github/scripts/owners.test.js .github/workflows/maintainer-approval.test.js`

Five cases added to `maintainer-approval.test.js`. Three fail against the
current code and pass with this change:

- owner approves, then requests changes -> no longer approved
- maintainer approves, then requests changes -> no longer approved
- approval later dismissed -> no longer approved

Two guard the opposite direction and pass both before and after, so the
fix does not over-correct:

- owner requests changes, then approves -> approved
- owner approves, then leaves a `COMMENTED` review -> still approved

No changelog fragment: this changes repository CI tooling, not CLI
behaviour.
