### PR TITLE
apps: stop planning an update on every deploy

### DIFF
--- a/.nextchanges/bundles/apps-forward-user-access-token-drift.md
+++ b/.nextchanges/bundles/apps-forward-user-access-token-drift.md
@@ -1,1 +1,0 @@
-Fixed apps planning an update on every deploy. The backend enables `forward_user_access_token` and reports it as `true` even when the bundle omits it, which the direct engine read as drift and turned into a no-op update call on each deploy ([#6328](https://github.com/databricks/cli/pull/6328)).

--- a/.nextchanges/bundles/apps-forward-user-access-token-drift.md
+++ b/.nextchanges/bundles/apps-forward-user-access-token-drift.md
@@ -1,1 +1,1 @@
-Fixed apps planning an update on every deploy. The backend enables `forward_user_access_token` and reports it as `true` even when the bundle omits it, which the direct engine read as drift and turned into a no-op update call on each deploy.
+Fixed apps planning an update on every deploy. The backend enables `forward_user_access_token` and reports it as `true` even when the bundle omits it, which the direct engine read as drift and turned into a no-op update call on each deploy ([#6328](https://github.com/databricks/cli/pull/6328)).

--- a/.nextchanges/bundles/apps-forward-user-access-token-drift.md
+++ b/.nextchanges/bundles/apps-forward-user-access-token-drift.md
@@ -1,0 +1,1 @@
+Fixed apps planning an update on every deploy. The backend enables `forward_user_access_token` and reports it as `true` even when the bundle omits it, which the direct engine read as drift and turned into a no-op update call on each deploy.

--- a/acceptance/bundle/generate/app_not_yet_deployed/output.txt
+++ b/acceptance/bundle/generate/app_not_yet_deployed/output.txt
@@ -10,6 +10,7 @@
     "message": "App compute is stopped.",
     "state": "STOPPED"
   },
+  "forward_user_access_token": true,
   "id": "1000",
   "name": "my-app",
   "service_principal_client_id": "[UUID]",

--- a/acceptance/bundle/resources/apps/create_already_exists/output.txt
+++ b/acceptance/bundle/resources/apps/create_already_exists/output.txt
@@ -19,6 +19,7 @@
     "state": "ACTIVE"
   },
   "default_source_code_path": "/Workspace/Users/[USERNAME]/test-app-already-exists",
+  "forward_user_access_token": true,
   "id": "1000",
   "name": "test-app-already-exists",
   "service_principal_client_id": "[UUID]",

--- a/acceptance/cmd/workspace/apps/output.txt
+++ b/acceptance/cmd/workspace/apps/output.txt
@@ -21,6 +21,7 @@
   },
   "default_source_code_path": "/Workspace/Users/[USERNAME]/test-name",
   "description": "My app description.",
+  "forward_user_access_token": true,
   "id": "1000",
   "name": "test-name",
   "resources": [
@@ -62,6 +63,7 @@
   },
   "default_source_code_path": "/Workspace/Users/[USERNAME]/test-name",
   "description": "My app description.",
+  "forward_user_access_token": true,
   "id": "1001",
   "name": "test-name",
   "resources": [

--- a/bundle/direct/dresources/resources.yml
+++ b/bundle/direct/dresources/resources.yml
@@ -555,6 +555,10 @@ resources:
     backend_defaults:
       # Backend sets it "MEDIUM" when not specified in the config
       - field: compute_size
+      # Backend enables token forwarding and reports true even when the config omits it,
+      # so an omitted field would otherwise plan an update on every deploy. An explicit
+      # value in the config still diffs normally.
+      - field: forward_user_access_token
       # lifecycle.started is derived from remote compute status in RemapState, so the
       # remote side always has a value. When the user omits lifecycle from config,
       # both old and new are nil and backend_defaults correctly skips the remote value.

--- a/libs/testserver/apps.go
+++ b/libs/testserver/apps.go
@@ -329,6 +329,10 @@ func (s *FakeWorkspace) AppsUpsert(req Request, name string) Response {
 		app.ComputeSize = "MEDIUM"
 	}
 
+	// The platform enables user access token forwarding regardless of what the
+	// request asked for, so the remote always reports true.
+	app.ForwardUserAccessToken = true
+
 	// Assign a service principal to the app, mimicking the real platform.
 	if app.ServicePrincipalClientId == "" {
 		app.ServicePrincipalClientId = nextUUID()


### PR DESCRIPTION
## Changes

The direct engine planned an Apps update on every deploy, so each `bundle deploy` issued a no-op `Apps.CreateUpdate` call. Every plan looked like this, with a remote value and no local one:

```json
"forward_user_access_token": { "action": "update", "remote": true }
```

`forward_user_access_token` became part of `apps.App` in databricks-sdk-go v0.171.0 (#6320) and was added to the app update mask, but nothing classified it. The backend enables token forwarding and reports it as `true` even when the bundle omits the field, so the remote `true` read as drift, `hasAppChanges` returned true, and the update fired.

Declared under `backend_defaults`, exactly like `compute_size`: the remote value is skipped when the config omits the field, while an explicit value in the config still diffs normally (so real drift is still caught).
