### PR TITLE
ssh setup: use the shared cluster picker so duplicate cluster names work

### DIFF
--- a/.nextchanges/cli/ssh-setup-duplicate-cluster-names.md
+++ b/.nextchanges/cli/ssh-setup-duplicate-cluster-names.md
@@ -1,0 +1,1 @@
+`databricks ssh setup` no longer fails to list clusters when a workspace has several clusters sharing the same name. The picker now shows the cluster ID alongside the name so duplicates can be told apart.

--- a/experimental/ssh/internal/setup/setup.go
+++ b/experimental/ssh/internal/setup/setup.go
@@ -10,8 +10,8 @@ import (
 	"github.com/databricks/cli/experimental/ssh/internal/keys"
 	"github.com/databricks/cli/experimental/ssh/internal/sshconfig"
 	"github.com/databricks/cli/libs/cmdio"
+	"github.com/databricks/cli/libs/databrickscfg/cfgpickers"
 	"github.com/databricks/databricks-sdk-go"
-	"github.com/databricks/databricks-sdk-go/service/compute"
 )
 
 type SetupOptions struct {
@@ -47,20 +47,13 @@ func generateHostConfig(ctx context.Context, opts SetupOptions, proxyCommand str
 var clusterSelectionPrompt = defaultClusterSelectionPrompt
 
 func defaultClusterSelectionPrompt(ctx context.Context, client *databricks.WorkspaceClient) (string, error) {
-	sp := cmdio.NewSpinner(ctx)
-	sp.Update("Loading clusters.")
-	clusters, err := client.Clusters.ClusterDetailsClusterNameToClusterIdMap(ctx, compute.ListClustersRequest{
-		FilterBy: &compute.ListClustersFilterBy{
-			ClusterSources: []compute.ClusterSource{compute.ClusterSourceApi, compute.ClusterSourceUi},
-		},
-	})
-	sp.Close()
+	// AskForCluster keys the picker by list position instead of by display name,
+	// so workspaces that have several clusters sharing a name still work. It
+	// lists with the same API/UI cluster-source filter this prompt needs, and
+	// shows the cluster ID alongside the name to disambiguate duplicates.
+	id, err := cfgpickers.AskForCluster(ctx, client)
 	if err != nil {
-		return "", fmt.Errorf("failed to load names for Clusters drop-down. Please manually specify cluster argument. Original error: %w", err)
-	}
-	id, err := cmdio.Select(ctx, clusters, "The cluster to connect to")
-	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to select a cluster. Please manually specify cluster argument. Original error: %w", err)
 	}
 	return id, nil
 }

--- a/experimental/ssh/internal/setup/setup_test.go
+++ b/experimental/ssh/internal/setup/setup_test.go
@@ -12,7 +12,9 @@ import (
 	"github.com/databricks/cli/libs/cmdio"
 	"github.com/databricks/databricks-sdk-go"
 	"github.com/databricks/databricks-sdk-go/experimental/mocks"
+	"github.com/databricks/databricks-sdk-go/qa"
 	"github.com/databricks/databricks-sdk-go/service/compute"
+	"github.com/databricks/databricks-sdk-go/service/iam"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -291,6 +293,81 @@ func TestSetup_PromptsForClusterWhenNotProvided(t *testing.T) {
 	hostConfigStr := string(hostContent)
 	assert.Contains(t, hostConfigStr, "--cluster=picked-cluster")
 	assert.NotContains(t, hostConfigStr, "--cluster= ")
+}
+
+// clusterListFixtures returns the API responses the cluster picker needs to
+// list the given clusters.
+func clusterListFixtures(clusters []compute.ClusterDetails) qa.HTTPFixtures {
+	return qa.HTTPFixtures{
+		{
+			Method:   "GET",
+			Resource: "/api/2.1/clusters/list?filter_by.cluster_sources=API&filter_by.cluster_sources=UI&page_size=100",
+			Response: compute.ListClustersResponse{Clusters: clusters},
+		},
+		{
+			Method:   "GET",
+			Resource: "/api/2.0/preview/scim/v2/Me?",
+			Response: iam.User{UserName: "someone@example.com"},
+		},
+		{
+			Method:   "GET",
+			Resource: "/api/2.1/clusters/spark-versions",
+			Response: compute.GetSparkVersionsResponse{
+				Versions: []compute.SparkVersion{{Key: "14.5.x-scala2.12", Name: "14.5 (Scala 2.12)"}},
+			},
+		},
+	}
+}
+
+func TestDefaultClusterSelectionPrompt_DuplicateClusterNames(t *testing.T) {
+	cfg, server := clusterListFixtures([]compute.ClusterDetails{
+		{
+			ClusterId:     "cluster-a",
+			ClusterName:   "shared name",
+			ClusterSource: compute.ClusterSourceUi,
+			SparkVersion:  "14.5.x-scala2.12",
+			State:         compute.StateRunning,
+		},
+		{
+			ClusterId:     "cluster-b",
+			ClusterName:   "shared name",
+			ClusterSource: compute.ClusterSourceApi,
+			SparkVersion:  "14.5.x-scala2.12",
+			State:         compute.StateRunning,
+		},
+	}).Config(t)
+	defer server.Close()
+	w := databricks.Must(databricks.NewWorkspaceClient((*databricks.Config)(cfg)))
+
+	ctx := cmdio.MockDiscard(t.Context())
+	_, err := defaultClusterSelectionPrompt(ctx, w)
+
+	// Both clusters share a display name. Listing must still succeed and reach
+	// the picker, which cannot run without a TTY -- the point is that it fails
+	// there rather than while loading the cluster list.
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Choose compatible cluster")
+	assert.NotContains(t, err.Error(), "duplicate")
+}
+
+func TestDefaultClusterSelectionPrompt_SingleCluster(t *testing.T) {
+	cfg, server := clusterListFixtures([]compute.ClusterDetails{
+		{
+			ClusterId:     "only-cluster",
+			ClusterName:   "the only one",
+			ClusterSource: compute.ClusterSourceUi,
+			SparkVersion:  "14.5.x-scala2.12",
+			State:         compute.StateRunning,
+		},
+	}).Config(t)
+	defer server.Close()
+	w := databricks.Must(databricks.NewWorkspaceClient((*databricks.Config)(cfg)))
+
+	ctx := cmdio.MockDiscard(t.Context())
+	id, err := defaultClusterSelectionPrompt(ctx, w)
+
+	require.NoError(t, err)
+	assert.Equal(t, "only-cluster", id)
 }
 
 func TestSetup_SuccessfulWithExistingConfigFile(t *testing.T) {


### PR DESCRIPTION
## Changes

The `ssh setup` interactive cluster picker called
`ClusterDetailsClusterNameToClusterIdMap`, which builds a `map[string]string`
keyed by cluster display name. Databricks allows several clusters to share a
name, so on those workspaces listing failed outright:

```
Error: failed to load names for Clusters drop-down. Please manually specify
cluster argument. Original error: duplicate .ClusterName: <name>
```

This switches the prompt to `cfgpickers.AskForCluster`, the picker
`auth login --configure-cluster` already uses. It fits without modification:

- lists via `ListAll` with the same `ClusterSourceApi`/`ClusterSourceUi`
  filter this prompt was already using,
- keys the picker by list position rather than by display name, so duplicate
  names are not a problem,
- already renders the cluster ID next to the name, so duplicates are
  distinguishable in the list.

Passing no filters keeps the current selection semantics — every API/UI
cluster stays eligible.

Two behaviour changes worth calling out explicitly:

- When the workspace has exactly one cluster, `AskForCluster` returns it
  without prompting. Previously `ssh setup` always prompted.
- The list now also shows state, access mode and runtime, and is searchable.
  Rendering those costs one `CurrentUser.Me` and one `SparkVersions` call.

The prompt label changes from "The cluster to connect to" to
`AskForCluster`'s "Choose compatible cluster".

## Why

Users on workspaces with duplicate cluster names cannot use `ssh setup`
interactively at all — the command fails before showing anything, and the
only way forward is to find the cluster ID by hand and pass `--cluster`.

Reusing the existing picker rather than adding a second one keeps the two
interactive cluster selections in the CLI behaving the same way.

Part of #974. That issue was originally reported against
`auth login --configure-cluster`, which was fixed by moving to
`AskForCluster`; `ssh setup` was left on the name-keyed SDK helper. Note it
does not close the issue completely: the generated commands in
`cmd/workspace/clusters` still call the same helper in 13 places, but those
are produced by the SDK generator and cannot be fixed in this repository.

## Tests

`go test ./experimental/ssh/... ./libs/databrickscfg/...` — all green.

Two tests added to `experimental/ssh/internal/setup/setup_test.go`, driving
`defaultClusterSelectionPrompt` against `qa.HTTPFixtures`:

- **duplicate names**: two clusters sharing a display name. Listing must
  succeed and reach the picker, which cannot run without a TTY, so the test
  asserts the failure comes from the picker and not from loading. Against
  `main` this fails with `duplicate .ClusterName: shared name`.
- **single cluster**: asserts the ID is returned directly.
