### PR TITLE
acc: document that all tests run locally, Cloud=true only adds a cloud run

### DIFF
--- a/.agents/rules/testing.md
+++ b/.agents/rules/testing.md
@@ -11,8 +11,8 @@ paths:
 ## Test Types
 
 - **Unit tests**: Standard Go tests alongside source files
-- **Integration tests**: `integration/` directory, requires live Databricks workspace
-- **Acceptance tests**: `acceptance/` directory, uses mock HTTP server
+- **Acceptance tests**: `acceptance/` directory. Every test runs locally against the mock HTTP server; a subset *additionally* runs against a real workspace (`Cloud = true`). This is where new end-to-end coverage belongs.
+- **Integration tests**: `integration/` directory, requires a live Databricks workspace. **Deprecated — do not add tests here.** Write an acceptance test with `Cloud = true` instead, so the same test runs both locally and against a real workspace.
 
 ## Choosing a test level
 
@@ -21,6 +21,8 @@ paths:
 **Unit tests are still the right tool** for pure functions, utility code, parsing/formatting helpers, and anything you can meaningfully test without mocking the whole world. Don't force a unit into an acceptance test just because the code lives under `cmd/`, and don't add a mutator unit test that only duplicates what an acceptance test already covers.
 
 When in doubt: would the test fail in a useful way if a mutator earlier in the pipeline changed? If yes, the test wants to be an acceptance test.
+
+**RULE: Do not add new tests under `integration/`. That tree is deprecated.** When coverage needs a real workspace, write an acceptance test and set `Cloud = true` in its `test.toml`. You get the local run against the fake server *and* the real-workspace run from one test, instead of a workspace-only test that never runs in the local suite.
 
 ## Unit tests
 
@@ -53,6 +55,12 @@ func TestApplySomeChangeFixesThings(t *testing.T) {
 When writing tests, don't include an explanation in each test case in your responses. Only the tests are needed.
 
 ## Acceptance Tests
+
+**RULE: `Cloud`/`CloudSlow` add a cloud run; they never remove the local run.** Every test under `acceptance/` runs locally against the fake server in `libs/testserver`. `Cloud = true` in a `test.toml` or `out.test.toml` means "this test *also* runs against a real workspace when `CLOUD_ENV` is set" — it never means "this test does not run locally". Never tell the user a test doesn't run locally because it is `Cloud = true`.
+
+The whole `Cloud*` family lives inside an `if isRunningOnCloud` branch in `getSkipReason` (`acceptance/acceptance_test.go`), so it can only ever subtract from the cloud run: `CloudSlow` drops it under `-short`, and `CloudEnvs` / `RequiresUnityCatalog` / `RequiresCluster` / `RequiresWarehouse` narrow it to environments that have the prerequisite. To find what skips a test *locally*, look at a different set: `GOOS`, `RunsOnDbr`, and `DATABRICKS_TEST_SKIPLOCAL` (which cloud CI runs set precisely because those tests already ran locally).
+
+`Cloud` is inherited, so a parent `test.toml` can opt a whole subtree in; a leaf `test.toml` with no `Cloud` line is not evidence of anything. Read the generated `out.test.toml` for a test's effective settings.
 
 **RULE: Never edit generated acceptance output files directly.** Files named `output.txt`, `out.test.toml`, `out.requests.txt`, or anything starting with `out` are regenerated. Use the `-update` flag to regenerate them.
 
@@ -117,14 +125,14 @@ Ignore = ["databricks.yml"]   # parsed as EnvMatrix.Ignore, not top-level Ignore
 
 ### Reference
 
-- Tests live in `acceptance/` with a nested directory structure.
+- Tests live in `acceptance/` with a nested directory structure. All of them run locally; those with `Cloud`/`CloudSlow` set also run against a real workspace.
 - Each test directory contains `databricks.yml`, `script`, and `output.txt`.
 - Source files: `test.toml`, `script`, `script.prepare`, `databricks.yml`, etc.
 - Tests are configured via `test.toml`. Config schema and explanation is in `acceptance/internal/config.go`. Certain options are also dumped to `out.test.toml` so that inherited values are visible on PRs.
 - Run a single test: `go test ./acceptance -run TestAccept/bundle/<path>/<to>/<folder>`
 - Run a specific variant by appending `EnvMatrix` values to the test name: `go test ./acceptance -run 'TestAccept/.../DATABRICKS_BUNDLE_ENGINE=direct'`. When there are multiple `EnvMatrix` variables, they appear in alphabetical order.
 - Useful flags: `-v` for verbose output, `-tail` to follow test output (requires `-v`), `-logrequests` to log all HTTP requests/responses (requires `-v`).
-- Run tests on cloud: `deco env run -i -n aws-prod-ucws -- <go test command>` (requires `deco` tool and access to test env).
+- Run tests on cloud: `deco env run -i -n aws-prod-ucws -- <go test command>` (requires `deco` tool and access to test env). This is an *additional* pass over the same test directories, restricted to those with `Cloud`/`CloudSlow` set; it does not replace the local run.
 - `script.prepare` files from parent directories are concatenated into the test script. Use them for shared bash helpers.
 
 ### Built-in shell helpers

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,10 +21,12 @@ This is the Databricks CLI, a command-line interface for interacting with Databr
 ### Building and Testing
 
 - `./task build` - Build the CLI binary
-- `./task test` - Run unit and acceptance tests for all packages
+- `./task test` - Run unit and acceptance tests for all packages. This runs the *entire* acceptance suite locally against the fake server in `libs/testserver`.
 - `go test ./acceptance -run TestAccept/bundle/<path>/<to>/<folder> -tail -test.v` - run a single acceptance test
-- `./task integration` - Run integration tests (requires environment variables)
+- `./task integration` - Run integration tests (requires environment variables). The `integration/` tree is deprecated; new coverage that needs a real workspace goes into an acceptance test with `Cloud = true`.
 - `./task cover` - Generate test coverage reports
+
+Every acceptance test runs locally. `Cloud = true` in a `test.toml` means the test *also* runs against a real workspace when `CLOUD_ENV` is set — never that it skips the local run. See `.agents/rules/testing.md`.
 
 ### Code Quality
 

--- a/acceptance/README.md
+++ b/acceptance/README.md
@@ -1,6 +1,21 @@
 Acceptance tests are blackbox tests that are run against compiled binary.
 
-Currently these tests are run against "fake" HTTP server pretending to be Databricks API. However, they will be extended to run against real environment as regular integration tests.
+## Where tests run
+
+**Every test runs locally**, against a "fake" HTTP server pretending to be Databricks API (`libs/testserver`). This is what `./task test` does and it covers the whole `acceptance` tree.
+
+A test can *additionally* opt into running against a real workspace by setting `Cloud = true` in its `test.toml`. That is an extra run, not a different one: `Cloud = true` never means "this test does not run locally". Related settings:
+
+- `CloudSlow = true` implies `Cloud = true`, but the cloud run is skipped when `-short` is passed.
+- `CloudEnvs` and `RequiresUnityCatalog` / `RequiresCluster` / `RequiresWarehouse` only narrow the cloud run further. They are ignored locally.
+- `Cloud` is inherited from parent `test.toml` files, so a whole subtree can be opted in at once. The root `acceptance/test.toml` defaults it to `Cloud = false`, i.e. local only.
+- Each test's effective settings are visible in its generated `out.test.toml`.
+
+The cloud run is keyed off `CLOUD_ENV`; see `getSkipReason` in `acceptance/acceptance_test.go` for the exact gating. What skips a test *locally* is a different set of settings entirely: `GOOS`, `RunsOnDbr`, and `DATABRICKS_TEST_SKIPLOCAL` (used by cloud CI runs to skip tests that already ran locally).
+
+To run tests against a real workspace: `deco env run -i -n aws-prod-ucws -- <go test command>` (requires the `deco` tool and access to a test env).
+
+## Authoring
 
 To author a test,
  - Add a new directory under `acceptance`. Any level of nesting is supported.

--- a/acceptance/internal/config.go
+++ b/acceptance/internal/config.go
@@ -37,25 +37,32 @@ type TestConfig struct {
 	// If absent, default to true.
 	GOOS map[string]bool
 
+	// Every test runs locally against the fake server in libs/testserver. None of the
+	// six cloud fields that follow can prevent that: they are only consulted when
+	// CLOUD_ENV is set (an additional run against a real workspace) and can only
+	// subtract from that run. What skips a test locally is a different set entirely:
+	// GOOS, RunsOnDbr, DATABRICKS_TEST_SKIPLOCAL.
+
 	// Which Clouds the test is enabled on. Allowed values: "aws", "azure", "gcp".
 	// If absent, default to true.
 	// Only checked if CLOUD_ENV is not empty.
 	CloudEnvs map[string]bool
 
-	// If true, run this test when running with cloud env configured
+	// If true, ALSO run this test against a real workspace when cloud env is configured.
+	// Does not affect the local run, which happens either way.
 	Cloud *bool
 
-	// If true, run this test when running with cloud env configured and -short is not passed
-	// This also sets -tail when -v is passed.
+	// Like Cloud, but the cloud run is skipped when -short is passed.
+	// This also sets -tail when -v is passed. Implies Cloud.
 	CloudSlow *bool
 
-	// If true and Cloud=true, run this test only if unity catalog is available in the cloud environment
+	// If true and Cloud=true, run the cloud part of this test only if unity catalog is available in the cloud environment
 	RequiresUnityCatalog *bool
 
-	// If true and Cloud=true, run this test only if a default test cluster is available in the cloud environment
+	// If true and Cloud=true, run the cloud part of this test only if a default test cluster is available in the cloud environment
 	RequiresCluster *bool
 
-	// If true and Cloud=true, run this test only if a default warehouse is available in the cloud environment
+	// If true and Cloud=true, run the cloud part of this test only if a default warehouse is available in the cloud environment
 	RequiresWarehouse *bool
 
 	// If set, current user will be set to a service principal-like UUID instead of email (default is false)

--- a/acceptance/test.toml
+++ b/acceptance/test.toml
@@ -1,5 +1,6 @@
 # Default settings that apply to all tests unless overriden by test.toml files in inner directories.
 # Tests always run locally; set Cloud/CloudSlow to also run on a real workspace.
+# Cloud = false (the inherited default) therefore means local only.
 Cloud = false
 
 # default timeouts

--- a/integration/README.md
+++ b/integration/README.md
@@ -2,6 +2,12 @@
 
 This directory contains integration tests for the project.
 
+## Deprecated: do not add tests here
+
+This tree is deprecated and should not be extended with new tests. A test here only ever runs against a real workspace, so it contributes nothing to the local suite and is only exercised when someone runs a cloud job.
+
+Write an acceptance test instead (see `acceptance/README.md`) and set `Cloud = true` in its `test.toml`. One test then covers both: it runs locally against the fake server in `libs/testserver` on every `./task test`, *and* against a real workspace when `CLOUD_ENV` is set. Existing tests here are still maintained; extend them only when there is no acceptance-test equivalent.
+
 The tree structure generally mirrors the source code tree structure.
 
 Requirements for new files in this directory:


### PR DESCRIPTION
## Why
Saw agents interpreting "Cloud = true" as cloud test without local equivalent