### PR TITLE
Reject dangling ${resources.*} refs at validate time

### DIFF
--- a/.nextchanges/bundles/dangling-resource-refs.md
+++ b/.nextchanges/bundles/dangling-resource-refs.md
@@ -1,0 +1,1 @@
+Reject ${resources.*} references to resources that are not defined in the bundle.

--- a/acceptance/bundle/validate/dangling_resource_refs/databricks.yml
+++ b/acceptance/bundle/validate/dangling_resource_refs/databricks.yml
@@ -1,0 +1,10 @@
+bundle:
+  name: dangling-resource-refs
+
+resources:
+  jobs:
+    my_job:
+      name: my_job
+      permissions:
+        - level: CAN_VIEW
+          group_name: ${resources.jobs.does_not_exist.id}

--- a/acceptance/bundle/validate/dangling_resource_refs/out.test.toml
+++ b/acceptance/bundle/validate/dangling_resource_refs/out.test.toml
@@ -1,0 +1,2 @@
+Cloud = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/dangling_resource_refs/output.txt
+++ b/acceptance/bundle/validate/dangling_resource_refs/output.txt
@@ -1,0 +1,17 @@
+
+>>> [CLI] bundle validate --strict
+Error: reference does not exist: ${resources.jobs.does_not_exist.id}
+  at resources.jobs.my_job.permissions[0].group_name
+
+Name: dangling-resource-refs
+Target: default
+Workspace:
+  User: [USERNAME]
+  Path: /Workspace/Users/[USERNAME]/.bundle/dangling-resource-refs/default
+
+Found 1 error
+
+>>> [CLI] bundle deploy
+Error: reference does not exist: ${resources.jobs.does_not_exist.id}
+  at resources.jobs.my_job.permissions[0].group_name
+

--- a/acceptance/bundle/validate/dangling_resource_refs/script
+++ b/acceptance/bundle/validate/dangling_resource_refs/script
@@ -1,0 +1,4 @@
+# Without the fix, validate --strict succeeds and deploy fails with
+# "invalid dependency" (direct) or an unresolved terraform reference.
+musterr trace $CLI bundle validate --strict
+musterr trace $CLI bundle deploy

--- a/bundle/config/validate/dangling_resource_references.go
+++ b/bundle/config/validate/dangling_resource_references.go
@@ -1,0 +1,80 @@
+package validate
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/databricks/cli/bundle"
+	"github.com/databricks/cli/libs/diag"
+	"github.com/databricks/cli/libs/dyn"
+	"github.com/databricks/cli/libs/dyn/dynvar"
+)
+
+type danglingResourceReferences struct{}
+
+// DanglingResourceReferences rejects ${resources.*} references whose target
+// resource is not defined in the bundle. Deploy fails later with an invalid
+// dependency (direct) or an unresolved reference (terraform); catch it here.
+func DanglingResourceReferences() bundle.Mutator {
+	return &danglingResourceReferences{}
+}
+
+func (m *danglingResourceReferences) Name() string {
+	return "validate:dangling_resource_references"
+}
+
+func (m *danglingResourceReferences) Apply(_ context.Context, b *bundle.Bundle) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	_ = dyn.WalkReadOnly(b.Config.Value(), func(path dyn.Path, v dyn.Value) error {
+		ref, ok := dynvar.NewRef(v)
+		if !ok {
+			return nil
+		}
+		for _, r := range ref.References() {
+			if !strings.HasPrefix(r, "resources.") {
+				continue
+			}
+			if d := checkDanglingResourceReference(b, r, path, v.Locations()); d != nil {
+				diags = append(diags, *d)
+			}
+		}
+		return nil
+	})
+
+	return diags
+}
+
+// checkDanglingResourceReference checks a reference like
+// "resources.jobs.missing.id" and returns a diagnostic when the resource
+// (resources.jobs.missing) is not defined.
+func checkDanglingResourceReference(b *bundle.Bundle, ref string, path dyn.Path, locs []dyn.Location) *diag.Diagnostic {
+	p, err := dyn.NewPathFromString(ref)
+	// resources.<group>.<name>[.<field>...]
+	if err != nil || len(p) < 3 || p[0].Key() != "resources" {
+		return nil
+	}
+
+	// Identity is resources.<group>.<name>; trailing fields (.id, .permissions, …)
+	// are resolved at deploy time and are not required to exist in config.
+	resourceKey := p[:3]
+	v, err := dyn.GetByPath(b.Config.Value(), resourceKey)
+	if err == nil && v.Kind() != dyn.KindInvalid && v.Kind() != dyn.KindNil {
+		return nil
+	}
+
+	d := &diag.Diagnostic{
+		Severity: diag.Error,
+		Summary:  fmt.Sprintf("reference does not exist: ${%s}", ref),
+		Paths:    []dyn.Path{path},
+	}
+	// ApplyBundlePermissions rewrites permission entries without locations; skip
+	// empty ones so we don't print "in :0:0".
+	for _, loc := range locs {
+		if loc.File != "" {
+			d.Locations = append(d.Locations, loc)
+		}
+	}
+	return d
+}

--- a/bundle/config/validate/dangling_resource_references_test.go
+++ b/bundle/config/validate/dangling_resource_references_test.go
@@ -1,0 +1,73 @@
+package validate
+
+import (
+	"testing"
+
+	"github.com/databricks/cli/bundle"
+	"github.com/databricks/cli/bundle/config"
+	"github.com/databricks/cli/bundle/config/resources"
+	"github.com/databricks/cli/bundle/internal/bundletest"
+	"github.com/databricks/cli/libs/diag"
+	"github.com/databricks/cli/libs/dyn"
+	"github.com/databricks/databricks-sdk-go/service/jobs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDanglingResourceReferences_MissingResource(t *testing.T) {
+	b := &bundle.Bundle{
+		Config: config.Root{
+			Resources: config.Resources{
+				Jobs: map[string]*resources.Job{
+					"my_job": {JobSettings: jobs.JobSettings{Name: "my_job"}},
+				},
+			},
+		},
+	}
+	bundletest.Mutate(t, b, func(v dyn.Value) (dyn.Value, error) {
+		return dyn.Set(v, "resources.jobs.my_job.name", dyn.V("${resources.jobs.does_not_exist.id}"))
+	})
+
+	diags := DanglingResourceReferences().Apply(t.Context(), b)
+	require.Len(t, diags, 1)
+	assert.Equal(t, diag.Error, diags[0].Severity)
+	assert.Equal(t, "reference does not exist: ${resources.jobs.does_not_exist.id}", diags[0].Summary)
+}
+
+func TestDanglingResourceReferences_ExistingResource(t *testing.T) {
+	b := &bundle.Bundle{
+		Config: config.Root{
+			Resources: config.Resources{
+				Jobs: map[string]*resources.Job{
+					"src": {JobSettings: jobs.JobSettings{Name: "src"}},
+					"dst": {JobSettings: jobs.JobSettings{Name: "dst"}},
+				},
+			},
+		},
+	}
+	bundletest.Mutate(t, b, func(v dyn.Value) (dyn.Value, error) {
+		return dyn.Set(v, "resources.jobs.dst.name", dyn.V("${resources.jobs.src.id}"))
+	})
+
+	diags := DanglingResourceReferences().Apply(t.Context(), b)
+	assert.Empty(t, diags)
+}
+
+func TestDanglingResourceReferences_UnknownType(t *testing.T) {
+	b := &bundle.Bundle{
+		Config: config.Root{
+			Resources: config.Resources{
+				Jobs: map[string]*resources.Job{
+					"my_job": {JobSettings: jobs.JobSettings{Name: "my_job"}},
+				},
+			},
+		},
+	}
+	bundletest.Mutate(t, b, func(v dyn.Value) (dyn.Value, error) {
+		return dyn.Set(v, "resources.jobs.my_job.name", dyn.V("${resources.unknown.foo.id}"))
+	})
+
+	diags := DanglingResourceReferences().Apply(t.Context(), b)
+	require.Len(t, diags, 1)
+	assert.Contains(t, diags[0].Summary, "${resources.unknown.foo.id}")
+}

--- a/bundle/phases/initialize.go
+++ b/bundle/phases/initialize.go
@@ -189,6 +189,10 @@ func Initialize(ctx context.Context, b *bundle.Bundle) {
 		validate.ValidateJobRunIdempotencyToken(),
 
 		// Reads (dynamic): * (strings) (searches for ${resources.*} references)
+		// Errors when a cross-resource reference targets a resource that is not defined.
+		validate.DanglingResourceReferences(),
+
+		// Reads (dynamic): * (strings) (searches for ${resources.*} references)
 		// Warns (TF engine) or errors (direct engine) when a cross-resource reference
 		// points to a Terraform-only field with no DABs equivalent.
 		validate.TFOnlyReferences(),


### PR DESCRIPTION
## Changes
Add `validate.DanglingResourceReferences` in initialize so `${resources.*}` refs to undefined resources fail at validate (and deploy) instead of later with an invalid dependency.

## Why
`bundle validate --strict` accepted configs like `group_name: ${resources.jobs.does_not_exist.id}`. Direct deploy then failed with `invalid dependency … no such node`. Catch the misconfiguration at validate.

_Found by fuzz testing._

## Tests
- Reproduced on dogfood against `origin/main`: validate OK, direct deploy → invalid dependency
- Confirmed fix on dogfood: validate --strict / deploy both exit 1 with `reference does not exist`
- Unit tests + acceptance `bundle/validate/dangling_resource_refs` (terraform & direct)