### PR TITLE
acc: Reproduce that file syncs are done despite failed resource deployments

### DIFF
--- a/acceptance/bundle/deploy/files/move-during-failed-deploy/databricks.yml
+++ b/acceptance/bundle/deploy/files/move-during-failed-deploy/databricks.yml
@@ -1,0 +1,15 @@
+bundle:
+  name: move-during-failed-deploy
+
+resources:
+  jobs:
+    foo:
+      name: test-job
+      tasks:
+        - task_key: my_task
+          spark_python_task:
+            python_file: ./src/main.py
+          new_cluster:
+            num_workers: 1
+            spark_version: 13.3.x-scala2.12
+            node_type_id: i3.xlarge

--- a/acceptance/bundle/deploy/files/move-during-failed-deploy/out.test.toml
+++ b/acceptance/bundle/deploy/files/move-during-failed-deploy/out.test.toml
@@ -1,0 +1,2 @@
+Cloud = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/deploy/files/move-during-failed-deploy/output.txt
+++ b/acceptance/bundle/deploy/files/move-during-failed-deploy/output.txt
@@ -6,7 +6,7 @@ Created jobs.foo
 Files: 5 uploaded, 0 deleted
 Resources: 1 created, 0 changed, 0 deleted, 0 unchanged
 
->>> [CLI] workspace get-status /Workspace/Users/[USERNAME]/.bundle/move-during-failed-deploy/default/files/src/main.py
+>>> MSYS_NO_PATHCONV=1 [CLI] workspace get-status /Workspace/Users/[USERNAME]/.bundle/move-during-failed-deploy/default/files/src/main.py
 {
   "object_type": "FILE",
   "path": "/Workspace/Users/[USERNAME]/.bundle/move-during-failed-deploy/default/files/src/main.py"
@@ -31,11 +31,11 @@ API message: Fault injected by test.
 Files: 3 uploaded, 1 deleted
 
 === Broken state: the failed deploy already deleted the old file from the workspace
->>> musterr [CLI] workspace get-status /Workspace/Users/[USERNAME]/.bundle/move-during-failed-deploy/default/files/src/main.py
+>>> MSYS_NO_PATHCONV=1 musterr [CLI] workspace get-status /Workspace/Users/[USERNAME]/.bundle/move-during-failed-deploy/default/files/src/main.py
 Error: Path (/Workspace/Users/[USERNAME]/.bundle/move-during-failed-deploy/default/files/src/main.py) doesn't exist.
 
 === The new file was uploaded
->>> [CLI] workspace get-status /Workspace/Users/[USERNAME]/.bundle/move-during-failed-deploy/default/files/src/renamed.py
+>>> MSYS_NO_PATHCONV=1 [CLI] workspace get-status /Workspace/Users/[USERNAME]/.bundle/move-during-failed-deploy/default/files/src/renamed.py
 {
   "object_type": "FILE",
   "path": "/Workspace/Users/[USERNAME]/.bundle/move-during-failed-deploy/default/files/src/renamed.py"

--- a/acceptance/bundle/deploy/files/move-during-failed-deploy/output.txt
+++ b/acceptance/bundle/deploy/files/move-during-failed-deploy/output.txt
@@ -1,0 +1,46 @@
+
+=== Deploy 1: the job references src/main.py, which is uploaded to the workspace
+>>> [CLI] bundle deploy
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/move-during-failed-deploy/default/files...
+Created jobs.foo
+Files: 5 uploaded, 0 deleted
+Resources: 1 created, 0 changed, 0 deleted, 0 unchanged
+
+>>> [CLI] workspace get-status /Workspace/Users/[USERNAME]/.bundle/move-during-failed-deploy/default/files/src/main.py
+{
+  "object_type": "FILE",
+  "path": "/Workspace/Users/[USERNAME]/.bundle/move-during-failed-deploy/default/files/src/main.py"
+}
+
+=== Move the referenced file and point the job at the new location
+>>> mv src/main.py src/renamed.py
+
+>>> update_file.py databricks.yml src/main.py src/renamed.py
+
+=== Fail the job update. Files are still synced first, so main.py is deleted and
+renamed.py uploaded before the failing jobs/reset.
+>>> musterr [CLI] bundle deploy
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/move-during-failed-deploy/default/files...
+Error: cannot update resources.jobs.foo: updating id=[FOO_ID]: Fault injected by test. (403 INJECTED)
+
+Endpoint: POST [DATABRICKS_URL]/api/2.2/jobs/reset
+HTTP Status: 403 Forbidden
+API error_code: INJECTED
+API message: Fault injected by test.
+
+Files: 3 uploaded, 1 deleted
+
+=== Broken state: the failed deploy already deleted the old file from the workspace
+>>> musterr [CLI] workspace get-status /Workspace/Users/[USERNAME]/.bundle/move-during-failed-deploy/default/files/src/main.py
+Error: Path (/Workspace/Users/[USERNAME]/.bundle/move-during-failed-deploy/default/files/src/main.py) doesn't exist.
+
+=== The new file was uploaded
+>>> [CLI] workspace get-status /Workspace/Users/[USERNAME]/.bundle/move-during-failed-deploy/default/files/src/renamed.py
+{
+  "object_type": "FILE",
+  "path": "/Workspace/Users/[USERNAME]/.bundle/move-during-failed-deploy/default/files/src/renamed.py"
+}
+
+=== But the deployed job still points at the deleted file, so a run fails file-not-found
+>>> [CLI] jobs get [FOO_ID]
+"/Workspace/Users/[USERNAME]/.bundle/move-during-failed-deploy/default/files/src/main.py"

--- a/acceptance/bundle/deploy/files/move-during-failed-deploy/script
+++ b/acceptance/bundle/deploy/files/move-during-failed-deploy/script
@@ -1,0 +1,23 @@
+BUNDLE_FILES="/Workspace/Users/${CURRENT_USER_NAME}/.bundle/move-during-failed-deploy/default/files"
+
+title "Deploy 1: the job references src/main.py, which is uploaded to the workspace"
+trace $CLI bundle deploy
+trace $CLI workspace get-status "$BUNDLE_FILES/src/main.py" | jq '{object_type,path}'
+
+title "Move the referenced file and point the job at the new location"
+trace mv src/main.py src/renamed.py
+trace update_file.py databricks.yml src/main.py src/renamed.py
+
+title "Fail the job update. Files are still synced first, so main.py is deleted and\nrenamed.py uploaded before the failing jobs/reset."
+fault.py "POST /api/2.2/jobs/reset" 403 0 1
+trace musterr $CLI bundle deploy
+
+title "Broken state: the failed deploy already deleted the old file from the workspace"
+trace musterr $CLI workspace get-status "$BUNDLE_FILES/src/main.py"
+
+title "The new file was uploaded"
+trace $CLI workspace get-status "$BUNDLE_FILES/src/renamed.py" | jq '{object_type,path}'
+
+title "But the deployed job still points at the deleted file, so a run fails file-not-found"
+job_id=$(read_id.py foo)
+trace $CLI jobs get "$job_id" | jq '.settings.tasks[0].spark_python_task.python_file'

--- a/acceptance/bundle/deploy/files/move-during-failed-deploy/script
+++ b/acceptance/bundle/deploy/files/move-during-failed-deploy/script
@@ -2,7 +2,10 @@ BUNDLE_FILES="/Workspace/Users/${CURRENT_USER_NAME}/.bundle/move-during-failed-d
 
 title "Deploy 1: the job references src/main.py, which is uploaded to the workspace"
 trace $CLI bundle deploy
-trace $CLI workspace get-status "$BUNDLE_FILES/src/main.py" | jq '{object_type,path}'
+# MSYS_NO_PATHCONV=1 keeps Git Bash from rewriting the leading-slash workspace path
+# into a Windows path before the CLI sees it. Scoped per-command so it does not also
+# break the shebang-resolved .py helpers (update_file.py, read_id.py) on Windows.
+trace MSYS_NO_PATHCONV=1 $CLI workspace get-status "$BUNDLE_FILES/src/main.py" | jq '{object_type,path}'
 
 title "Move the referenced file and point the job at the new location"
 trace mv src/main.py src/renamed.py
@@ -13,10 +16,10 @@ fault.py "POST /api/2.2/jobs/reset" 403 0 1
 trace musterr $CLI bundle deploy
 
 title "Broken state: the failed deploy already deleted the old file from the workspace"
-trace musterr $CLI workspace get-status "$BUNDLE_FILES/src/main.py"
+trace MSYS_NO_PATHCONV=1 musterr $CLI workspace get-status "$BUNDLE_FILES/src/main.py"
 
 title "The new file was uploaded"
-trace $CLI workspace get-status "$BUNDLE_FILES/src/renamed.py" | jq '{object_type,path}'
+trace MSYS_NO_PATHCONV=1 $CLI workspace get-status "$BUNDLE_FILES/src/renamed.py" | jq '{object_type,path}'
 
 title "But the deployed job still points at the deleted file, so a run fails file-not-found"
 job_id=$(read_id.py foo)

--- a/acceptance/bundle/deploy/files/move-during-failed-deploy/src/main.py
+++ b/acceptance/bundle/deploy/files/move-during-failed-deploy/src/main.py
@@ -1,0 +1,1 @@
+print("hello")

--- a/acceptance/bundle/deploy/files/move-during-failed-deploy/test.toml
+++ b/acceptance/bundle/deploy/files/move-during-failed-deploy/test.toml
@@ -9,9 +9,3 @@ EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]
 # The script moves src/main.py to src/renamed.py, so the renamed file is not a
 # committed input and would otherwise be flagged as an unexpected leftover.
 Ignore = ["src/renamed.py"]
-
-[Env]
-# The script passes absolute workspace paths like /Workspace/Users/.../src/main.py as
-# CLI arguments. On Windows the script runs under MSYS2, which rewrites such
-# leading-slash arguments to Windows paths before the CLI sees them. Disable that.
-MSYS_NO_PATHCONV = "1"

--- a/acceptance/bundle/deploy/files/move-during-failed-deploy/test.toml
+++ b/acceptance/bundle/deploy/files/move-during-failed-deploy/test.toml
@@ -1,0 +1,17 @@
+Badness = "A deploy uploads and deletes bundle files before it applies resources, so a resource-update failure after a file move leaves the job pointing at a file that no longer exists in the workspace."
+
+# The injected fault (POST /api/2.2/jobs/reset) and the state inspection differ in
+# output between the terraform and direct engines, so pin the direct engine (same
+# precedent as ../partial-summary-on-push-fail). The ordering bug being demonstrated
+# is engine-independent: files.Upload runs before deployCore for both engines.
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]
+
+# The script moves src/main.py to src/renamed.py, so the renamed file is not a
+# committed input and would otherwise be flagged as an unexpected leftover.
+Ignore = ["src/renamed.py"]
+
+[Env]
+# The script passes absolute workspace paths like /Workspace/Users/.../src/main.py as
+# CLI arguments. On Windows the script runs under MSYS2, which rewrites such
+# leading-slash arguments to Windows paths before the CLI sees them. Disable that.
+MSYS_NO_PATHCONV = "1"


### PR DESCRIPTION
## Changes

Reproduce (via an acceptance test) that file syncs happen at the start of a deployment.

In this case, we inject a failure into the resource deployment and observe that a file move operation takes effect regardless of deployment success.

## Why

Discovered this behaviour during an investigation on job file deploy-time race condition.

Ideally, file deletion happens **after** the deployment finishes (and conditional on success)
