### PR TITLE
Revert "Bump Go toolchain to go1.26.7 (#6325)"

### DIFF
--- a/.nextchanges/dependency-updates/go-toolchain-go1.26.7.md
+++ b/.nextchanges/dependency-updates/go-toolchain-go1.26.7.md
@@ -1,1 +1,0 @@
-Bump Go toolchain to 1.26.7 ([#6325](https://github.com/databricks/cli/pull/6325)).

--- a/bundle/internal/tf/codegen/go.mod
+++ b/bundle/internal/tf/codegen/go.mod
@@ -2,7 +2,7 @@ module github.com/databricks/cli/bundle/internal/tf/codegen
 
 go 1.26.0
 
-toolchain go1.26.7
+toolchain go1.26.6
 
 require (
 	github.com/hashicorp/go-version v1.9.0

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/databricks/cli
 
 go 1.26.0
 
-toolchain go1.26.7
+toolchain go1.26.6
 
 require (
 	dario.cat/mergo v1.0.2 // BSD-3-Clause

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -2,7 +2,7 @@ module github.com/databricks/cli/tools
 
 go 1.26.0
 
-toolchain go1.26.7
+toolchain go1.26.6
 
 require github.com/stretchr/testify v1.11.1
 

--- a/tools/task/go.mod
+++ b/tools/task/go.mod
@@ -2,7 +2,7 @@ module github.com/databricks/cli/tools/task
 
 go 1.26.0
 
-toolchain go1.26.7
+toolchain go1.26.6
 
 require (
 	cel.dev/expr v0.25.1 // indirect


### PR DESCRIPTION
This reverts commit a34848758861d30676c15400200545069debc272.
