### PR TITLE
config-remote-sync: skip changes nested inside a variable reference

### DIFF
--- a/acceptance/bundle/config-remote-sync/variable_reference_parent/databricks.yml.tmpl
+++ b/acceptance/bundle/config-remote-sync/variable_reference_parent/databricks.yml.tmpl
@@ -1,0 +1,29 @@
+bundle:
+  name: test-bundle-$UNIQUE_NAME
+
+variables:
+  spark_conf:
+    type: complex
+    default:
+      spark.speculation: "true"
+
+targets:
+  default:
+    mode: development
+
+resources:
+  jobs:
+    my_job:
+      max_concurrent_runs: 1
+      job_clusters:
+        - job_cluster_key: shared
+          new_cluster:
+            spark_version: $DEFAULT_SPARK_VERSION
+            node_type_id: $NODE_TYPE_ID
+            num_workers: 1
+            spark_conf: ${var.spark_conf}
+      tasks:
+        - task_key: main
+          job_cluster_key: shared
+          notebook_task:
+            notebook_path: /Users/{{workspace_user_name}}/notebook

--- a/acceptance/bundle/config-remote-sync/variable_reference_parent/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/variable_reference_parent/out.test.toml
@@ -1,0 +1,3 @@
+Cloud = false
+GOOS.windows = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/variable_reference_parent/output.txt
+++ b/acceptance/bundle/config-remote-sync/variable_reference_parent/output.txt
@@ -1,6 +1,6 @@
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle-[UNIQUE_NAME]/default/files...
 Created jobs.my_job
-Files: 5 uploaded, 0 deleted
+Files: 6 uploaded, 0 deleted
 Resources: 1 created, 0 changed, 0 deleted, 0 unchanged
 
 === Inject a spark_conf key under a field defined as a complex variable
@@ -28,6 +28,36 @@ Resource: resources.jobs.my_job
 +      max_concurrent_runs: 5
        job_clusters:
          - job_cluster_key: shared
+
+=== Telemetry
+
+>>> cat out.requests.txt
+{
+  "save": true,
+  "changes_total": 2,
+  "add_count": 1,
+  "replace_count": 1,
+  "resource_changes": [
+    {
+      "resource_type": "jobs",
+      "changes_count": 2,
+      "add_count": 1,
+      "replace_count": 1
+    }
+  ],
+  "files_changed_count": 1,
+  "files_written_count": 1,
+  "skipped_changes_count": 1,
+  "state_serial": 1,
+  "state_lineage": "[UUID]",
+  "state_source": "local",
+  "states_available_count": 2,
+  "state_resource_ids": {
+    "resource_job_ids": [
+      "[MY_JOB_ID]"
+    ]
+  }
+}
 
 >>> [CLI] bundle destroy --auto-approve
 The following resources will be deleted:

--- a/acceptance/bundle/config-remote-sync/variable_reference_parent/output.txt
+++ b/acceptance/bundle/config-remote-sync/variable_reference_parent/output.txt
@@ -1,0 +1,38 @@
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle-[UNIQUE_NAME]/default/files...
+Created jobs.my_job
+Files: 5 uploaded, 0 deleted
+Resources: 1 created, 0 changed, 0 deleted, 0 unchanged
+
+=== Inject a spark_conf key under a field defined as a complex variable
+spark_conf is set to a variable reference, so a remotely-added key cannot be
+written into that scalar node; the change is skipped while unrelated edits still sync.
+
+=== Detect and save all changes
+Detected changes in 1 resource(s):
+
+Resource: resources.jobs.my_job
+  job_clusters[job_cluster_key='shared'].new_cluster.spark_conf['spark.executor.memory']: add
+  max_concurrent_runs: replace
+
+
+
+=== Configuration changes
+
+>>> diff.py databricks.yml.backup databricks.yml
+--- databricks.yml.backup
++++ databricks.yml
+@@ -15,5 +15,5 @@
+   jobs:
+     my_job:
+-      max_concurrent_runs: 1
++      max_concurrent_runs: 5
+       job_clusters:
+         - job_cluster_key: shared
+
+>>> [CLI] bundle destroy --auto-approve
+The following resources will be deleted:
+  delete resources.jobs.my_job
+
+All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/test-bundle-[UNIQUE_NAME]/default
+
+Destroy: 1 deleted

--- a/acceptance/bundle/config-remote-sync/variable_reference_parent/output.txt
+++ b/acceptance/bundle/config-remote-sync/variable_reference_parent/output.txt
@@ -11,7 +11,7 @@ written into that scalar node; the change is skipped while unrelated edits still
 Detected changes in 1 resource(s):
 
 Resource: resources.jobs.my_job
-  job_clusters[job_cluster_key='shared'].new_cluster.spark_conf['spark.executor.memory']: add
+  job_clusters[job_cluster_key='shared'].new_cluster.spark_conf['spark.executor.memory']: skip
   max_concurrent_runs: replace
 
 

--- a/acceptance/bundle/config-remote-sync/variable_reference_parent/script
+++ b/acceptance/bundle/config-remote-sync/variable_reference_parent/script
@@ -4,6 +4,8 @@ envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
   trace $CLI bundle destroy --auto-approve
+  # destroy records requests too; drop the recorded file so it is not compared.
+  rm -f out.requests.txt
 }
 trap cleanup EXIT
 
@@ -30,3 +32,9 @@ title "Configuration changes"
 echo
 trace diff.py databricks.yml.backup databricks.yml
 rm databricks.yml.backup
+
+title "Telemetry"
+echo
+# The engine name is dropped because both EnvMatrix variants share this output.
+# skipped_changes_count reflects the spark_conf change skipped under a variable reference.
+trace cat out.requests.txt | jq 'select(has("path") and .path == "/telemetry-ext") | .body.protoLogs[] | fromjson | .entry.databricks_cli_log.bundle_config_remote_sync_event | select(. != null) | del(.engine)'

--- a/acceptance/bundle/config-remote-sync/variable_reference_parent/script
+++ b/acceptance/bundle/config-remote-sync/variable_reference_parent/script
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+envsubst < databricks.yml.tmpl > databricks.yml
+
+cleanup() {
+  trace $CLI bundle destroy --auto-approve
+}
+trap cleanup EXIT
+
+$CLI bundle deploy
+job_id="$(read_id.py my_job)"
+
+title "Inject a spark_conf key under a field defined as a complex variable"
+echo
+echo "spark_conf is set to a variable reference, so a remotely-added key cannot be"
+echo "written into that scalar node; the change is skipped while unrelated edits still sync."
+edit_resource.py jobs $job_id <<'EOF'
+r["max_concurrent_runs"] = 5
+
+for jc in r.get("job_clusters", []):
+    jc["new_cluster"]["spark_conf"]["spark.executor.memory"] = "4g"
+EOF
+
+title "Detect and save all changes"
+echo
+cp databricks.yml databricks.yml.backup
+$CLI bundle config-remote-sync --save
+
+title "Configuration changes"
+echo
+trace diff.py databricks.yml.backup databricks.yml
+rm databricks.yml.backup

--- a/acceptance/bundle/config-remote-sync/variable_reference_parent/test.toml
+++ b/acceptance/bundle/config-remote-sync/variable_reference_parent/test.toml
@@ -1,0 +1,8 @@
+RecordRequests = false
+Ignore = [".databricks", "databricks.yml", "databricks.yml.backup"]
+
+[Env]
+DATABRICKS_BUNDLE_ENABLE_EXPERIMENTAL_YAML_SYNC = "true"
+
+[EnvMatrix]
+DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/variable_reference_parent/test.toml
+++ b/acceptance/bundle/config-remote-sync/variable_reference_parent/test.toml
@@ -1,8 +1,6 @@
 RecordRequests = false
 Ignore = [".databricks", "databricks.yml", "databricks.yml.backup"]
 
-[Env]
-DATABRICKS_BUNDLE_ENABLE_EXPERIMENTAL_YAML_SYNC = "true"
+Env.DATABRICKS_BUNDLE_ENABLE_EXPERIMENTAL_YAML_SYNC = "true"
 
-[EnvMatrix]
-DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/variable_reference_parent/test.toml
+++ b/acceptance/bundle/config-remote-sync/variable_reference_parent/test.toml
@@ -1,4 +1,7 @@
-RecordRequests = false
+# RecordRequests captures the config-remote-sync telemetry event so the script
+# can assert skipped_changes_count (the change skipped under a variable reference).
+# out.requests.txt is removed in the script's cleanup so it is not compared.
+RecordRequests = true
 Ignore = [".databricks", "databricks.yml", "databricks.yml.backup"]
 
 Env.DATABRICKS_BUNDLE_ENABLE_EXPERIMENTAL_YAML_SYNC = "true"

--- a/bundle/configsync/patch.go
+++ b/bundle/configsync/patch.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 
 	"github.com/databricks/cli/bundle"
-	"github.com/databricks/cli/libs/dyn/dynvar"
 	"github.com/databricks/cli/libs/log"
 	"github.com/databricks/cli/libs/structs/structpath"
 	"github.com/palantir/pkg/yamlpatch/gopkgv3yamlpatcher"
@@ -21,14 +20,11 @@ import (
 	"go.yaml.in/yaml/v3"
 )
 
-// ApplyChangesToYAML generates YAML files for the given field changes. It returns
-// the number of changes left unapplied because their parent in the file is a
-// variable reference (see parentIsVariableReference), so the caller can record them.
-func ApplyChangesToYAML(ctx context.Context, b *bundle.Bundle, fieldChanges []FieldChange) ([]FileChange, int, error) {
+// ApplyChangesToYAML generates YAML files for the given field changes.
+func ApplyChangesToYAML(ctx context.Context, b *bundle.Bundle, fieldChanges []FieldChange) ([]FileChange, error) {
 	originalFiles := make(map[string][]byte)
 	modifiedFiles := make(map[string][]byte)
 	fileFieldChanges := make(map[string][]FieldChange)
-	skipped := 0
 
 	for _, fieldChange := range fieldChanges {
 		filePath := fieldChange.FilePath
@@ -36,25 +32,15 @@ func ApplyChangesToYAML(ctx context.Context, b *bundle.Bundle, fieldChanges []Fi
 		if _, exists := modifiedFiles[filePath]; !exists {
 			content, err := os.ReadFile(filePath)
 			if err != nil {
-				return nil, 0, fmt.Errorf("failed to read file %s: %w", filePath, err)
+				return nil, fmt.Errorf("failed to read file %s: %w", filePath, err)
 			}
 			originalFiles[filePath] = content
 			modifiedFiles[filePath] = preserveBlankLines(content)
 		}
 
-		// The field is nested inside a value written as a variable reference (e.g.
-		// spark_env_vars: ${var.env_vars}), which is a scalar in the file. A nested
-		// key or index cannot be written into it, so leave the change unapplied
-		// instead of failing the whole run.
-		if parentIsVariableReference(modifiedFiles[filePath], fieldChange.WritePath) {
-			log.Debugf(ctx, "config-remote-sync: skipping %s: parent is a variable reference", fieldChange.WritePath)
-			skipped++
-			continue
-		}
-
 		modifiedContent, err := applyChange(ctx, modifiedFiles[filePath], fieldChange)
 		if err != nil {
-			return nil, 0, fmt.Errorf("failed to apply change to file %s for a field %s: %w", filePath, fieldChange.WritePath, err)
+			return nil, fmt.Errorf("failed to apply change to file %s for a field %s: %w", filePath, fieldChange.WritePath, err)
 		}
 
 		modifiedFiles[filePath] = modifiedContent
@@ -68,7 +54,7 @@ func ApplyChangesToYAML(ctx context.Context, b *bundle.Bundle, fieldChanges []Fi
 		// In this case flow style will never appear because empty nodes are never serialized and we won't need clearAddedFlowStyle
 		normalized, err := clearAddedFlowStyle(modifiedFiles[filePath], fileFieldChanges[filePath])
 		if err != nil {
-			return nil, 0, fmt.Errorf("failed to normalize YAML style in %s: %w", filePath, err)
+			return nil, fmt.Errorf("failed to normalize YAML style in %s: %w", filePath, err)
 		}
 		result = append(result, FileChange{
 			Path:            filePath,
@@ -81,59 +67,7 @@ func ApplyChangesToYAML(ctx context.Context, b *bundle.Bundle, fieldChanges []Fi
 		return cmp.Compare(a.Path, b.Path)
 	})
 
-	return result, skipped, nil
-}
-
-// parentIsVariableReference reports whether the parent of writePath in content is
-// a scalar holding a variable reference (e.g. spark_env_vars: ${var.env_vars}).
-func parentIsVariableReference(content []byte, writePath string) bool {
-	node, err := structpath.ParsePath(writePath)
-	if err != nil {
-		return false
-	}
-	parts := node.AsSlice()
-	if len(parts) < 2 {
-		return false
-	}
-
-	var doc yaml.Node
-	if err := yaml.Unmarshal(content, &doc); err != nil {
-		return false
-	}
-	current := &doc
-	if current.Kind == yaml.DocumentNode && len(current.Content) > 0 {
-		current = current.Content[0]
-	}
-
-	for _, n := range parts[:len(parts)-1] {
-		if key, ok := n.StringKey(); ok {
-			if current.Kind != yaml.MappingNode {
-				return false
-			}
-			found := false
-			for i := 0; i+1 < len(current.Content); i += 2 {
-				if current.Content[i].Value == key {
-					current = current.Content[i+1]
-					found = true
-					break
-				}
-			}
-			if !found {
-				return false
-			}
-			continue
-		}
-		if idx, ok := n.Index(); ok {
-			if current.Kind != yaml.SequenceNode || idx < 0 || idx >= len(current.Content) {
-				return false
-			}
-			current = current.Content[idx]
-			continue
-		}
-		return false
-	}
-
-	return current.Kind == yaml.ScalarNode && dynvar.ContainsVariableReference(current.Value)
+	return result, nil
 }
 
 type parentNode struct {

--- a/bundle/configsync/patch.go
+++ b/bundle/configsync/patch.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/databricks/cli/bundle"
+	"github.com/databricks/cli/libs/dyn/dynvar"
 	"github.com/databricks/cli/libs/log"
 	"github.com/databricks/cli/libs/structs/structpath"
 	"github.com/palantir/pkg/yamlpatch/gopkgv3yamlpatcher"
@@ -20,11 +21,14 @@ import (
 	"go.yaml.in/yaml/v3"
 )
 
-// ApplyChangesToYAML generates YAML files for the given field changes.
-func ApplyChangesToYAML(ctx context.Context, b *bundle.Bundle, fieldChanges []FieldChange) ([]FileChange, error) {
+// ApplyChangesToYAML generates YAML files for the given field changes. It returns
+// the number of changes left unapplied because their parent in the file is a
+// variable reference (see parentIsVariableReference), so the caller can record them.
+func ApplyChangesToYAML(ctx context.Context, b *bundle.Bundle, fieldChanges []FieldChange) ([]FileChange, int, error) {
 	originalFiles := make(map[string][]byte)
 	modifiedFiles := make(map[string][]byte)
 	fileFieldChanges := make(map[string][]FieldChange)
+	skipped := 0
 
 	for _, fieldChange := range fieldChanges {
 		filePath := fieldChange.FilePath
@@ -32,15 +36,25 @@ func ApplyChangesToYAML(ctx context.Context, b *bundle.Bundle, fieldChanges []Fi
 		if _, exists := modifiedFiles[filePath]; !exists {
 			content, err := os.ReadFile(filePath)
 			if err != nil {
-				return nil, fmt.Errorf("failed to read file %s: %w", filePath, err)
+				return nil, 0, fmt.Errorf("failed to read file %s: %w", filePath, err)
 			}
 			originalFiles[filePath] = content
 			modifiedFiles[filePath] = preserveBlankLines(content)
 		}
 
+		// The field is nested inside a value written as a variable reference (e.g.
+		// spark_env_vars: ${var.env_vars}), which is a scalar in the file. A nested
+		// key or index cannot be written into it, so leave the change unapplied
+		// instead of failing the whole run.
+		if parentIsVariableReference(modifiedFiles[filePath], fieldChange.WritePath) {
+			log.Debugf(ctx, "config-remote-sync: skipping %s: parent is a variable reference", fieldChange.WritePath)
+			skipped++
+			continue
+		}
+
 		modifiedContent, err := applyChange(ctx, modifiedFiles[filePath], fieldChange)
 		if err != nil {
-			return nil, fmt.Errorf("failed to apply change to file %s for a field %s: %w", filePath, fieldChange.WritePath, err)
+			return nil, 0, fmt.Errorf("failed to apply change to file %s for a field %s: %w", filePath, fieldChange.WritePath, err)
 		}
 
 		modifiedFiles[filePath] = modifiedContent
@@ -54,7 +68,7 @@ func ApplyChangesToYAML(ctx context.Context, b *bundle.Bundle, fieldChanges []Fi
 		// In this case flow style will never appear because empty nodes are never serialized and we won't need clearAddedFlowStyle
 		normalized, err := clearAddedFlowStyle(modifiedFiles[filePath], fileFieldChanges[filePath])
 		if err != nil {
-			return nil, fmt.Errorf("failed to normalize YAML style in %s: %w", filePath, err)
+			return nil, 0, fmt.Errorf("failed to normalize YAML style in %s: %w", filePath, err)
 		}
 		result = append(result, FileChange{
 			Path:            filePath,
@@ -67,7 +81,59 @@ func ApplyChangesToYAML(ctx context.Context, b *bundle.Bundle, fieldChanges []Fi
 		return cmp.Compare(a.Path, b.Path)
 	})
 
-	return result, nil
+	return result, skipped, nil
+}
+
+// parentIsVariableReference reports whether the parent of writePath in content is
+// a scalar holding a variable reference (e.g. spark_env_vars: ${var.env_vars}).
+func parentIsVariableReference(content []byte, writePath string) bool {
+	node, err := structpath.ParsePath(writePath)
+	if err != nil {
+		return false
+	}
+	parts := node.AsSlice()
+	if len(parts) < 2 {
+		return false
+	}
+
+	var doc yaml.Node
+	if err := yaml.Unmarshal(content, &doc); err != nil {
+		return false
+	}
+	current := &doc
+	if current.Kind == yaml.DocumentNode && len(current.Content) > 0 {
+		current = current.Content[0]
+	}
+
+	for _, n := range parts[:len(parts)-1] {
+		if key, ok := n.StringKey(); ok {
+			if current.Kind != yaml.MappingNode {
+				return false
+			}
+			found := false
+			for i := 0; i+1 < len(current.Content); i += 2 {
+				if current.Content[i].Value == key {
+					current = current.Content[i+1]
+					found = true
+					break
+				}
+			}
+			if !found {
+				return false
+			}
+			continue
+		}
+		if idx, ok := n.Index(); ok {
+			if current.Kind != yaml.SequenceNode || idx < 0 || idx >= len(current.Content) {
+				return false
+			}
+			current = current.Content[idx]
+			continue
+		}
+		return false
+	}
+
+	return current.Kind == yaml.ScalarNode && dynvar.ContainsVariableReference(current.Value)
 }
 
 type parentNode struct {

--- a/bundle/configsync/patch_test.go
+++ b/bundle/configsync/patch_test.go
@@ -50,13 +50,12 @@ resources:
 		},
 	}
 
-	fieldChanges, skipped, err := ResolveChanges(ctx, b, changes)
+	fieldChanges, skipped, err := ResolveChanges(ctx, b, changes, LoadPreResolvedConfig(ctx, b))
 	require.NoError(t, err)
 	require.Empty(t, skipped)
 
-	fileChanges, skippedApply, err := ApplyChangesToYAML(ctx, b, fieldChanges)
+	fileChanges, err := ApplyChangesToYAML(ctx, b, fieldChanges)
 	require.NoError(t, err)
-	require.Empty(t, skippedApply)
 	require.Len(t, fileChanges, 1)
 
 	modified := fileChanges[0].ModifiedContent

--- a/bundle/configsync/patch_test.go
+++ b/bundle/configsync/patch_test.go
@@ -54,8 +54,9 @@ resources:
 	require.NoError(t, err)
 	require.Empty(t, skipped)
 
-	fileChanges, err := ApplyChangesToYAML(ctx, b, fieldChanges)
+	fileChanges, skippedApply, err := ApplyChangesToYAML(ctx, b, fieldChanges)
 	require.NoError(t, err)
+	require.Empty(t, skippedApply)
 	require.Len(t, fileChanges, 1)
 
 	modified := fileChanges[0].ModifiedContent

--- a/bundle/configsync/resolve.go
+++ b/bundle/configsync/resolve.go
@@ -193,11 +193,14 @@ func adjustArrayIndex(path *structpath.PatternNode, scope string, operations map
 
 // ResolveChanges resolves selectors and computes field path candidates for each change.
 //
-// A change that cannot be attributed to a single source location is left unapplied
-// rather than written to a guessed one. The count of those is returned so the caller can
-// record it: the command runs unattended, so a change that silently disappears looks
-// identical to one that was written.
-func ResolveChanges(ctx context.Context, b *bundle.Bundle, configChanges Changes) ([]FieldChange, int, error) {
+// A change that cannot be attributed to a single source location, or whose parent
+// in the config is written as a variable reference, is left unapplied rather than
+// written to a guessed or non-existent location. The count of those is returned so
+// the caller can record it: the command runs unattended, so a change that silently
+// disappears looks identical to one that was written. preResolved is the merged
+// config with ${...} references still literal, used to detect variable-reference
+// parents.
+func ResolveChanges(ctx context.Context, b *bundle.Bundle, configChanges Changes, preResolved dyn.Value) ([]FieldChange, int, error) {
 	var result []FieldChange
 	skipped := 0
 	targetName := b.Config.Bundle.Target
@@ -269,6 +272,18 @@ func ResolveChanges(ctx context.Context, b *bundle.Bundle, configChanges Changes
 
 			// Captured before routing rewrites indices to be block-local.
 			mergedIndexPath := resolvedPath
+
+			// The field is nested inside a value written as a variable reference (e.g.
+			// spark_conf: ${var.spark_conf}), which is a scalar in the file with no node
+			// to place the key or index under. Leave it unapplied, and record the skip on
+			// the shared change so the output reports "skip" rather than a write that never
+			// happens (matching the reclassification below).
+			if parentIsVariableReference(preResolved, mergedIndexPath.String()) {
+				log.Debugf(ctx, "config-remote-sync: skipping %s: parent is a variable reference", fullPath)
+				configChange.Operation = OperationSkip
+				skipped++
+				continue
+			}
 
 			destinations, err := routeChange(blocks, resolved, isRename)
 			if err != nil {

--- a/bundle/configsync/variables.go
+++ b/bundle/configsync/variables.go
@@ -46,17 +46,14 @@ var varPrefix = dyn.NewPath(dyn.Key("var"))
 // matches the leaf value. Non-sequence Adds (new map fields) are left
 // untouched.
 //
-// The pre-resolved config is obtained by re-loading the bundle from disk
-// through the standard loader mutators (entry point + includes + target
-// overrides) but skipping variable resolution. This gives a fully merged
-// view where ${var.X} and ${resources.X.Y.id} references are still literal
+// The caller supplies preResolved (see LoadPreResolvedConfig): the merged
+// config where ${var.X} and ${resources.X.Y.id} references are still literal
 // strings — enabling correct sibling lookup even for sequences split across
 // files via target overrides.
 // Restoration counts by mechanism are accumulated into stats (used for
 // telemetry); pass nil when counters are not needed (the counter methods are
 // nil-safe).
-func RestoreVariableReferences(ctx context.Context, b *bundle.Bundle, fieldChanges []FieldChange, stats *RestoreStats) error {
-	preResolved := loadPreResolvedConfig(ctx, b)
+func RestoreVariableReferences(ctx context.Context, b *bundle.Bundle, fieldChanges []FieldChange, preResolved dyn.Value, stats *RestoreStats) error {
 	if !preResolved.IsValid() {
 		return errors.New("pre-resolved config unavailable; variable-backed fields will be hardcoded")
 	}
@@ -118,12 +115,12 @@ func RestoreVariableReferences(ctx context.Context, b *bundle.Bundle, fieldChang
 	return nil
 }
 
-// loadPreResolvedConfig loads the bundle's configuration through the standard
+// LoadPreResolvedConfig loads the bundle's configuration through the standard
 // loader mutators (entry point, includes, target overrides) but without
 // variable resolution. The resulting dyn.Value is fully merged across files
 // and targets, yet retains ${...} references as literal strings. Returns
 // InvalidValue if loading fails (restoration is then skipped).
-func loadPreResolvedConfig(ctx context.Context, b *bundle.Bundle) dyn.Value {
+func LoadPreResolvedConfig(ctx context.Context, b *bundle.Bundle) dyn.Value {
 	fresh := &bundle.Bundle{
 		BundleRootPath: b.BundleRootPath,
 		BundleRoot:     b.BundleRoot,
@@ -578,6 +575,28 @@ func preResolvedValueAt(preResolved dyn.Value, fieldPath string) (dyn.Value, boo
 		return dyn.InvalidValue, false
 	}
 	return v, true
+}
+
+// parentIsVariableReference reports whether the parent of fieldPath resolves to a
+// scalar variable reference in the pre-resolved config (e.g. spark_conf:
+// ${var.spark_conf}). A nested key or index cannot be written into such a scalar,
+// so config-remote-sync skips the change. fieldPath is a merged-index path, the
+// same space as FieldChange.originalPath.
+func parentIsVariableReference(preResolved dyn.Value, fieldPath string) bool {
+	node, err := structpath.ParsePattern(fieldPath)
+	if err != nil {
+		return false
+	}
+	parent := node.Parent()
+	if parent == nil {
+		return false
+	}
+	v, ok := preResolvedValueAt(preResolved, parent.String())
+	if !ok {
+		return false
+	}
+	s, ok := v.AsString()
+	return ok && dynvar.ContainsVariableReference(s)
 }
 
 // sequenceSiblings returns the sibling elements of the parent sequence when

--- a/cmd/bundle/config_remote_sync.go
+++ b/cmd/bundle/config_remote_sync.go
@@ -119,23 +119,26 @@ Examples:
 					changes = configsync.FilterChanges(changes, selected)
 				}
 
-				fieldChanges, skipped, err := configsync.ResolveChanges(ctx, b, changes)
+				// Loaded once and shared: ResolveChanges uses it to skip changes whose
+				// parent is a variable reference, RestoreVariableReferences to restore refs.
+				preResolved := configsync.LoadPreResolvedConfig(ctx, b)
+
+				fieldChanges, skipped, err := configsync.ResolveChanges(ctx, b, changes, preResolved)
 				if err != nil {
 					stats.ErrorCategory = protos.BundleConfigRemoteSyncErrorCategoryResolveFailed
 					return fmt.Errorf("failed to resolve field changes: %w", err)
 				}
 				stats.SkippedChangesCount = int64(skipped)
 
-				if err := configsync.RestoreVariableReferences(ctx, b, fieldChanges, &stats.Restore); err != nil {
+				if err := configsync.RestoreVariableReferences(ctx, b, fieldChanges, preResolved, &stats.Restore); err != nil {
 					log.Warnf(ctx, "variable restoration skipped: %v", err)
 				}
 
-				files, applySkipped, err := configsync.ApplyChangesToYAML(ctx, b, fieldChanges)
+				files, err := configsync.ApplyChangesToYAML(ctx, b, fieldChanges)
 				if err != nil {
 					stats.ErrorCategory = protos.BundleConfigRemoteSyncErrorCategoryYamlApplyFailed
 					return fmt.Errorf("failed to generate YAML files: %w", err)
 				}
-				stats.SkippedChangesCount += int64(applySkipped)
 				stats.FilesChangedCount = int64(len(files))
 
 				if save {

--- a/cmd/bundle/config_remote_sync.go
+++ b/cmd/bundle/config_remote_sync.go
@@ -130,11 +130,12 @@ Examples:
 					log.Warnf(ctx, "variable restoration skipped: %v", err)
 				}
 
-				files, err := configsync.ApplyChangesToYAML(ctx, b, fieldChanges)
+				files, applySkipped, err := configsync.ApplyChangesToYAML(ctx, b, fieldChanges)
 				if err != nil {
 					stats.ErrorCategory = protos.BundleConfigRemoteSyncErrorCategoryYamlApplyFailed
 					return fmt.Errorf("failed to generate YAML files: %w", err)
 				}
+				stats.SkippedChangesCount += int64(applySkipped)
 				stats.FilesChangedCount = int64(len(files))
 
 				if save {


### PR DESCRIPTION
## Changes
`config-remote-sync` now skips a change whose parent field in the YAML is a variable reference (e.g. `spark_conf: ${var.spark_conf}`) instead of failing the whole run. Such skips are recorded in the existing skipped-changes telemetry.

## Why
A nested key or index cannot be written into a scalar `${var}` node, so the write-back aborted the entire sync and dropped every other detected change. Skipping only the unwritable change lets the rest apply.

## Tests
Added an acceptance test: a remotely-added key under a `${var}` field is skipped while an unrelated edit still syncs.
