### PR TITLE
acc: make $TESTDIR use forward slashes on all platforms

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -963,7 +963,9 @@ func runTest(t *testing.T,
 
 	absDir, err := filepath.Abs(dir)
 	require.NoError(t, err)
-	cmd.Env = append(cmd.Env, "TESTDIR="+absDir)
+	// Use forward slashes so paths built from $TESTDIR (e.g. echoed in trace
+	// output) are stable across OSes and don't need per-test slash replacements.
+	cmd.Env = append(cmd.Env, "TESTDIR="+filepath.ToSlash(absDir))
 	cmd.Env = append(cmd.Env, "CLOUD_ENV="+cloudEnv)
 	cmd.Env = append(cmd.Env, "CURRENT_USER_NAME="+user.UserName)
 	if !isRunningOnCloud {

--- a/acceptance/bundle/templates/default-sql-catalog-dash/test.toml
+++ b/acceptance/bundle/templates/default-sql-catalog-dash/test.toml
@@ -1,5 +1,0 @@
-[[Repls]]
-# On Windows $TESTDIR expands with backslashes; normalize them so the diff.py
-# path in output.txt matches across platforms.
-Old = '\\'
-New = '/'


### PR DESCRIPTION
## Changes

Normalize the `TESTDIR` env var in the acceptance harness with `filepath.ToSlash`, so paths built from `$TESTDIR` (e.g. the `diff.py` invocation echoed in `trace` output) use forward slashes on every OS.

The other backslash replacements across the suite address paths emitted by the CLI itself (bundle roots, sync paths, artifact globs) and are left in place.

## Why

Follow-up to review feedback from @denik on #6293: rather than papering over the Windows backslashes with a per-test replacement, fix it at the source where the path is produced. This matches the repo rule "Always output file paths with forward slashes, even on Windows. Use `filepath.ToSlash`."

The `[TESTROOT]` replacement already registers both slash forms on Windows (`SetPathNoEval`), so the forward-slash `TESTDIR` prefix is still collapsed to `[TESTROOT]` — no golden changes.