### PR TITLE
acceptance: add destroy-bundle to clean up the bundle directory

### DIFF
--- a/.agents/rules/testing.md
+++ b/.agents/rules/testing.md
@@ -146,6 +146,7 @@ Ignore = ["databricks.yml"]   # parsed as EnvMatrix.Ignore, not top-level Ignore
 - `errcode CMD...`: run CMD; if it exits non-zero, append `Exit code: N` to the output but let the script continue (scripts run under `bash -e`, which would otherwise abort). Use when a command is *allowed* to fail and later steps must still run.
 - `musterr CMD...`: run CMD and fail the whole test if it *succeeds*; on the expected failure the script continues. Use to assert a command must error.
 - `withdir DIR CMD...`: run CMD with the working directory set to DIR, restoring it afterwards.
+- `destroy-bundle [ARGS...]`: run `bundle destroy --auto-approve` (traced, so output is identical to calling it directly) and then remove the `~/.bundle/<name>` directory the bundle was deployed under. Prefer it over a bare `trace $CLI bundle destroy --auto-approve` when the test is done with the bundle: on a real workspace a leftover directory is never reused, and they accumulate against the workspace's child-node limit. It removes the directory recursively, so do not use it to destroy one target while another target of the same bundle must stay deployed.
 - `git-repo-init`: initialize a deterministic git repo (fixed user/email, no hooks) and commit `databricks.yml`.
 - `uuid`, `sethome DIR`, `venv_activate`, `as-test-sp CMD...`, `readplanarg FILE`, `envsubst`: see `acceptance/script.prepare` for the full list and exact semantics.
 

--- a/acceptance/apps/deploy/bundle-no-args-with-flags/script
+++ b/acceptance/apps/deploy/bundle-no-args-with-flags/script
@@ -3,4 +3,4 @@
 
 trace $CLI apps deploy --skip-validation --auto-approve --force-lock --fail-on-active-runs
 
-trace $CLI bundle destroy --auto-approve
+destroy-bundle

--- a/acceptance/apps/deploy/bundle-no-args/script
+++ b/acceptance/apps/deploy/bundle-no-args/script
@@ -4,4 +4,4 @@
 
 trace $CLI apps deploy --skip-validation
 
-trace $CLI bundle destroy --auto-approve
+destroy-bundle

--- a/acceptance/bundle/ai_runtime_task/local_code_source/script
+++ b/acceptance/bundle/ai_runtime_task/local_code_source/script
@@ -25,5 +25,5 @@ trace $CLI bundle deploy
 trace print_requests.py --sort --del-field raw_body '//.air_snapshots/'
 
 title "destroy removes the deployed bundle (including the synced snapshots)\n"
-trace $CLI bundle destroy --auto-approve
+destroy-bundle
 rm out.requests.txt

--- a/acceptance/bundle/apps/app_yaml/script
+++ b/acceptance/bundle/apps/app_yaml/script
@@ -5,5 +5,5 @@ trace jq 'select(.path | test("app.yml"))' out.requests.txt | sed 's/\\r//g'  > 
 #trace print_requests.py //apps  # currently fails due to TF inserting description=""
 rm out.requests.txt
 
-trace $CLI bundle destroy --auto-approve
+destroy-bundle
 trace print_requests.py //apps

--- a/acceptance/bundle/apps/compute_size/script
+++ b/acceptance/bundle/apps/compute_size/script
@@ -5,7 +5,7 @@ envsubst < databricks.yml.tmpl > databricks.yml
 
 # Set up cleanup trap to ensure resources are destroyed even on failure
 cleanup() {
-  trace $CLI bundle destroy --auto-approve
+  destroy-bundle
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/apps/git_source/script
+++ b/acceptance/bundle/apps/git_source/script
@@ -5,7 +5,7 @@ envsubst < databricks.yml.tmpl > databricks.yml
 
 # Set up cleanup trap to ensure resources are destroyed even on failure
 cleanup() {
-  trace $CLI bundle destroy --auto-approve
+  destroy-bundle
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/apps/job_permissions/script
+++ b/acceptance/bundle/apps/job_permissions/script
@@ -35,4 +35,4 @@ patch -s --no-backup-if-mismatch databricks.yml < fix.patch
 trace $CLI bundle deploy -qq
 trace has_manage_run
 
-trace $CLI bundle destroy --auto-approve
+destroy-bundle

--- a/acceptance/bundle/bundle_tag/id/script
+++ b/acceptance/bundle/bundle_tag/id/script
@@ -4,5 +4,5 @@ trace $CLI bundle plan
 trace $CLI bundle deploy
 trace print_requests.py //jobs
 trace $CLI bundle summary
-trace $CLI bundle destroy --auto-approve
+destroy-bundle
 trace print_requests.py //jobs

--- a/acceptance/bundle/bundle_tag/url/script
+++ b/acceptance/bundle/bundle_tag/url/script
@@ -4,5 +4,5 @@ trace $CLI bundle plan
 trace $CLI bundle deploy
 trace print_requests.py //jobs
 trace $CLI bundle summary
-trace $CLI bundle destroy --auto-approve
+destroy-bundle
 trace print_requests.py //jobs

--- a/acceptance/bundle/config-remote-sync/cli_defaults/script
+++ b/acceptance/bundle/config-remote-sync/cli_defaults/script
@@ -3,7 +3,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-  trace $CLI bundle destroy --auto-approve
+  destroy-bundle
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/config-remote-sync/config_edits/script
+++ b/acceptance/bundle/config-remote-sync/config_edits/script
@@ -3,7 +3,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-  trace $CLI bundle destroy --auto-approve
+  destroy-bundle
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/config-remote-sync/dashboard_etag/script
+++ b/acceptance/bundle/config-remote-sync/dashboard_etag/script
@@ -3,7 +3,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-  trace $CLI bundle destroy --auto-approve
+  destroy-bundle
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/config-remote-sync/flushed_cache/script
+++ b/acceptance/bundle/config-remote-sync/flushed_cache/script
@@ -3,7 +3,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-  trace $CLI bundle destroy --auto-approve
+  destroy-bundle
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/config-remote-sync/formatting_preserved/script
+++ b/acceptance/bundle/config-remote-sync/formatting_preserved/script
@@ -3,7 +3,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-  trace $CLI bundle destroy --auto-approve
+  destroy-bundle
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/config-remote-sync/job_fields/script
+++ b/acceptance/bundle/config-remote-sync/job_fields/script
@@ -5,7 +5,7 @@ add_repl "$DEFAULT_SPARK_VERSION" DEFAULT_SPARK_VERSION
 add_repl "$NODE_TYPE_ID" NODE_TYPE_ID
 
 cleanup() {
-  trace $CLI bundle destroy --auto-approve
+  destroy-bundle
   # destroy records requests too; drop the recorded file so it is not compared.
   rm -f out.requests.txt
 }

--- a/acceptance/bundle/config-remote-sync/job_multiple_tasks/script
+++ b/acceptance/bundle/config-remote-sync/job_multiple_tasks/script
@@ -3,7 +3,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-  trace $CLI bundle destroy --auto-approve
+  destroy-bundle
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/config-remote-sync/job_params_variables/script
+++ b/acceptance/bundle/config-remote-sync/job_params_variables/script
@@ -3,7 +3,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-  trace $CLI bundle destroy --auto-approve
+  destroy-bundle
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/config-remote-sync/job_pipeline_task/script
+++ b/acceptance/bundle/config-remote-sync/job_pipeline_task/script
@@ -3,7 +3,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-  trace $CLI bundle destroy --auto-approve
+  destroy-bundle
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/config-remote-sync/multiple_files/script
+++ b/acceptance/bundle/config-remote-sync/multiple_files/script
@@ -5,7 +5,7 @@ envsubst < resources/job1.yml.tmpl > resources/job1.yml
 envsubst < resources/job2.yml.tmpl > resources/job2.yml
 
 cleanup() {
-  trace $CLI bundle destroy --auto-approve
+  destroy-bundle
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/config-remote-sync/multiple_resources/script
+++ b/acceptance/bundle/config-remote-sync/multiple_resources/script
@@ -6,7 +6,7 @@ cleanup() {
   # Restore original config before destroy to avoid Terraform errors
   # from server-side-only fields (e.g. creator_name) written by config-remote-sync.
   envsubst < databricks.yml.tmpl > databricks.yml
-  trace $CLI bundle destroy --auto-approve
+  destroy-bundle
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/config-remote-sync/output_json/script
+++ b/acceptance/bundle/config-remote-sync/output_json/script
@@ -3,7 +3,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-  trace $CLI bundle destroy --auto-approve
+  destroy-bundle
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/config-remote-sync/output_no_changes/script
+++ b/acceptance/bundle/config-remote-sync/output_no_changes/script
@@ -3,7 +3,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-  trace $CLI bundle destroy --auto-approve
+  destroy-bundle
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/config-remote-sync/pipeline_fields/script
+++ b/acceptance/bundle/config-remote-sync/pipeline_fields/script
@@ -3,7 +3,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-  trace $CLI bundle destroy --auto-approve
+  destroy-bundle
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/config-remote-sync/policy_injected_cluster_fields/script
+++ b/acceptance/bundle/config-remote-sync/policy_injected_cluster_fields/script
@@ -3,7 +3,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-  trace $CLI bundle destroy --auto-approve
+  destroy-bundle
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/config-remote-sync/resolve_variables/script
+++ b/acceptance/bundle/config-remote-sync/resolve_variables/script
@@ -3,7 +3,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-  trace $CLI bundle destroy --auto-approve
+  destroy-bundle
   # destroy records requests too; drop the recorded file so it is not compared.
   rm -f out.requests.txt
 }

--- a/acceptance/bundle/config-remote-sync/select_basic/script
+++ b/acceptance/bundle/config-remote-sync/select_basic/script
@@ -3,7 +3,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-  trace $CLI bundle destroy --auto-approve
+  destroy-bundle
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/config-remote-sync/select_multiple/script
+++ b/acceptance/bundle/config-remote-sync/select_multiple/script
@@ -3,7 +3,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-  trace $CLI bundle destroy --auto-approve
+  destroy-bundle
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/config-remote-sync/skip_permissions/script
+++ b/acceptance/bundle/config-remote-sync/skip_permissions/script
@@ -3,7 +3,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-  trace $CLI bundle destroy --auto-approve
+  destroy-bundle
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/config-remote-sync/split/isolation/script
+++ b/acceptance/bundle/config-remote-sync/split/isolation/script
@@ -3,7 +3,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-  trace $CLI bundle destroy --auto-approve -t dev
+  destroy-bundle -t dev
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/config-remote-sync/split/keyed_edit/script
+++ b/acceptance/bundle/config-remote-sync/split/keyed_edit/script
@@ -3,7 +3,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-  trace $CLI bundle destroy --auto-approve -t dev
+  destroy-bundle -t dev
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/config-remote-sync/split/keyed_remove/script
+++ b/acceptance/bundle/config-remote-sync/split/keyed_remove/script
@@ -3,7 +3,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-  trace $CLI bundle destroy --auto-approve -t dev
+  destroy-bundle -t dev
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/config-remote-sync/split/keyed_rename/script
+++ b/acceptance/bundle/config-remote-sync/split/keyed_rename/script
@@ -3,7 +3,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-  trace $CLI bundle destroy --auto-approve -t dev
+  destroy-bundle -t dev
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/config-remote-sync/split/keyed_twoblock/script
+++ b/acceptance/bundle/config-remote-sync/split/keyed_twoblock/script
@@ -3,7 +3,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-  trace $CLI bundle destroy --auto-approve -t dev
+  destroy-bundle -t dev
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/config-remote-sync/split/multifile/script
+++ b/acceptance/bundle/config-remote-sync/split/multifile/script
@@ -5,7 +5,7 @@ envsubst < overrides/10-first.yml.tmpl > overrides/10-first.yml
 envsubst < overrides/20-second.yml.tmpl > overrides/20-second.yml
 
 cleanup() {
-  trace $CLI bundle destroy --auto-approve -t dev
+  destroy-bundle -t dev
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/config-remote-sync/split/nested_sequence/script
+++ b/acceptance/bundle/config-remote-sync/split/nested_sequence/script
@@ -3,7 +3,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-  trace $CLI bundle destroy --auto-approve -t dev
+  destroy-bundle -t dev
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/config-remote-sync/split/positional/script
+++ b/acceptance/bundle/config-remote-sync/split/positional/script
@@ -3,7 +3,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-  trace $CLI bundle destroy --auto-approve -t dev
+  destroy-bundle -t dev
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/config-remote-sync/split/target_variable/script
+++ b/acceptance/bundle/config-remote-sync/split/target_variable/script
@@ -3,7 +3,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-  trace $CLI bundle destroy --auto-approve -t dev
+  destroy-bundle -t dev
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/config-remote-sync/target_override/script
+++ b/acceptance/bundle/config-remote-sync/target_override/script
@@ -3,7 +3,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-  trace $CLI bundle destroy --auto-approve -t dev
+  destroy-bundle -t dev
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/config-remote-sync/task_rename_revert/script
+++ b/acceptance/bundle/config-remote-sync/task_rename_revert/script
@@ -3,7 +3,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-  trace $CLI bundle destroy --auto-approve
+  destroy-bundle
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/config-remote-sync/validation_errors/script
+++ b/acceptance/bundle/config-remote-sync/validation_errors/script
@@ -8,7 +8,7 @@ cleanup() {
   # Restore valid paths for destroy to work (includes pipeline_root_v2 from sync)
   mkdir -p pipeline_root pipeline_root_v2 src
   echo '# Databricks notebook source' > src/notebook.py
-  trace $CLI bundle destroy --auto-approve
+  destroy-bundle
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/deploy/empty-bundle/script
+++ b/acceptance/bundle/deploy/empty-bundle/script
@@ -1,6 +1,6 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/deploy/files/no-snapshot-sync/script
+++ b/acceptance/bundle/deploy/files/no-snapshot-sync/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/deploy/immutable-no-artifacts/script
+++ b/acceptance/bundle/deploy/immutable-no-artifacts/script
@@ -15,4 +15,4 @@ trace $CLI jobs get $JOB_ID | jq '.settings.tasks' | jq '.[] | select(.spark_pyt
 trace $CLI jobs get $JOB_ID | jq '.settings.tasks' | jq '.[] | select(.notebook_task != null) | .notebook_task.notebook_path'
 trace $CLI jobs get $JOB_ID | jq '.settings.tasks' | jq '.[] | select(.notebook_task != null) | .notebook_task.base_parameters.path'
 
-trace $CLI bundle destroy --auto-approve
+destroy-bundle

--- a/acceptance/bundle/deploy/immutable-permissions-change/script
+++ b/acceptance/bundle/deploy/immutable-permissions-change/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/deploy/immutable/script
+++ b/acceptance/bundle/deploy/immutable/script
@@ -1,6 +1,6 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/deploy/partial-summary-on-push-fail/script
+++ b/acceptance/bundle/deploy/partial-summary-on-push-fail/script
@@ -2,7 +2,7 @@ cleanup() {
     # Second deploy has no fault, so it succeeds and prints both summary lines; this
     # both cleans up and shows the contrast with the failed deploy above.
     trace $CLI bundle deploy
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/deploy/pipeline-config-dots/script
+++ b/acceptance/bundle/deploy/pipeline-config-dots/script
@@ -1,7 +1,7 @@
 trace $CLI bundle validate
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/deploy/readplan/basic/script
+++ b/acceptance/bundle/deploy/readplan/basic/script
@@ -14,5 +14,5 @@ trace $CLI bundle deploy --plan out.plan_skip.json
 # Show what requests were made (should not create/update job again; should not read remote state)
 trace print_requests.py --get //jobs | contains.py "!GET" "!POST"
 
-trace $CLI bundle destroy --auto-approve
+destroy-bundle
 rm out.requests.txt

--- a/acceptance/bundle/deploy/readplan/cli-version-mismatch/script
+++ b/acceptance/bundle/deploy/readplan/cli-version-mismatch/script
@@ -5,5 +5,5 @@ jq '.cli_version = "1.2.3"' plan.json > plan.json.tmp && mv plan.json.tmp plan.j
 trace $CLI bundle deploy --plan plan.json
 rm plan.json
 print_requests.py //jobs
-trace $CLI bundle destroy --auto-approve
+destroy-bundle
 rm out.requests.txt

--- a/acceptance/bundle/deploy/readplan/postgres_role/script
+++ b/acceptance/bundle/deploy/readplan/postgres_role/script
@@ -19,5 +19,5 @@ trace print_requests.py //roles
 # A follow-up plan must show no drift.
 trace $CLI bundle plan
 
-trace $CLI bundle destroy --auto-approve
+destroy-bundle
 rm out.requests.txt

--- a/acceptance/bundle/deploy/readplan/serial-mismatch/script
+++ b/acceptance/bundle/deploy/readplan/serial-mismatch/script
@@ -11,4 +11,4 @@ jq '.serial = 999' plan.json > plan.json.tmp && mv plan.json.tmp plan.json
 musterr $CLI bundle deploy --plan plan.json
 
 rm plan.json
-trace $CLI bundle destroy --auto-approve
+destroy-bundle

--- a/acceptance/bundle/deploy/spark-jar-task/script
+++ b/acceptance/bundle/deploy/spark-jar-task/script
@@ -1,4 +1,4 @@
 envsubst < databricks.yml.tmpl > databricks.yml
-trap "errcode trace '$CLI' bundle destroy --auto-approve" EXIT
+trap "errcode destroy-bundle" EXIT
 trace $CLI bundle deploy
 trace $CLI bundle run jar_job

--- a/acceptance/bundle/deployment/bind/catalog/script
+++ b/acceptance/bundle/deployment/bind/catalog/script
@@ -20,7 +20,7 @@ title "Unbind catalog"
 trace $CLI bundle deployment unbind foo
 
 title "Destroy bundle"
-trace $CLI bundle destroy --auto-approve
+destroy-bundle
 
 title "Read the pre-defined catalog again (expecting it still exists): "
 trace $CLI catalogs get "test-catalog-$UNIQUE_NAME" | jq '{comment, name}'

--- a/acceptance/bundle/deployment/bind/dashboard/script
+++ b/acceptance/bundle/deployment/bind/dashboard/script
@@ -22,7 +22,7 @@ trace $CLI lakeview get "${DASHBOARD_ID}" | jq --sort-keys '{display_name, lifec
 
 trace $CLI bundle deployment unbind dashboard1
 
-trace $CLI bundle destroy --auto-approve
+destroy-bundle
 
 # Read the pre-defined dashboard again (expecting it still exists and is not deleted):
 trace $CLI lakeview get "${DASHBOARD_ID}" | jq --sort-keys '{display_name, lifecycle_state, path, parent_path, serialized_dashboard} | .serialized_dashboard |= fromjson'

--- a/acceptance/bundle/deployment/bind/experiment/script
+++ b/acceptance/bundle/deployment/bind/experiment/script
@@ -33,6 +33,6 @@ $CLI bundle plan --output json | jq '{plan: .plan | map_values({action, name_cha
 
 trace $CLI bundle deployment unbind experiment1
 
-trace $CLI bundle destroy --auto-approve
+destroy-bundle
 
 trace $CLI experiments get-experiment ${EXPERIMENT_ID} | jq '{name: .experiment.name, lifecycle_stage: .experiment.lifecycle_stage}'

--- a/acceptance/bundle/deployment/bind/external_location/script
+++ b/acceptance/bundle/deployment/bind/external_location/script
@@ -20,7 +20,7 @@ title "Unbind external location"
 trace $CLI bundle deployment unbind test_location
 
 title "Destroy bundle"
-trace $CLI bundle destroy --auto-approve
+destroy-bundle
 
 title "Read the pre-defined external location again (expecting it still exists): "
 trace $CLI external-locations get "test-location-$UNIQUE_NAME" | jq '{name, url, credential_name}'

--- a/acceptance/bundle/deployment/bind/genie_space/script
+++ b/acceptance/bundle/deployment/bind/genie_space/script
@@ -24,7 +24,7 @@ trace $CLI genie get-space "${GENIE_SPACE_ID}" | jq --sort-keys '{title, parent_
 
 trace $CLI bundle deployment unbind genie_space1
 
-trace $CLI bundle destroy --auto-approve
+destroy-bundle
 
 # Read the Genie space again (expecting it still exists and is not deleted):
 trace $CLI genie get-space "${GENIE_SPACE_ID}" | jq --sort-keys '{title, parent_path, warehouse_id}'

--- a/acceptance/bundle/deployment/bind/job/generate-and-bind/script
+++ b/acceptance/bundle/deployment/bind/job/generate-and-bind/script
@@ -47,7 +47,7 @@ trace cat resources/test_job_key.job.yml | grep "name: generate-job-${UNIQUE_NAM
 trace $CLI bundle deployment bind test_job_key $JOB_ID --auto-approve
 trace $CLI bundle deploy
 
-trace $CLI bundle destroy --auto-approve
+destroy-bundle
 
 title "Check that job is bound and does not exist after bundle is destroyed:"
 trace errcode $CLI jobs get "${JOB_ID}" --output json

--- a/acceptance/bundle/deployment/bind/job/job-spark-python-task/script
+++ b/acceptance/bundle/deployment/bind/job/job-spark-python-task/script
@@ -50,7 +50,7 @@ title "Remove .databricks directory to simulate fresh deployment:"
 trace rm -rf .databricks
 
 title "Destroy the bundle:"
-trace $CLI bundle destroy --auto-approve
+destroy-bundle
 
 title "Read the pre-defined job again (expecting it still exists):"
 trace $CLI jobs get ${JOB_ID} | jq '{job_id, settings: {name: .settings.name, tasks: [.settings.tasks[] | {task_key, spark_python_task: {python_file: .spark_python_task.python_file}}]}}'

--- a/acceptance/bundle/deployment/bind/model-serving-endpoint/script
+++ b/acceptance/bundle/deployment/bind/model-serving-endpoint/script
@@ -21,7 +21,7 @@ trace $CLI serving-endpoints get "${ENDPOINT_NAME}" | jq '{name, permission_leve
 
 trace $CLI bundle deployment unbind endpoint1
 
-trace $CLI bundle destroy --auto-approve
+destroy-bundle
 
 # Read the pre-defined serving-endpoint again (expecting it still exists and is not deleted):
 trace $CLI serving-endpoints get "${ENDPOINT_NAME}" | jq '{name, permission_level, route_optimized, state}'

--- a/acceptance/bundle/deployment/bind/registered-model/script
+++ b/acceptance/bundle/deployment/bind/registered-model/script
@@ -26,7 +26,7 @@ trace $CLI registered-models get "${MODEL_FULL_NAME}" | jq '{full_name, schema_n
 
 trace $CLI bundle deployment unbind model1
 
-trace $CLI bundle destroy --auto-approve
+destroy-bundle
 
 # Read the pre-defined model again (expecting it still exists and is not deleted):
 trace $CLI registered-models get "${MODEL_FULL_NAME}" | jq '{full_name, schema_name, name}'

--- a/acceptance/bundle/deployment/bind/secret-scope/script
+++ b/acceptance/bundle/deployment/bind/secret-scope/script
@@ -18,6 +18,6 @@ trace $CLI secrets list-scopes -o json | jq --arg value ${SECRET_SCOPE_NAME} '.[
 
 trace $CLI bundle deployment unbind secret_scope1
 
-trace $CLI bundle destroy --auto-approve
+destroy-bundle
 
 trace $CLI secrets list-scopes -o json | jq --arg value ${SECRET_SCOPE_NAME} '.[] | select(.name == $value)'

--- a/acceptance/bundle/deployment/bind/vector_search_endpoint/script
+++ b/acceptance/bundle/deployment/bind/vector_search_endpoint/script
@@ -17,7 +17,7 @@ trace $CLI vector-search-endpoints get-endpoint "${ENDPOINT_NAME}" | jq '{id, na
 
 trace $CLI bundle deployment unbind endpoint1
 
-trace $CLI bundle destroy --auto-approve
+destroy-bundle
 
 # Read the pre-defined endpoint again (expecting it still exists and is not deleted):
 trace $CLI vector-search-endpoints get-endpoint "${ENDPOINT_NAME}" | jq '{id, name, endpoint_type}'

--- a/acceptance/bundle/deployment/bind/vector_search_index/script
+++ b/acceptance/bundle/deployment/bind/vector_search_index/script
@@ -21,7 +21,7 @@ trace $CLI vector-search-indexes get-index "${INDEX_NAME}" | jq '{name, endpoint
 
 trace $CLI bundle deployment unbind index1
 
-trace $CLI bundle destroy --auto-approve
+destroy-bundle
 
 # Read the pre-defined index again (expecting it still exists and is not deleted):
 trace $CLI vector-search-indexes get-index "${INDEX_NAME}" | jq '{name, endpoint_name, index_type, primary_key}'

--- a/acceptance/bundle/deployment/bind/volume/script
+++ b/acceptance/bundle/deployment/bind/volume/script
@@ -25,6 +25,6 @@ trace $CLI volumes read "${VOLUME_FULL_NAME}" | jq '{catalog_name, full_name, sc
 
 trace $CLI bundle deployment unbind volume1
 
-trace $CLI bundle destroy --auto-approve
+destroy-bundle
 
 trace $CLI volumes read "${VOLUME_FULL_NAME}" | jq '{catalog_name, full_name, schema_name, volume_type}'

--- a/acceptance/bundle/deployment/unbind/grants/script
+++ b/acceptance/bundle/deployment/unbind/grants/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     if [[ -n "$schema_id" ]]; then
         trace $CLI schemas delete $schema_id
     fi

--- a/acceptance/bundle/deployment/unbind/permissions/script
+++ b/acceptance/bundle/deployment/unbind/permissions/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     trace $CLI jobs delete $job_id
     echo $?
 }

--- a/acceptance/bundle/destroy/all-resources/script
+++ b/acceptance/bundle/destroy/all-resources/script
@@ -1,2 +1,2 @@
 trace $CLI bundle deploy
-trace $CLI bundle destroy --auto-approve
+destroy-bundle

--- a/acceptance/bundle/destroy/all-resources/script
+++ b/acceptance/bundle/destroy/all-resources/script
@@ -1,2 +1,2 @@
 trace $CLI bundle deploy
-destroy-bundle
+trace $CLI bundle destroy --auto-approve

--- a/acceptance/bundle/destroy/jobs-and-pipeline/script
+++ b/acceptance/bundle/destroy/jobs-and-pipeline/script
@@ -8,7 +8,7 @@ DEPLOYMENT_PATH="//Workspace/Users/${CURRENT_USER_NAME}/.bundle/${UNIQUE_NAME}"
 
 cleanup() {
   title "Destroy bundle"
-  trace $CLI bundle destroy --auto-approve
+  destroy-bundle
 
   title "Assert pipeline is deleted"
   trace errcode $CLI pipelines get "${PIPELINE_ID}"

--- a/acceptance/bundle/generate/auto-bind/script
+++ b/acceptance/bundle/generate/auto-bind/script
@@ -45,7 +45,7 @@ title "Deploy the bound job:"
 trace $CLI bundle deploy
 
 title "Destroy the bundle:"
-trace $CLI bundle destroy --auto-approve
+destroy-bundle
 
 title "Check that job is bound and does not exist after bundle is destroyed:"
 trace errcode $CLI jobs get "${JOB_ID}" --output json

--- a/acceptance/bundle/generate/pipeline_and_deploy/script
+++ b/acceptance/bundle/generate/pipeline_and_deploy/script
@@ -50,4 +50,4 @@ title "Deploy the generated bundle"
 trace $CLI bundle deploy
 
 title "Destroy the deployed bundle"
-trace $CLI bundle destroy --auto-approve
+destroy-bundle

--- a/acceptance/bundle/generate/python_job_and_deploy/script
+++ b/acceptance/bundle/generate/python_job_and_deploy/script
@@ -47,4 +47,4 @@ title "Deploy the generated bundle"
 trace $CLI bundle deploy
 
 title "Destroy the deployed bundle"
-trace $CLI bundle destroy --auto-approve
+destroy-bundle

--- a/acceptance/bundle/integration_whl/base/script
+++ b/acceptance/bundle/integration_whl/base/script
@@ -1,7 +1,7 @@
 export EXTRA_CONFIG=empty.yml
 envsubst < databricks.yml.tmpl > databricks.yml
 trace cat databricks.yml
-trap "errcode trace '$CLI' bundle destroy --auto-approve" EXIT
+trap "errcode destroy-bundle" EXIT
 trace $CLI bundle deploy
 
 # Add all resource IDs to runtime replacements to avoid pattern matching ambiguity

--- a/acceptance/bundle/integration_whl/custom_params/script
+++ b/acceptance/bundle/integration_whl/custom_params/script
@@ -2,7 +2,7 @@ export EXTRA_CONFIG=empty.yml
 envsubst < $TESTDIR/../base/databricks.yml.tmpl > databricks.yml
 cp -r $TESTDIR/../base/{$EXTRA_CONFIG,setup.py,my_test_code} .
 trace cat databricks.yml
-trap "errcode trace '$CLI' bundle destroy --auto-approve" EXIT
+trap "errcode destroy-bundle" EXIT
 trace $CLI bundle deploy
 
 # Add all resource IDs to runtime replacements to avoid pattern matching ambiguity

--- a/acceptance/bundle/integration_whl/interactive_cluster/script
+++ b/acceptance/bundle/integration_whl/interactive_cluster/script
@@ -1,7 +1,7 @@
 export DATA_SECURITY_MODE=USER_ISOLATION
 envsubst < databricks.yml.tmpl > databricks.yml
 trace cat databricks.yml
-trap "errcode trace '$CLI' bundle destroy --auto-approve" EXIT
+trap "errcode destroy-bundle" EXIT
 trace $CLI bundle deploy
 
 # Add all resource IDs to runtime replacements to avoid pattern matching ambiguity

--- a/acceptance/bundle/integration_whl/interactive_cluster_dynamic_version/script
+++ b/acceptance/bundle/integration_whl/interactive_cluster_dynamic_version/script
@@ -1,6 +1,6 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 cp -r $TESTDIR/../interactive_cluster/{setup.py,my_test_code} .
-trap "errcode trace '$CLI' bundle destroy --auto-approve" EXIT
+trap "errcode destroy-bundle" EXIT
 trace $CLI bundle deploy
 
 # Add all resource IDs to runtime replacements to avoid pattern matching ambiguity

--- a/acceptance/bundle/integration_whl/interactive_single_user/script
+++ b/acceptance/bundle/integration_whl/interactive_single_user/script
@@ -2,7 +2,7 @@ export DATA_SECURITY_MODE=SINGLE_USER
 envsubst < $TESTDIR/../interactive_cluster/databricks.yml.tmpl > databricks.yml
 trace cat databricks.yml
 cp -r $TESTDIR/../interactive_cluster/{setup.py,my_test_code} .
-trap "errcode trace '$CLI' bundle destroy --auto-approve" EXIT
+trap "errcode destroy-bundle" EXIT
 trace $CLI bundle deploy
 
 # Add all resource IDs to runtime replacements to avoid pattern matching ambiguity

--- a/acceptance/bundle/integration_whl/serverless/script
+++ b/acceptance/bundle/integration_whl/serverless/script
@@ -1,6 +1,6 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 trace cp -r $TESTDIR/../base/{setup.py,my_test_code} .
-trap "errcode trace '$CLI' bundle destroy --auto-approve" EXIT
+trap "errcode destroy-bundle" EXIT
 trace $CLI bundle deploy
 
 # Add all resource IDs to runtime replacements to avoid pattern matching ambiguity

--- a/acceptance/bundle/integration_whl/serverless_custom_params/script
+++ b/acceptance/bundle/integration_whl/serverless_custom_params/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/integration_whl/serverless_dynamic_version/script
+++ b/acceptance/bundle/integration_whl/serverless_dynamic_version/script
@@ -1,6 +1,6 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 trace cp -r $TESTDIR/../base/{setup.py,my_test_code} .
-trap "errcode trace '$CLI' bundle destroy --auto-approve" EXIT
+trap "errcode destroy-bundle" EXIT
 trace $CLI bundle deploy
 
 # Add all resource IDs to runtime replacements to avoid pattern matching ambiguity

--- a/acceptance/bundle/integration_whl/serverless_extras/script
+++ b/acceptance/bundle/integration_whl/serverless_extras/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/integration_whl/serverless_extras_dynamic_version/script
+++ b/acceptance/bundle/integration_whl/serverless_extras_dynamic_version/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/integration_whl/wrapper/script
+++ b/acceptance/bundle/integration_whl/wrapper/script
@@ -7,7 +7,7 @@ export EXTRA_CONFIG=python_wheel_wrapper.yml
 envsubst < $TESTDIR/../base/databricks.yml.tmpl > databricks.yml
 cp -r $TESTDIR/../base/{$EXTRA_CONFIG,setup.py,my_test_code} .
 trace cat databricks.yml
-trap "errcode trace '$CLI' bundle destroy --auto-approve" EXIT
+trap "errcode destroy-bundle" EXIT
 trace $CLI bundle deploy
 
 # Add all resource IDs to runtime replacements to avoid pattern matching ambiguity

--- a/acceptance/bundle/integration_whl/wrapper_custom_params/script
+++ b/acceptance/bundle/integration_whl/wrapper_custom_params/script
@@ -3,6 +3,6 @@ export EXTRA_CONFIG=python_wheel_wrapper.yml
 envsubst < $TESTDIR/../base/databricks.yml.tmpl > databricks.yml
 cp -r $TESTDIR/../base/{$EXTRA_CONFIG,setup.py,my_test_code} .
 trace cat databricks.yml
-trap "errcode trace '$CLI' bundle destroy --auto-approve" EXIT
+trap "errcode destroy-bundle" EXIT
 trace $CLI bundle deploy
 trace $CLI bundle run some_other_job --python-params param1,param2

--- a/acceptance/bundle/quiet-levels/script
+++ b/acceptance/bundle/quiet-levels/script
@@ -42,4 +42,4 @@ trace $CLI bundle destroy --auto-approve -q
 # a TTY, so TestApprovalForDestroyQuietWhilePrompting covers it.
 title "destroy --auto-approve -qq: nothing"
 trace $CLI bundle deploy -qq
-trace $CLI bundle destroy --auto-approve -qq
+destroy-bundle -qq

--- a/acceptance/bundle/resource_deps/create_error/script
+++ b/acceptance/bundle/resource_deps/create_error/script
@@ -18,5 +18,5 @@ diff.py out.deploy.$DATABRICKS_BUNDLE_ENGINE.txt out.deploy2.$DATABRICKS_BUNDLE_
 rm out.deploy2.$DATABRICKS_BUNDLE_ENGINE.txt
 trace print_requests.py //jobs
 
-trace $CLI bundle destroy --auto-approve
+destroy-bundle
 trace print_requests.py //jobs

--- a/acceptance/bundle/resource_deps/job_id/script
+++ b/acceptance/bundle/resource_deps/job_id/script
@@ -12,5 +12,5 @@ trace $CLI bundle plan -o json > out.plan_delete.$DATABRICKS_BUNDLE_ENGINE.json
 trace $CLI bundle deploy
 trace print_requests.py //jobs
 
-trace $CLI bundle destroy --auto-approve
+destroy-bundle
 trace print_requests.py //jobs

--- a/acceptance/bundle/resource_deps/job_id_big_graph/delete_all/script
+++ b/acceptance/bundle/resource_deps/job_id_big_graph/delete_all/script
@@ -15,5 +15,5 @@ cp empty.yml databricks.yml
 trace $CLI bundle plan > out.plan_delete.txt
 trace $CLI bundle deploy
 
-trace $CLI bundle destroy --auto-approve
+destroy-bundle
 rm -f out.requests.txt

--- a/acceptance/bundle/resource_deps/job_id_big_graph/destroy/script
+++ b/acceptance/bundle/resource_deps/job_id_big_graph/destroy/script
@@ -10,5 +10,5 @@ replace_ids.py
 trace $CLI bundle plan > out.plan_sanity.txt
 
 title "Destroy all via bundle destroy"
-trace $CLI bundle destroy --auto-approve
+destroy-bundle
 rm -f out.requests.txt

--- a/acceptance/bundle/resource_deps/job_id_delete_bar/script
+++ b/acceptance/bundle/resource_deps/job_id_delete_bar/script
@@ -14,5 +14,5 @@ trace $CLI bundle deploy
 # (foo's dependency on bar was removed in only_foo.yml), so execution order is non-deterministic.
 trace print_requests.py --sort //jobs > out.deploy2.requests.$DATABRICKS_BUNDLE_ENGINE.json
 
-trace $CLI bundle destroy --auto-approve
+destroy-bundle
 trace print_requests.py //jobs

--- a/acceptance/bundle/resource_deps/job_id_delete_foo/script
+++ b/acceptance/bundle/resource_deps/job_id_delete_foo/script
@@ -12,5 +12,5 @@ trace $CLI bundle plan -o json > out.plan_delete.$DATABRICKS_BUNDLE_ENGINE.json
 trace $CLI bundle deploy
 trace print_requests.py //jobs
 
-trace $CLI bundle destroy --auto-approve
+destroy-bundle
 trace print_requests.py //jobs

--- a/acceptance/bundle/resource_deps/jobs_update/script
+++ b/acceptance/bundle/resource_deps/jobs_update/script
@@ -25,7 +25,7 @@ trace $CLI jobs get $foo_id > out.get_foo.$DATABRICKS_BUNDLE_ENGINE.json
 trace $CLI jobs get $bar_id
 rm out.requests.txt
 
-trace $CLI bundle destroy --auto-approve
+destroy-bundle
 trace print_requests.py //jobs
 
 trace musterr $CLI jobs get $foo_id

--- a/acceptance/bundle/resource_deps/jobs_update_remote/script
+++ b/acceptance/bundle/resource_deps/jobs_update_remote/script
@@ -15,5 +15,5 @@ trace envsubst < job_update.json > tmp.json && mv tmp.json job_update.json
 trace $CLI jobs reset --json @job_update.json
 $CLI bundle plan -o json > out.plan_update.$DATABRICKS_BUNDLE_ENGINE.json
 
-trace $CLI bundle destroy --auto-approve
+destroy-bundle
 trace print_requests.py //jobs

--- a/acceptance/bundle/resource_deps/pipelines_recreate/script
+++ b/acceptance/bundle/resource_deps/pipelines_recreate/script
@@ -33,7 +33,7 @@ $CLI bundle plan -o json > out.plan_noop.$DATABRICKS_BUNDLE_ENGINE.json
 trace $CLI bundle deploy
 trace print_requests.py //jobs //pipelines
 
-trace $CLI bundle destroy --auto-approve
+destroy-bundle
 trace print_requests.py //jobs //pipelines
 
 trace musterr $CLI pipelines get $foo_id

--- a/acceptance/bundle/resource_deps/remote_app_url/script
+++ b/acceptance/bundle/resource_deps/remote_app_url/script
@@ -5,5 +5,5 @@ trace print_requests.py '^//import-file/'
 trace $CLI bundle deploy
 trace print_requests.py '^//import-file/'
 
-trace $CLI bundle destroy --auto-approve
+destroy-bundle
 trace print_requests.py --sort '^//import-file/'

--- a/acceptance/bundle/resources/alerts/basic/script
+++ b/acceptance/bundle/resources/alerts/basic/script
@@ -14,7 +14,7 @@ trace $CLI permissions get alertsv2 $alert_id | jq ".access_control_list.[]" -c 
 title "assert that no permanent drift happens"
 trace $CLI bundle plan
 
-trace $CLI bundle destroy --auto-approve
+destroy-bundle
 
 errcode trace $CLI alerts-v2 get-alert $alert_id
 

--- a/acceptance/bundle/resources/alerts/with_file/script
+++ b/acceptance/bundle/resources/alerts/with_file/script
@@ -2,7 +2,7 @@ envsubst < databricks.yml.tmpl > databricks.yml
 
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/resources/apps/config-drift-stopped/script
+++ b/acceptance/bundle/resources/apps/config-drift-stopped/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/resources/apps/config-drift/script
+++ b/acceptance/bundle/resources/apps/config-drift/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     rm -f out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/apps/inline_config/script
+++ b/acceptance/bundle/resources/apps/inline_config/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     rm out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/apps/lifecycle-started-omitted/script
+++ b/acceptance/bundle/resources/apps/lifecycle-started-omitted/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     rm -f out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/apps/lifecycle-started-toggle/script
+++ b/acceptance/bundle/resources/apps/lifecycle-started-toggle/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     rm -f out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/apps/lifecycle-started/script
+++ b/acceptance/bundle/resources/apps/lifecycle-started/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     rm -f out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/apps/update/script
+++ b/acceptance/bundle/resources/apps/update/script
@@ -24,5 +24,5 @@ trace print_requests >> out.requests.$DATABRICKS_BUNDLE_ENGINE.json
 
 trace $CLI bundle plan
 trace $CLI bundle summary
-trace $CLI bundle destroy --auto-approve
+destroy-bundle
 trace print_requests >> out.requests.$DATABRICKS_BUNDLE_ENGINE.json

--- a/acceptance/bundle/resources/catalogs/auto-approve/script
+++ b/acceptance/bundle/resources/catalogs/auto-approve/script
@@ -7,7 +7,7 @@ VOLUME_NAME="test-volume-${UNIQUE_NAME}"
 
 cleanup() {
   title "Test cleanup"
-  trace $CLI bundle destroy --auto-approve
+  destroy-bundle
 
   title "Assert the catalog is deleted"
   trace errcode $CLI catalogs get "${CATALOG_NAME}" 2>/dev/null

--- a/acceptance/bundle/resources/catalogs/basic/script
+++ b/acceptance/bundle/resources/catalogs/basic/script
@@ -4,7 +4,7 @@ CATALOG_NAME="test_catalog_${UNIQUE_NAME}"
 
 cleanup() {
   title "Test cleanup"
-  trace $CLI bundle destroy --auto-approve
+  destroy-bundle
 
   title "Assert the catalog is deleted"
   trace errcode $CLI catalogs get "${CATALOG_NAME}" 2>/dev/null

--- a/acceptance/bundle/resources/catalogs/with-schemas/script
+++ b/acceptance/bundle/resources/catalogs/with-schemas/script
@@ -5,7 +5,7 @@ SCHEMA_FULL_NAME="${CATALOG_NAME}.schema1"
 
 cleanup() {
   title "Test cleanup"
-  trace $CLI bundle destroy --auto-approve
+  destroy-bundle
 
   title "Assert schema is deleted"
   trace errcode $CLI schemas get "${SCHEMA_FULL_NAME}" 2>/dev/null

--- a/acceptance/bundle/resources/clusters/deploy/data_security_mode/script
+++ b/acceptance/bundle/resources/clusters/deploy/data_security_mode/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/resources/clusters/deploy/local_ssd_count/script
+++ b/acceptance/bundle/resources/clusters/deploy/local_ssd_count/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     rm out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/clusters/deploy/simple/script
+++ b/acceptance/bundle/resources/clusters/deploy/simple/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/resources/clusters/deploy/update-after-create/script
+++ b/acceptance/bundle/resources/clusters/deploy/update-after-create/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     rm -f out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/clusters/deploy/update-and-resize-autoscale/script
+++ b/acceptance/bundle/resources/clusters/deploy/update-and-resize-autoscale/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     rm out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/clusters/deploy/update-and-resize/script
+++ b/acceptance/bundle/resources/clusters/deploy/update-and-resize/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     rm out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/clusters/lifecycle-started-toggle/script
+++ b/acceptance/bundle/resources/clusters/lifecycle-started-toggle/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     rm -f out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/clusters/lifecycle-started/script
+++ b/acceptance/bundle/resources/clusters/lifecycle-started/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     rm -f out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/clusters/resize-terminated-fallback/script
+++ b/acceptance/bundle/resources/clusters/resize-terminated-fallback/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     rm -f out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/clusters/run/spark_python_task/script
+++ b/acceptance/bundle/resources/clusters/run/spark_python_task/script
@@ -3,7 +3,7 @@ trace cp $TESTDIR/../../deploy/simple/databricks.yml.tmpl .
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/resources/dashboards/change-embed-credentials/script
+++ b/acceptance/bundle/resources/dashboards/change-embed-credentials/script
@@ -1,7 +1,7 @@
 export EMBED_CREDENTIALS="false"
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     rm out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/dashboards/change-name/script
+++ b/acceptance/bundle/resources/dashboards/change-name/script
@@ -1,7 +1,7 @@
 export NAME="dashboard1"
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     rm out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/dashboards/change-parent-path/script
+++ b/acceptance/bundle/resources/dashboards/change-parent-path/script
@@ -4,7 +4,7 @@ export USERNAME=$($CLI current-user me --output json | jq -r '.userName')
 export PARENT_PATH=" /Users/$USERNAME/.bundle/change-parent-path-$UNIQUE_NAME/default/resources"
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     rm out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/dashboards/change-serialized-dashboard/script
+++ b/acceptance/bundle/resources/dashboards/change-serialized-dashboard/script
@@ -1,5 +1,5 @@
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     rm out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/dashboards/dataset-catalog-schema/script
+++ b/acceptance/bundle/resources/dashboards/dataset-catalog-schema/script
@@ -9,7 +9,7 @@ export DASHBOARD_DISPLAY_NAME
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     rm -f out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/dashboards/delete-trashed-out-of-band/script
+++ b/acceptance/bundle/resources/dashboards/delete-trashed-out-of-band/script
@@ -30,4 +30,4 @@ trace $CLI bundle plan -o json > out.plan.$DATABRICKS_BUNDLE_ENGINE.json
 # Run destroy - should succeed even though dashboard is already trashed.
 # -qq drops the summary: terraform refreshes the trashed dashboard away and reports
 # "0 deleted" while direct still counts it as "1 deleted".
-trace $CLI bundle destroy --auto-approve -qq
+destroy-bundle -qq

--- a/acceptance/bundle/resources/dashboards/destroy/script
+++ b/acceptance/bundle/resources/dashboards/destroy/script
@@ -16,6 +16,6 @@ add_repl "$DASHBOARD_ID" DASHBOARD_ID
 # Verify dashboard was deployed
 trace retry $CLI lakeview get $DASHBOARD_ID | jq '{lifecycle_state, parent_path}'
 
-trace $CLI bundle destroy --auto-approve
+destroy-bundle
 
 trace $CLI lakeview get $DASHBOARD_ID | jq '{lifecycle_state, parent_path}'

--- a/acceptance/bundle/resources/dashboards/detect-change/script
+++ b/acceptance/bundle/resources/dashboards/detect-change/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     rm out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/dashboards/generate_inplace/script
+++ b/acceptance/bundle/resources/dashboards/generate_inplace/script
@@ -5,7 +5,7 @@ mv databricks.yml.subst databricks.yml
 trace $CLI bundle deploy
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/resources/dashboards/nested-folders/script
+++ b/acceptance/bundle/resources/dashboards/nested-folders/script
@@ -8,7 +8,7 @@ envsubst < databricks.yml.tmpl > databricks.yml
 envsubst < resources/dashboards.yml.tmpl > resources/dashboards.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/resources/dashboards/publish-failure-stale-content/script
+++ b/acceptance/bundle/resources/dashboards/publish-failure-stale-content/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     rm -f out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/dashboards/republish-after-draft-update/script
+++ b/acceptance/bundle/resources/dashboards/republish-after-draft-update/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/resources/dashboards/simple/script
+++ b/acceptance/bundle/resources/dashboards/simple/script
@@ -8,7 +8,7 @@ export DASHBOARD_DISPLAY_NAME
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/resources/dashboards/simple_outside_bundle_root/script
+++ b/acceptance/bundle/resources/dashboards/simple_outside_bundle_root/script
@@ -8,7 +8,7 @@ export DASHBOARD_DISPLAY_NAME
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/resources/dashboards/simple_syncroot/script
+++ b/acceptance/bundle/resources/dashboards/simple_syncroot/script
@@ -8,7 +8,7 @@ export DASHBOARD_DISPLAY_NAME
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     rm sample-dashboard.lvdash.json
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/database_catalogs/basic/script
+++ b/acceptance/bundle/resources/database_catalogs/basic/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-  trace $CLI bundle destroy --auto-approve
+  destroy-bundle
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/resources/database_catalogs/recreate/script
+++ b/acceptance/bundle/resources/database_catalogs/recreate/script
@@ -1,5 +1,5 @@
 cleanup() {
-   trace $CLI bundle destroy --auto-approve
+   destroy-bundle
    rm -f out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/database_instances/recreate/script
+++ b/acceptance/bundle/resources/database_instances/recreate/script
@@ -1,5 +1,5 @@
 cleanup() {
-   trace $CLI bundle destroy --auto-approve
+   destroy-bundle
    rm -f out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/database_instances/single-instance/script
+++ b/acceptance/bundle/resources/database_instances/single-instance/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-   trace $CLI bundle destroy --auto-approve
+   destroy-bundle
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/resources/experiments/basic/script
+++ b/acceptance/bundle/resources/experiments/basic/script
@@ -1,5 +1,5 @@
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
 }
 
 trap cleanup EXIT

--- a/acceptance/bundle/resources/external_locations/script
+++ b/acceptance/bundle/resources/external_locations/script
@@ -7,7 +7,7 @@ EXT_LOCATION_NAME="test_ext_location_${UNIQUE_NAME}"
 
 cleanup() {
   title "Test cleanup"
-  trace $CLI bundle destroy --auto-approve
+  destroy-bundle
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/resources/genie_spaces/delete_warning/script
+++ b/acceptance/bundle/resources/genie_spaces/delete_warning/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/resources/genie_spaces/inline/script
+++ b/acceptance/bundle/resources/genie_spaces/inline/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/resources/genie_spaces/parent_path_update/script
+++ b/acceptance/bundle/resources/genie_spaces/parent_path_update/script
@@ -1,5 +1,5 @@
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/resources/genie_spaces/recreate_when_gone/script
+++ b/acceptance/bundle/resources/genie_spaces/recreate_when_gone/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/resources/genie_spaces/serialized_space/script
+++ b/acceptance/bundle/resources/genie_spaces/serialized_space/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     rm -f out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/genie_spaces/simple/script
+++ b/acceptance/bundle/resources/genie_spaces/simple/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/resources/genie_spaces/version_migration/script
+++ b/acceptance/bundle/resources/genie_spaces/version_migration/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/resources/grants/catalogs/script
+++ b/acceptance/bundle/resources/grants/catalogs/script
@@ -20,5 +20,5 @@ trace print_requests.py //permissions > out.deploy2.requests.$DATABRICKS_BUNDLE_
 
 trace $CLI grants get catalog catalog_grants_$UNIQUE_NAME | jq --sort-keys
 
-trace $CLI bundle destroy --auto-approve
+destroy-bundle
 trace print_requests.py //permissions > out.destroy.requests.$DATABRICKS_BUNDLE_ENGINE.json

--- a/acceptance/bundle/resources/grants/registered_models/script
+++ b/acceptance/bundle/resources/grants/registered_models/script
@@ -8,5 +8,5 @@ trace print_requests.py //permissions > out.deploy1.requests.$DATABRICKS_BUNDLE_
 # Since we're sending different requests between terraform and direct, assert that the end result is the same:
 trace $CLI grants get function main.myschema_$UNIQUE_NAME.mymodel | jq --sort-keys
 
-trace $CLI bundle destroy --auto-approve
+destroy-bundle
 trace print_requests.py //permissions > out.destroy.requests.$DATABRICKS_BUNDLE_ENGINE.json

--- a/acceptance/bundle/resources/grants/schemas/all_privileges/script
+++ b/acceptance/bundle/resources/grants/schemas/all_privileges/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     rm -f out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/grants/schemas/change_privilege/script
+++ b/acceptance/bundle/resources/grants/schemas/change_privilege/script
@@ -20,5 +20,5 @@ trace print_requests.py //permissions > out.deploy2.requests.$DATABRICKS_BUNDLE_
 
 trace $CLI grants get schema main.schema_grants_$UNIQUE_NAME | jq --sort-keys
 
-trace $CLI bundle destroy --auto-approve
+destroy-bundle
 trace print_requests.py //permissions > out.destroy.requests.$DATABRICKS_BUNDLE_ENGINE.json

--- a/acceptance/bundle/resources/grants/schemas/duplicate_principals/script
+++ b/acceptance/bundle/resources/grants/schemas/duplicate_principals/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     rm -f out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/grants/schemas/duplicate_privileges/script
+++ b/acceptance/bundle/resources/grants/schemas/duplicate_privileges/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     rm -f out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/grants/volumes/script
+++ b/acceptance/bundle/resources/grants/volumes/script
@@ -16,5 +16,5 @@ trace print_requests.py //permissions > out.deploy2.requests.$DATABRICKS_BUNDLE_
 
 trace $CLI grants get volume main.schema_grants_$UNIQUE_NAME.volume_name | jq --sort-keys
 
-trace $CLI bundle destroy --auto-approve
+destroy-bundle
 trace print_requests.py //permissions > out.destroy.requests.$DATABRICKS_BUNDLE_ENGINE.json

--- a/acceptance/bundle/resources/instance_pools/script
+++ b/acceptance/bundle/resources/instance_pools/script
@@ -25,7 +25,7 @@ trace jq 'select(.method == "POST" and (.path | contains("/instance-pools/edit")
 trace $CLI bundle summary
 
 title "Destroy the instance pool"
-trace $CLI bundle destroy --auto-approve
+destroy-bundle
 
 title "Verify the destroy request"
 trace jq 'select(.method == "POST" and (.path | contains("/instance-pools/delete")))' out.requests.txt

--- a/acceptance/bundle/resources/job_runs/basic/script
+++ b/acceptance/bundle/resources/job_runs/basic/script
@@ -1,5 +1,5 @@
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     # destroy deletes the triggered run via jobs/runs/delete (also unlinks out.requests.txt)
     trace print_requests.py //jobs/runs/delete
 }

--- a/acceptance/bundle/resources/job_runs/failed_run/script
+++ b/acceptance/bundle/resources/job_runs/failed_run/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     rm -f out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/job_runs/interrupted_run/script
+++ b/acceptance/bundle/resources/job_runs/interrupted_run/script
@@ -1,5 +1,5 @@
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     rm -f out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/job_runs/job_parameters/script
+++ b/acceptance/bundle/resources/job_runs/job_parameters/script
@@ -1,5 +1,5 @@
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     rm out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/job_runs/on_bundle_deploy/script
+++ b/acceptance/bundle/resources/job_runs/on_bundle_deploy/script
@@ -1,5 +1,5 @@
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     rm -f out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/job_runs/redeploy/script
+++ b/acceptance/bundle/resources/job_runs/redeploy/script
@@ -1,5 +1,5 @@
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     rm out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/job_runs/retried_run_now/script
+++ b/acceptance/bundle/resources/job_runs/retried_run_now/script
@@ -1,5 +1,5 @@
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     rm -f out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/job_runs/wait/script
+++ b/acceptance/bundle/resources/job_runs/wait/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/resources/jobs/alert-task/script
+++ b/acceptance/bundle/resources/jobs/alert-task/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/resources/jobs/big_id/script
+++ b/acceptance/bundle/resources/jobs/big_id/script
@@ -4,5 +4,5 @@ $CLI bundle deploy $(readplanarg out.plan.direct.json)
 trace print_requests.py //jobs
 print_state.py > out.state.$DATABRICKS_BUNDLE_ENGINE.json
 trace $CLI bundle plan | contains.py '0 to add, 0 to change, 0 to delete'
-trace $CLI bundle destroy --auto-approve
+destroy-bundle
 trace print_requests.py //jobs

--- a/acceptance/bundle/resources/jobs/check-metadata/script
+++ b/acceptance/bundle/resources/jobs/check-metadata/script
@@ -2,7 +2,7 @@ envsubst < databricks.yml.tmpl > databricks.yml
 envsubst < a/b/resources.yml.tmpl > a/b/resources.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/resources/jobs/double-underscore-keys/script
+++ b/acceptance/bundle/resources/jobs/double-underscore-keys/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/resources/jobs/fail-on-active-runs/script
+++ b/acceptance/bundle/resources/jobs/fail-on-active-runs/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/resources/jobs/shared-root-path/script
+++ b/acceptance/bundle/resources/jobs/shared-root-path/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/resources/jobs/update/script
+++ b/acceptance/bundle/resources/jobs/update/script
@@ -29,7 +29,7 @@ trace $CLI jobs get $ppid | jq 'del(.settings.run_as)'
 rm out.requests.txt
 
 title "Destroy the job and verify that it's removed from the state and from remote"
-trace $CLI bundle destroy --auto-approve
+destroy-bundle
 trace print_requests.py //jobs
 
 trace musterr $CLI jobs get $ppid

--- a/acceptance/bundle/resources/jobs/update_single_node/script
+++ b/acceptance/bundle/resources/jobs/update_single_node/script
@@ -23,7 +23,7 @@ trace $CLI jobs get $ppid | jq 'del(.settings.run_as)'
 rm out.requests.txt
 
 title "Destroy the job and verify that it's removed from the state and from remote"
-trace $CLI bundle destroy --auto-approve
+destroy-bundle
 trace print_requests.py //jobs
 
 trace musterr $CLI jobs get $ppid

--- a/acceptance/bundle/resources/model_serving_endpoints/basic/script
+++ b/acceptance/bundle/resources/model_serving_endpoints/basic/script
@@ -3,7 +3,7 @@ export ENDPOINT_NAME="test-endpoint-$UNIQUE_NAME-1"
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     rm out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/model_serving_endpoints/drift/recreated_same_name/script
+++ b/acceptance/bundle/resources/model_serving_endpoints/drift/recreated_same_name/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     rm -f out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/model_serving_endpoints/recreate/catalog-name/script
+++ b/acceptance/bundle/resources/model_serving_endpoints/recreate/catalog-name/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     rm -f out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/model_serving_endpoints/recreate/name-change/script
+++ b/acceptance/bundle/resources/model_serving_endpoints/recreate/name-change/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     rm -f out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/model_serving_endpoints/recreate/route-optimized/script
+++ b/acceptance/bundle/resources/model_serving_endpoints/recreate/route-optimized/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     rm -f out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/model_serving_endpoints/recreate/schema-name/script
+++ b/acceptance/bundle/resources/model_serving_endpoints/recreate/schema-name/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     rm -f out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/model_serving_endpoints/recreate/table-prefix/script
+++ b/acceptance/bundle/resources/model_serving_endpoints/recreate/table-prefix/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     rm -f out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/model_serving_endpoints/running-endpoint/script
+++ b/acceptance/bundle/resources/model_serving_endpoints/running-endpoint/script
@@ -3,7 +3,7 @@ export VERSION=$($CLI model-versions list system.ai.llama_v3_2_1b_instruct | jq 
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     rm out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/model_serving_endpoints/update/ai-gateway/script
+++ b/acceptance/bundle/resources/model_serving_endpoints/update/ai-gateway/script
@@ -2,7 +2,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     rm -f out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/model_serving_endpoints/update/both_gateway_and_tags/script
+++ b/acceptance/bundle/resources/model_serving_endpoints/update/both_gateway_and_tags/script
@@ -2,7 +2,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     rm -f out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/model_serving_endpoints/update/config/script
+++ b/acceptance/bundle/resources/model_serving_endpoints/update/config/script
@@ -2,7 +2,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     rm -f out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/model_serving_endpoints/update/email-notifications/script
+++ b/acceptance/bundle/resources/model_serving_endpoints/update/email-notifications/script
@@ -2,7 +2,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     rm -f out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/model_serving_endpoints/update/tags/script
+++ b/acceptance/bundle/resources/model_serving_endpoints/update/tags/script
@@ -2,7 +2,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     rm -f out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/models/basic/script
+++ b/acceptance/bundle/resources/models/basic/script
@@ -1,5 +1,5 @@
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/resources/models/readplan-permissions/script
+++ b/acceptance/bundle/resources/models/readplan-permissions/script
@@ -1,5 +1,5 @@
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     rm -f out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/permissions/dashboards/create/script
+++ b/acceptance/bundle/resources/permissions/dashboards/create/script
@@ -17,5 +17,5 @@ replace_ids.py
 
 print_requests.py //permissions > out.requests.deploy.$DATABRICKS_BUNDLE_ENGINE.json
 
-trace $CLI bundle destroy --auto-approve
+destroy-bundle
 print_requests.py //permissions > out.requests.destroy.$DATABRICKS_BUNDLE_ENGINE.json

--- a/acceptance/bundle/resources/permissions/factcheck/script
+++ b/acceptance/bundle/resources/permissions/factcheck/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/resources/permissions/genie_spaces/current_can_manage/script
+++ b/acceptance/bundle/resources/permissions/genie_spaces/current_can_manage/script
@@ -9,5 +9,5 @@ trace $CLI bundle deploy
 replace_ids.py
 print_requests.py //permissions > out.requests.deploy.$DATABRICKS_BUNDLE_ENGINE.json
 
-trace $CLI bundle destroy --auto-approve
+destroy-bundle
 print_requests.py //permissions > out.requests.destroy.$DATABRICKS_BUNDLE_ENGINE.json

--- a/acceptance/bundle/resources/permissions/genie_spaces/out_of_band_deletion/script
+++ b/acceptance/bundle/resources/permissions/genie_spaces/out_of_band_deletion/script
@@ -1,5 +1,5 @@
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/resources/permissions/jobs/update/script
+++ b/acceptance/bundle/resources/permissions/jobs/update/script
@@ -48,6 +48,6 @@ trace $CLI bundle plan -o json > out.plan_set_empty.$DATABRICKS_BUNDLE_ENGINE.js
 trace $CLI bundle deploy
 trace print_requests.py //jobs/ > out.requests_set_empty.$DATABRICKS_BUNDLE_ENGINE.json
 
-trace $CLI bundle destroy --auto-approve
+destroy-bundle
 trace print_requests.py //jobs/ > out.requests_destroy.$DATABRICKS_BUNDLE_ENGINE.json
 #rm -fr .databricks

--- a/acceptance/bundle/resources/permissions/models/current_can_manage/script
+++ b/acceptance/bundle/resources/permissions/models/current_can_manage/script
@@ -13,5 +13,5 @@ add_repl "$MODEL_ID" "FOO_MODEL_ID"
 
 print_requests.py //permissions > out.requests.deploy.$DATABRICKS_BUNDLE_ENGINE.json
 
-trace $CLI bundle destroy --auto-approve
+destroy-bundle
 print_requests.py //permissions > out.requests.destroy.$DATABRICKS_BUNDLE_ENGINE.json

--- a/acceptance/bundle/resources/permissions/pipelines/update/script
+++ b/acceptance/bundle/resources/permissions/pipelines/update/script
@@ -38,5 +38,5 @@ trace $CLI bundle deploy
 trace print_requests.py //pipeline > out.requests_restore_original.json
 trace $CLI bundle plan
 
-trace $CLI bundle destroy --auto-approve
+destroy-bundle
 print_requests.py //pipeline > out.requests_destroy.json

--- a/acceptance/bundle/resources/permissions/target_permissions/script
+++ b/acceptance/bundle/resources/permissions/target_permissions/script
@@ -3,5 +3,5 @@ $CLI bundle plan -o json > out.plan.$DATABRICKS_BUNDLE_ENGINE.json
 trace $CLI bundle deploy
 print_requests.py //jobs/ > out.requests_create.$DATABRICKS_BUNDLE_ENGINE.json
 
-trace $CLI bundle destroy --auto-approve
+destroy-bundle
 print_requests.py //jobs/ > out.requests_delete.$DATABRICKS_BUNDLE_ENGINE.json

--- a/acceptance/bundle/resources/pipelines/allow-duplicate-names/script
+++ b/acceptance/bundle/resources/pipelines/allow-duplicate-names/script
@@ -3,7 +3,7 @@ envsubst < pipeline.json.tmpl > pipeline.json
 touch foo.py
 
 cleanup() {
-  trace $CLI bundle destroy --auto-approve
+  destroy-bundle
   trace $CLI pipelines delete ${PIPELINE_ID}
   rm out.requests.txt
 }

--- a/acceptance/bundle/resources/pipelines/auto-approve/script
+++ b/acceptance/bundle/resources/pipelines/auto-approve/script
@@ -2,7 +2,7 @@ envsubst < databricks.yml.tmpl > databricks.yml
 envsubst < resources.yml.tmpl > resources.yml
 
 cleanup() {
-  trace $CLI bundle destroy --auto-approve
+  destroy-bundle
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/resources/pipelines/lakeflow-pipeline/script
+++ b/acceptance/bundle/resources/pipelines/lakeflow-pipeline/script
@@ -2,7 +2,7 @@ envsubst < databricks.yml.tmpl > databricks.yml
 trace $CLI bundle validate
 
 cleanup() {
-  trace $CLI bundle destroy --auto-approve
+  destroy-bundle
   rm out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/pipelines/recreate/script
+++ b/acceptance/bundle/resources/pipelines/recreate/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-  trace $CLI bundle destroy --auto-approve
+  destroy-bundle
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/resources/pipelines/update/script
+++ b/acceptance/bundle/resources/pipelines/update/script
@@ -25,7 +25,7 @@ trace $CLI pipelines get $ppid
 rm out.requests.txt
 
 title "Destroy the pipeline and verify that it's removed from the state and from remote"
-trace $CLI bundle destroy --auto-approve
+destroy-bundle
 
 trace print_requests
 trace musterr $CLI pipelines get $ppid

--- a/acceptance/bundle/resources/postgres_branches/basic/script
+++ b/acceptance/bundle/resources/postgres_branches/basic/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-   trace $CLI bundle destroy --auto-approve
+   destroy-bundle
    rm -f out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/postgres_branches/recreate/script
+++ b/acceptance/bundle/resources/postgres_branches/recreate/script
@@ -41,7 +41,7 @@ branch_id_2=`read_id.py main`
 $CLI postgres get-branch $branch_id_2 | branch_fields > out.get_branch.txt
 
 title "Destroy and verify cleanup"
-trace $CLI bundle destroy --auto-approve
+destroy-bundle
 
 print_requests.py --del-body parent,project_id,branch_id,endpoint_id,database_id,role_id,catalog_id,synced_table_id '//postgres' '^//workspace-files/' '^//workspace/' '^//telemetry-ext' '^//operations/' > out.requests.destroy.txt
 

--- a/acceptance/bundle/resources/postgres_branches/update_protected/script
+++ b/acceptance/bundle/resources/postgres_branches/update_protected/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-   trace $CLI bundle destroy --auto-approve
+   destroy-bundle
    rm -f out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/postgres_catalogs/basic/script
+++ b/acceptance/bundle/resources/postgres_catalogs/basic/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     rm -f out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/postgres_catalogs/recreate/script
+++ b/acceptance/bundle/resources/postgres_catalogs/recreate/script
@@ -1,5 +1,5 @@
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     rm -f out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/postgres_databases/basic/script
+++ b/acceptance/bundle/resources/postgres_databases/basic/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-   trace $CLI bundle destroy --auto-approve
+   destroy-bundle
    rm -f out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/postgres_databases/live_errors/bad_database_id/script
+++ b/acceptance/bundle/resources/postgres_databases/live_errors/bad_database_id/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-   trace $CLI bundle destroy --auto-approve
+   destroy-bundle
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/resources/postgres_databases/live_errors/bad_role_ref/script
+++ b/acceptance/bundle/resources/postgres_databases/live_errors/bad_role_ref/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-   trace $CLI bundle destroy --auto-approve
+   destroy-bundle
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/resources/postgres_databases/recreate/script
+++ b/acceptance/bundle/resources/postgres_databases/recreate/script
@@ -44,6 +44,6 @@ database_id_2=`read_id.py my_database`
 trace $CLI postgres get-database $database_id_2 | database_fields
 
 title "Destroy and verify cleanup"
-trace $CLI bundle destroy --auto-approve
+destroy-bundle
 
 trace print_requests.py --unique --del-body parent,project_id,branch_id,endpoint_id,database_id,role_id,catalog_id,synced_table_id '//postgres' '^//workspace-files/' '^//workspace/' '^//telemetry-ext' '^//operations/'

--- a/acceptance/bundle/resources/postgres_databases/replace_existing/script
+++ b/acceptance/bundle/resources/postgres_databases/replace_existing/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-   trace $CLI bundle destroy --auto-approve
+   destroy-bundle
    rm -f out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/postgres_databases/update/script
+++ b/acceptance/bundle/resources/postgres_databases/update/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-   trace $CLI bundle destroy --auto-approve
+   destroy-bundle
    rm -f out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/postgres_endpoints/basic/script
+++ b/acceptance/bundle/resources/postgres_endpoints/basic/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-   trace $CLI bundle destroy --auto-approve
+   destroy-bundle
    rm -f out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/postgres_endpoints/recreate/script
+++ b/acceptance/bundle/resources/postgres_endpoints/recreate/script
@@ -40,6 +40,6 @@ endpoint_id_2=`read_id.py my_endpoint`
 trace $CLI postgres get-endpoint $endpoint_id_2 | jq 'del(.create_time, .update_time)' | jq '.status.endpoint_type'
 
 title "Destroy and verify cleanup"
-trace $CLI bundle destroy --auto-approve
+destroy-bundle
 
 trace print_requests.py --unique --del-body parent,project_id,branch_id,endpoint_id,database_id,role_id,catalog_id,synced_table_id '//postgres' '^//workspace-files/' '^//workspace/' '^//telemetry-ext' '^//operations/'

--- a/acceptance/bundle/resources/postgres_endpoints/update_autoscaling/script
+++ b/acceptance/bundle/resources/postgres_endpoints/update_autoscaling/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-   trace $CLI bundle destroy --auto-approve
+   destroy-bundle
    rm -f out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/postgres_projects/basic/script
+++ b/acceptance/bundle/resources/postgres_projects/basic/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-   trace $CLI bundle destroy --auto-approve
+   destroy-bundle
    rm -f out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/postgres_projects/recreate/script
+++ b/acceptance/bundle/resources/postgres_projects/recreate/script
@@ -41,7 +41,7 @@ project_id_2=`read_id.py my_project`
 $CLI postgres get-project $project_id_2 | project_fields > out.get_project.txt
 
 title "Destroy and verify cleanup"
-trace $CLI bundle destroy --auto-approve
+destroy-bundle
 
 print_requests.py --del-body parent,project_id,branch_id,endpoint_id,database_id,role_id,catalog_id,synced_table_id '//postgres' '^//workspace-files/' '^//workspace/' '^//telemetry-ext' '^//operations/' > out.requests.destroy.txt
 

--- a/acceptance/bundle/resources/postgres_projects/update_display_name/script
+++ b/acceptance/bundle/resources/postgres_projects/update_display_name/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-   trace $CLI bundle destroy --auto-approve
+   destroy-bundle
    rm -f out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/postgres_roles/basic/script
+++ b/acceptance/bundle/resources/postgres_roles/basic/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-   trace $CLI bundle destroy --auto-approve
+   destroy-bundle
    rm -f out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/postgres_roles/inherited-role-bind/script
+++ b/acceptance/bundle/resources/postgres_roles/inherited-role-bind/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-   trace $CLI bundle destroy --auto-approve
+   destroy-bundle
    rm -f out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/postgres_roles/inherited-role-conflict/script
+++ b/acceptance/bundle/resources/postgres_roles/inherited-role-conflict/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-   trace $CLI bundle destroy --auto-approve
+   destroy-bundle
    rm -f out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/postgres_roles/recreate-postgres-role/script
+++ b/acceptance/bundle/resources/postgres_roles/recreate-postgres-role/script
@@ -35,6 +35,6 @@ role_name=`read_id.py my_role`
 trace $CLI postgres get-role $role_name | role_fields
 
 title "Destroy and verify cleanup"
-trace $CLI bundle destroy --auto-approve
+destroy-bundle
 
 trace print_requests.py --unique --del-body parent,project_id,branch_id,endpoint_id,database_id,role_id,catalog_id,synced_table_id '//postgres' '^//workspace-files/' '^//workspace/' '^//telemetry-ext' '^//operations/'

--- a/acceptance/bundle/resources/postgres_roles/recreate/script
+++ b/acceptance/bundle/resources/postgres_roles/recreate/script
@@ -37,6 +37,6 @@ role_id_2=`read_id.py my_role`
 trace $CLI postgres get-role $role_id_2 | role_fields
 
 title "Destroy and verify cleanup"
-trace $CLI bundle destroy --auto-approve
+destroy-bundle
 
 trace print_requests.py --unique --del-body parent,project_id,branch_id,endpoint_id,database_id,role_id,catalog_id,synced_table_id '//postgres' '^//workspace-files/' '^//workspace/' '^//telemetry-ext' '^//operations/'

--- a/acceptance/bundle/resources/postgres_roles/replace_existing/script
+++ b/acceptance/bundle/resources/postgres_roles/replace_existing/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-   trace $CLI bundle destroy --auto-approve
+   destroy-bundle
    rm -f out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/postgres_roles/update/script
+++ b/acceptance/bundle/resources/postgres_roles/update/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-   trace $CLI bundle destroy --auto-approve
+   destroy-bundle
    rm -f out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/postgres_synced_tables/basic/script
+++ b/acceptance/bundle/resources/postgres_synced_tables/basic/script
@@ -12,7 +12,7 @@ MSYS_NO_PATHCONV=1 $CLI api post "/api/2.0/sql/statements/" --json "{
   }" > /dev/null
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     echo "Cleaning up temporary source table"
     $CLI tables delete main.source_$UNIQUE_NAME.trips_source || true
     $CLI schemas delete main.source_$UNIQUE_NAME || true

--- a/acceptance/bundle/resources/postgres_synced_tables/recreate/script
+++ b/acceptance/bundle/resources/postgres_synced_tables/recreate/script
@@ -8,7 +8,7 @@ MSYS_NO_PATHCONV=1 $CLI api post "/api/2.0/sql/statements/" --json "{
   }" > /dev/null
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     echo "Cleaning up temporary source table"
     $CLI tables delete main.source_$UNIQUE_NAME.trips_source || true
     $CLI schemas delete main.source_$UNIQUE_NAME || true

--- a/acceptance/bundle/resources/quality_monitors/change_assets_dir/script
+++ b/acceptance/bundle/resources/quality_monitors/change_assets_dir/script
@@ -6,7 +6,7 @@ trace $CLI schemas create "qm_test_${UNIQUE_NAME}_2" main -o json | jq '{full_na
 trace create_table.py "$TABLE_NAME"
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     $CLI schemas delete "$SCHEMA_NAME" --force 2>/dev/null || true
     $CLI schemas delete "qm_test_${UNIQUE_NAME}_2" --force 2>/dev/null || true
     rm -f out.requests.txt

--- a/acceptance/bundle/resources/quality_monitors/change_output_schema_name/script
+++ b/acceptance/bundle/resources/quality_monitors/change_output_schema_name/script
@@ -6,7 +6,7 @@ trace $CLI schemas create "qm_test_${UNIQUE_NAME}_2" main -o json | jq '{full_na
 trace create_table.py "$TABLE_NAME"
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     $CLI schemas delete "$SCHEMA_NAME" --force 2>/dev/null || true
     $CLI schemas delete "qm_test_${UNIQUE_NAME}_2" --force 2>/dev/null || true
     rm -f out.requests.txt

--- a/acceptance/bundle/resources/quality_monitors/change_table_name/script
+++ b/acceptance/bundle/resources/quality_monitors/change_table_name/script
@@ -6,7 +6,7 @@ trace create_table.py "$TABLE_NAME"
 trace create_table.py "${TABLE_NAME}_2"
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     $CLI schemas delete "$SCHEMA_NAME" --force 2>/dev/null || true
     $CLI schemas delete "qm_test_${UNIQUE_NAME}_2" --force 2>/dev/null || true
     rm -f out.requests.txt

--- a/acceptance/bundle/resources/quality_monitors/create/script
+++ b/acceptance/bundle/resources/quality_monitors/create/script
@@ -7,7 +7,7 @@ trace $CLI schemas create "qm_test_${UNIQUE_NAME}_2" main -o json | jq '{full_na
 trace create_table.py "$TABLE_NAME"
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     # Clean up schemas and table (suppress errors since they may already be gone)
     $CLI schemas delete "$SCHEMA_NAME" --force 2>/dev/null || true
     $CLI schemas delete "qm_test_${UNIQUE_NAME}_2" --force 2>/dev/null || true

--- a/acceptance/bundle/resources/registered_models/aliases_converge/script
+++ b/acceptance/bundle/resources/registered_models/aliases_converge/script
@@ -4,7 +4,7 @@ trace export COMMENT="original comment"
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/resources/registered_models/basic/script
+++ b/acceptance/bundle/resources/registered_models/basic/script
@@ -11,7 +11,7 @@ trace $CLI catalogs create ${catalog_name} | jq '{full_name}'
 trace $CLI schemas create ${schema_name} ${catalog_name} | jq '{full_name}'
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     trace $CLI schemas delete ${catalog_name}.${schema_name} --force
     trace $CLI catalogs delete ${catalog_name} --force
 }

--- a/acceptance/bundle/resources/schemas/auto-approve/script
+++ b/acceptance/bundle/resources/schemas/auto-approve/script
@@ -7,7 +7,7 @@ VOLUME_NAME="test-volume-${UNIQUE_NAME}"
 
 cleanup() {
   title "Test cleanup"
-  trace $CLI bundle destroy --auto-approve
+  destroy-bundle
 
   title "Assert the schema is deleted"
   trace errcode $CLI schemas get "${CATALOG_NAME}.${SCHEMA_NAME}" 2>/dev/null

--- a/acceptance/bundle/resources/secret_scopes/basic/script
+++ b/acceptance/bundle/resources/secret_scopes/basic/script
@@ -3,7 +3,7 @@ export SECRET_SCOPE_NAME="test-scope-$UNIQUE_NAME-1"
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     rm out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/secret_scopes/delete_scope/script
+++ b/acceptance/bundle/resources/secret_scopes/delete_scope/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     rm out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/secret_scopes/permissions-collapse/script
+++ b/acceptance/bundle/resources/secret_scopes/permissions-collapse/script
@@ -3,7 +3,7 @@ export SECRET_SCOPE_NAME="test-scope-collapse-$UNIQUE_NAME"
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/resources/secret_scopes/permissions/script
+++ b/acceptance/bundle/resources/secret_scopes/permissions/script
@@ -31,7 +31,7 @@ EOF
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/resources/sql_warehouses/lifecycle-started-edit/script
+++ b/acceptance/bundle/resources/sql_warehouses/lifecycle-started-edit/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     rm -f out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/sql_warehouses/lifecycle-started-toggle/script
+++ b/acceptance/bundle/resources/sql_warehouses/lifecycle-started-toggle/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     rm -f out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/sql_warehouses/lifecycle-started/script
+++ b/acceptance/bundle/resources/sql_warehouses/lifecycle-started/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     rm -f out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/sql_warehouses/script
+++ b/acceptance/bundle/resources/sql_warehouses/script
@@ -25,7 +25,7 @@ trace jq 'select(.method == "POST" and (.path | contains("/sql/warehouses")) and
 trace $CLI bundle summary
 
 title "Destroy the warehouse"
-trace $CLI bundle destroy --auto-approve
+destroy-bundle
 
 title "Verify the destroy request"
 trace jq 'select(.method == "DELETE" and (.path | contains("/sql/warehouses")))' out.requests.txt

--- a/acceptance/bundle/resources/synced_database_tables/basic/script
+++ b/acceptance/bundle/resources/synced_database_tables/basic/script
@@ -13,7 +13,7 @@ MSYS_NO_PATHCONV=1 $CLI api post "/api/2.0/sql/statements/" --json "{
   }" > /dev/null
 
 cleanup() {
-  trace $CLI bundle destroy --auto-approve
+  destroy-bundle
   # Clean up the temporary source table
   echo "Cleaning up temporary source table"
   $CLI tables delete main.test_synced_$UNIQUE_NAME.trips_source || true

--- a/acceptance/bundle/resources/synced_database_tables/recreate/script
+++ b/acceptance/bundle/resources/synced_database_tables/recreate/script
@@ -1,5 +1,5 @@
 cleanup() {
-   trace $CLI bundle destroy --auto-approve
+   destroy-bundle
    rm -f out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/vector_search_endpoints/basic/script
+++ b/acceptance/bundle/resources/vector_search_endpoints/basic/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     rm -f out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/vector_search_endpoints/drift/budget_policy/script
+++ b/acceptance/bundle/resources/vector_search_endpoints/drift/budget_policy/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     rm -f out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/vector_search_endpoints/drift/recreated_same_name/script
+++ b/acceptance/bundle/resources/vector_search_endpoints/drift/recreated_same_name/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     rm -f out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/vector_search_endpoints/drift/target_qps/script
+++ b/acceptance/bundle/resources/vector_search_endpoints/drift/target_qps/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     rm -f out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/vector_search_endpoints/recreate/endpoint_type/script
+++ b/acceptance/bundle/resources/vector_search_endpoints/recreate/endpoint_type/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     rm -f out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/vector_search_endpoints/update/budget_policy/script
+++ b/acceptance/bundle/resources/vector_search_endpoints/update/budget_policy/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     rm -f out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/vector_search_endpoints/update/target_qps/script
+++ b/acceptance/bundle/resources/vector_search_endpoints/update/target_qps/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     rm -f out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/vector_search_indexes/basic/script
+++ b/acceptance/bundle/resources/vector_search_indexes/basic/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     rm -f out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/vector_search_indexes/drift/deleted_remotely/script
+++ b/acceptance/bundle/resources/vector_search_indexes/drift/deleted_remotely/script
@@ -2,7 +2,7 @@ envsubst < databricks.yml.tmpl > databricks.yml
 index_name="main.default.vs_index_${UNIQUE_NAME}"
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     rm -f out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/vector_search_indexes/drift/orphaned_endpoint/script
+++ b/acceptance/bundle/resources/vector_search_indexes/drift/orphaned_endpoint/script
@@ -3,7 +3,7 @@ endpoint_name="vs-endpoint-${UNIQUE_NAME}"
 index_name="main.default.vs_index_${UNIQUE_NAME}"
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     rm -f out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/vector_search_indexes/grants/select/script
+++ b/acceptance/bundle/resources/vector_search_indexes/grants/select/script
@@ -2,7 +2,7 @@ envsubst < databricks.yml.tmpl > databricks.yml
 index_name="main.default.vs_index_${UNIQUE_NAME}"
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     rm -f out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/vector_search_indexes/recreate/embedding_dimension/script
+++ b/acceptance/bundle/resources/vector_search_indexes/recreate/embedding_dimension/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     rm -f out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/vector_search_indexes/recreate/pending_deletion/script
+++ b/acceptance/bundle/resources/vector_search_indexes/recreate/pending_deletion/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     rm -f out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/vector_search_indexes/recreate/with_endpoint/script
+++ b/acceptance/bundle/resources/vector_search_indexes/recreate/with_endpoint/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     rm -f out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/vector_search_indexes/schema_normalization/script
+++ b/acceptance/bundle/resources/vector_search_indexes/schema_normalization/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     rm -f out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/volumes/change-comment/script
+++ b/acceptance/bundle/resources/volumes/change-comment/script
@@ -27,7 +27,7 @@ trace print_requests.py //unity
 title "Verify updated deployment: should show new comment"
 trace $CLI volumes read main.myschema.myvolume | jq .comment
 
-trace $CLI bundle destroy --auto-approve
+destroy-bundle
 trace print_requests.py //unity
 
 trace musterr $CLI volumes read main.myschema.myvolume

--- a/acceptance/bundle/resources/volumes/recreate/script
+++ b/acceptance/bundle/resources/volumes/recreate/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/resources/volumes/set-storage-location/script
+++ b/acceptance/bundle/resources/volumes/set-storage-location/script
@@ -1,5 +1,5 @@
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     trace print_requests.py //unity
 }
 

--- a/acceptance/bundle/run/app-with-job/script
+++ b/acceptance/bundle/run/app-with-job/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     rm out.app-run
 }
 trap cleanup EXIT

--- a/acceptance/bundle/run_as/job_default/script
+++ b/acceptance/bundle/run_as/job_default/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     rm -f out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/select/basic/script
+++ b/acceptance/bundle/select/basic/script
@@ -2,7 +2,7 @@ envsubst '$UNIQUE_NAME' < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
     title "Destroy"
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     rm -f out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/select/grants_permissions/script
+++ b/acceptance/bundle/select/grants_permissions/script
@@ -2,7 +2,7 @@ envsubst '$UNIQUE_NAME' < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
     title "Destroy"
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
     rm -f out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/select/plan_file_survives_not_selected/script
+++ b/acceptance/bundle/select/plan_file_survives_not_selected/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    trace $CLI bundle destroy --auto-approve
+    destroy-bundle
 }
 trap cleanup EXIT
 

--- a/acceptance/bundle/summary/modified_status/script
+++ b/acceptance/bundle/summary/modified_status/script
@@ -10,5 +10,5 @@ mv $VARIANT databricks.yml
 title "Expecting all resources to have modified_status=deleted"
 trace $CLI bundle summary -o json | jq .resources
 
-trace $CLI bundle destroy --auto-approve
+destroy-bundle
 trace $CLI bundle summary -o json | jq .resources

--- a/acceptance/bundle/user_agent/simple/script
+++ b/acceptance/bundle/user_agent/simple/script
@@ -16,5 +16,5 @@ trace print_requests.py --sort --get > out.requests.plan2.$DATABRICKS_BUNDLE_ENG
 musterr trace $CLI bundle run foo
 trace print_requests.py --sort --get > out.requests.run.$DATABRICKS_BUNDLE_ENGINE.json
 
-trace $CLI bundle destroy --auto-approve
+destroy-bundle
 trace print_requests.py --sort --get > out.requests.destroy.$DATABRICKS_BUNDLE_ENGINE.json

--- a/acceptance/script.prepare
+++ b/acceptance/script.prepare
@@ -187,7 +187,7 @@ destroy-bundle() {
     local exit_code=0
     trace $CLI bundle destroy --auto-approve "$@" || exit_code=$?
 
-    # root_path is configurable, so only the ~/.bundle/<name>/<target> layout is ours.
+    # Only ever clean up directories under .bundle.
     if [[ -n "$bundle_dir" && "$(basename "$(dirname "$bundle_dir")")" == ".bundle" ]]; then
         $CLI workspace delete "$bundle_dir" --recursive >>LOG.destroy-bundle 2>&1 || true
     fi

--- a/acceptance/script.prepare
+++ b/acceptance/script.prepare
@@ -166,6 +166,35 @@ as-test-sp() {
     "$@"
 }
 
+# destroy-bundle destroys the bundle and then removes the ~/.bundle/<name> directory it
+# was deployed under, so a destroy that only partially succeeded does not leave the tree
+# behind. Test bundle names are unique per run, so nothing ever reuses a leftover
+# directory and they pile up against the shared CI workspace's child-node limit.
+#
+# The `bundle destroy` invocation is traced exactly as a direct call would be, so
+# switching a test to this helper does not change its output. The extra cleanup runs only
+# against a real workspace and is best effort: it must never turn a passing test red.
+destroy-bundle() {
+    local bundle_dir=""
+    if [[ -n "$CLOUD_ENV" ]]; then
+        local root_path
+        root_path=$($CLI bundle validate -o json 2>>LOG.destroy-bundle | jq -r '.workspace.root_path // empty')
+        if [[ -n "$root_path" ]]; then
+            bundle_dir=$(dirname "$root_path")
+        fi
+    fi
+
+    local exit_code=0
+    trace $CLI bundle destroy --auto-approve "$@" || exit_code=$?
+
+    # root_path is configurable, so only the ~/.bundle/<name>/<target> layout is ours.
+    if [[ -n "$bundle_dir" && "$(basename "$(dirname "$bundle_dir")")" == ".bundle" ]]; then
+        $CLI workspace delete "$bundle_dir" --recursive >>LOG.destroy-bundle 2>&1 || true
+    fi
+
+    return $exit_code
+}
+
 readplanarg() {
     # Expands into "--plan <filename>" based on READPLAN env var
     # Use it with "bundle deploy" to configure two runs: once with saved plan and one without.


### PR DESCRIPTION
## Why

As we run more tests and create more PRs we are causing the production DB for webapp to slow down because of the number of treenodes. This PR adds a best-effort cleanup step that was added to existing tests to lower the amount of folder treenodes we end up with over a day.

The cleanup nightly job still handles the final cleanup and actually pruning all nodes after a day.