### PR TITLE
Drop non-local constraints before merging into the user's pyproject

### DIFF
--- a/acceptance/localenv/filter-nonlocal-constraints/out.test.toml
+++ b/acceptance/localenv/filter-nonlocal-constraints/out.test.toml
@@ -1,0 +1,2 @@
+Cloud = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/localenv/filter-nonlocal-constraints/output.txt
+++ b/acceptance/localenv/filter-nonlocal-constraints/output.txt
@@ -1,0 +1,55 @@
+
+>>> [CLI] environments setup-local --serverless-version 4 --dry-run --output json
+{
+  "schemaVersion": 1,
+  "command": "environments setup-local",
+  "ok": true,
+  "mode": "default",
+  "dryRun": true,
+  "compute": {
+    "source": "serverless",
+    "serverlessVersion": "v4",
+    "envKey": "serverless/serverless-v4"
+  },
+  "resolved": {
+    "pythonVersion": "3.12",
+    "dbconnectVersion": "17.2.0",
+    "artifactSource": "network"
+  },
+  "greenfield": false,
+  "plan": {
+    "wouldWrite": "[TEST_TMP_DIR]/pyproject.toml",
+    "wouldBackup": "[TEST_TMP_DIR]/pyproject.toml.bak",
+    "wouldInstallPython": "3.12",
+    "diff": "--- pyproject.toml\n+++ pyproject.toml.new\n@@ -1,3 +1,20 @@\n [project]\n name = \"demo\"\n requires-python = \"==3.12.*\"\n+\n+[dependency-groups]\n+dev = [\n+    \"databricks-connect~=17.2.0\",\n+]\n+\n+[tool.databricks.environment]\n+environment_version = \"4\"\n+\n+# managed by databricks environments setup-local — do not edit\n+[tool.uv]\n+constraint-dependencies = [\n+    \"numpy~=2.1.3\",\n+    \"torch~=2.7.0\",\n+    \"pyarrow~=21.0.0\",\n+]\n+# end managed by databricks environments setup-local\n"
+  },
+  "phases": [
+    {
+      "phase": "preflight",
+      "status": "ok"
+    },
+    {
+      "phase": "resolve",
+      "status": "ok"
+    },
+    {
+      "phase": "fetch",
+      "status": "ok"
+    },
+    {
+      "phase": "merge",
+      "status": "ok"
+    },
+    {
+      "phase": "provision",
+      "status": "ok"
+    },
+    {
+      "phase": "validate",
+      "status": "ok"
+    }
+  ],
+  "warnings": [],
+  "error": null,
+  "durationMs": [DURATION_MS]
+}

--- a/acceptance/localenv/filter-nonlocal-constraints/script
+++ b/acceptance/localenv/filter-nonlocal-constraints/script
@@ -1,0 +1,12 @@
+# The constraint artifact faithfully mirrors the cluster image, which includes builds
+# that cannot install on a developer machine. setup-local drops them before writing the
+# merged pyproject.toml, so the JSON diff's [tool.uv] constraint-dependencies keeps only
+# numpy, the plain torch pin, and pyarrow — the +cu129/+cpu/+db1 local-version builds and
+# the GPU-only nvidia-cublas-cu12 / triton pins are gone.
+cat > pyproject.toml <<'PY'
+[project]
+name = "demo"
+requires-python = "==3.12.*"
+PY
+
+trace $CLI environments setup-local --serverless-version 4 --dry-run --output json

--- a/acceptance/localenv/filter-nonlocal-constraints/test.toml
+++ b/acceptance/localenv/filter-nonlocal-constraints/test.toml
@@ -1,0 +1,37 @@
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]
+
+# The script writes pyproject.toml as the merge input; --dry-run leaves it unchanged.
+Ignore = ["pyproject.toml"]
+
+Env.DATABRICKS_LOCALENV_CONSTRAINT_SOURCE_URL_TEST_OVERRIDE = "$DATABRICKS_HOST"
+
+# The served artifact mirrors the cluster image faithfully, so it mixes locally
+# installable pins with ones that cannot resolve on a developer machine: pins
+# carrying a PEP 440 local version segment (+cu129 / +cpu / +db1) and GPU-only
+# distributions (nvidia-* CUDA components, triton). Only the installable pins
+# (numpy, pyarrow, and the plain torch pin) may reach the merged pyproject.toml.
+[[Server]]
+Pattern = "GET /serverless/serverless-v4/pyproject.toml"
+Response.Body = '''
+[project]
+requires-python = "==3.12.*"
+
+[dependency-groups]
+dev = ["databricks-connect~=17.2.0"]
+
+[tool.uv]
+constraint-dependencies = [
+    "numpy~=2.1.3",
+    "torch==2.7.0+cu129",
+    "torch==2.7.0+cpu",
+    "flask==1.1.2+db1",
+    "nvidia-cublas-cu12~=12.6.4.1",
+    "triton~=3.3.0",
+    "torch~=2.7.0",
+    "pyarrow~=21.0.0",
+]
+'''
+
+[[Repls]]
+Old = 'uv uv \S+(?: \([^)]+\))?'
+New = 'uv [UV_VERSION]'

--- a/libs/localenv/constraints.go
+++ b/libs/localenv/constraints.go
@@ -284,7 +284,11 @@ func parseConstraints(data []byte) (requiresPython, dbconnect string, deps []str
 		}
 	}
 
-	deps = p.Tool.UV.ConstraintDependencies
+	// Drop constraints that cannot install on a developer machine (GPU/CUDA builds,
+	// Databricks-image rebuilds). Filtering here covers both the live-fetch and
+	// cache-fallback paths, and leaves the cached artifact bytes untouched, so the
+	// policy re-applies on every read rather than being frozen into the cache.
+	deps = filterNonLocalConstraints(p.Tool.UV.ConstraintDependencies)
 	return requiresPython, dbconnect, deps, nil
 }
 
@@ -323,4 +327,59 @@ var pep503SepRe = regexp.MustCompile(`[-_.]+`)
 // run of "-", "_", or "." to a single "-".
 func normalizePackageName(name string) string {
 	return pep503SepRe.ReplaceAllString(strings.ToLower(strings.TrimSpace(name)), "-")
+}
+
+// nonLocalConstraintNames are GPU-only distributions that make no sense as a
+// local constraint: they require an NVIDIA GPU (and CUDA toolchain) that a
+// developer machine does not have, and on macOS they have no wheel at all. Every
+// nvidia-* PyPI distribution is a CUDA runtime component and is caught by prefix
+// below; these are the remaining GPU-only names. Compared PEP 503-normalized.
+var nonLocalConstraintNames = map[string]bool{
+	"triton":     true,
+	"flash-attn": true,
+	"deepspeed":  true,
+}
+
+// isNonLocalConstraint reports whether a constraint-dependencies entry names a
+// package that cannot (or should not) be installed on a developer machine, so it
+// must not be carried into the user's local pyproject.toml. The constraint
+// artifacts mirror the cluster image faithfully (see the databricks/environments
+// repo), which is the right contract for the image but wrong for a local env: an
+// unsatisfiable constraint only ever fails `uv sync` and never helps, because a
+// constraint binds a version only if the package enters the resolution.
+//
+// Two independent tests, both fail-open — an entry we cannot confidently parse is
+// kept, never dropped:
+//
+//   - A PEP 440 local version segment (a "+" in the specifier, e.g. "+cu129",
+//     "+cpu", "+db1"). These name a build published only on an out-of-band index
+//     (download.pytorch.org) or rebuilt inside the Databricks image, so they
+//     resolve nowhere off the cluster and are impossible on macOS/CPU entirely.
+//   - A GPU-only distribution: any nvidia-* CUDA runtime component, or one of
+//     nonLocalConstraintNames.
+func isNonLocalConstraint(entry string) bool {
+	name, spec, ok := splitDepSpec(entry)
+	if !ok {
+		return false
+	}
+	if strings.Contains(spec, "+") {
+		return true
+	}
+	if strings.HasPrefix(name, "nvidia-") {
+		return true
+	}
+	return nonLocalConstraintNames[name]
+}
+
+// filterNonLocalConstraints returns deps with every non-local constraint (see
+// isNonLocalConstraint) removed, preserving order. A nil input yields nil so a
+// missing constraint-dependencies key is not turned into an empty block.
+func filterNonLocalConstraints(deps []string) []string {
+	var kept []string
+	for _, d := range deps {
+		if !isNonLocalConstraint(d) {
+			kept = append(kept, d)
+		}
+	}
+	return kept
 }

--- a/libs/localenv/constraints_test.go
+++ b/libs/localenv/constraints_test.go
@@ -61,6 +61,96 @@ func TestParseConstraints(t *testing.T) {
 	assert.Equal(t, []string{"pydantic~=2.10.6", "anyio~=4.6.2"}, deps)
 }
 
+func TestIsNonLocalConstraint(t *testing.T) {
+	// Dropped: a PEP 440 local version segment (+cuNNN / +cpu / +db1) names a
+	// build published only on an out-of-band index or inside the cluster image,
+	// so it can never resolve on a developer machine.
+	for _, entry := range []string{
+		"torch==2.9.0+cu129",
+		"torchvision==0.24.0+cu129",
+		"torch==2.7.0+cpu",
+		"flask==1.1.2+db1",
+		"horovod==0.28.1+db1",
+	} {
+		assert.True(t, isNonLocalConstraint(entry), "expected %q to be dropped (local version segment)", entry)
+	}
+
+	// Dropped: the GPU-only distributions. Every nvidia-* PyPI distribution is a
+	// CUDA runtime component; triton/flash-attn/deepspeed are GPU-only too.
+	// Name matching is PEP 503-normalized (case and -/_/. runs are equivalent).
+	for _, entry := range []string{
+		"nvidia-cublas-cu12~=12.6.4.1",
+		"nvidia-cudnn-cu12~=9.5.1.17",
+		"NVIDIA_Cublas-cu12~=12.6.4.1",
+		"triton~=3.3.0",
+		"flash-attn~=2.7.4.post1",
+		"flash_attn~=2.7.4.post1",
+		"deepspeed~=0.16.5",
+	} {
+		assert.True(t, isNonLocalConstraint(entry), "expected %q to be dropped (GPU-only)", entry)
+	}
+
+	// Kept: ordinary pins that install cleanly on a developer machine, including a
+	// plain torch pin (resolves to a macOS/CPU wheel) and ray (on PyPI, usable
+	// locally). Only the +local torch builds are dropped, not torch itself.
+	for _, entry := range []string{
+		"boto3~=1.40.45",
+		"numpy~=2.1.3",
+		"pyarrow~=21.0.0",
+		"databricks-sdk~=0.67",
+		"ray~=2.37.0",
+		"torch~=2.7.0",
+	} {
+		assert.False(t, isNonLocalConstraint(entry), "expected %q to be kept", entry)
+	}
+}
+
+func TestIsNonLocalConstraintFailsOpenOnUnparseable(t *testing.T) {
+	// A shape we cannot confidently parse (an environment marker) is kept rather
+	// than dropped: filtering must never remove a constraint we are unsure about.
+	assert.False(t, isNonLocalConstraint(`torch==2.9.0+cu129 ; python_version < "3.13"`))
+	assert.False(t, isNonLocalConstraint(""))
+}
+
+func TestFilterNonLocalConstraintsPreservesOrderAndKeeps(t *testing.T) {
+	in := []string{
+		"boto3~=1.40.45",
+		"torch==2.7.0+cpu",
+		"numpy~=2.1.3",
+		"nvidia-cublas-cu12~=12.6.4.1",
+		"triton~=3.3.0",
+		"pyarrow~=21.0.0",
+	}
+	got := filterNonLocalConstraints(in)
+	assert.Equal(t, []string{"boto3~=1.40.45", "numpy~=2.1.3", "pyarrow~=21.0.0"}, got)
+}
+
+func TestFilterNonLocalConstraintsPreservesNil(t *testing.T) {
+	// A missing constraint-dependencies key parses to nil; the filter must not
+	// turn that into a non-nil empty slice (mergeToolUv treats the two differently).
+	assert.Nil(t, filterNonLocalConstraints(nil))
+}
+
+func TestParseConstraintsDropsNonLocal(t *testing.T) {
+	toml := `[project]
+requires-python = "==3.12.*"
+
+[dependency-groups]
+dev = ["databricks-connect~=17.3.0"]
+
+[tool.uv]
+constraint-dependencies = [
+    "numpy~=2.1.3",
+    "torch==2.7.0+cu129",
+    "nvidia-cublas-cu12~=12.6.4.1",
+    "pyarrow~=21.0.0",
+]
+`
+	_, _, deps, err := parseConstraints([]byte(toml))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"numpy~=2.1.3", "pyarrow~=21.0.0"}, deps)
+}
+
 func TestParseConstraintsRejectsMissingRequiresPython(t *testing.T) {
 	// Valid TOML but no requires-python is not a usable artifact; it must error
 	// rather than return an empty result that would be cached and fail later.


### PR DESCRIPTION
## Why

The per-environment constraint artifacts in [databricks/environments](https://github.com/databricks/environments) mirror the cluster image faithfully — the right contract for the image, but wrong for a local environment. They pin builds that cannot install on a developer machine:

- **PEP 440 local-version-segment pins** — `torch==2.9.0+cu129`, `torch==2.7.0+cpu`, `flask==1.1.2+db1`, `horovod==0.28.1+db1`. These builds are published only on an out-of-band index (`download.pytorch.org`) or rebuilt inside the Databricks image, so they resolve nowhere off the cluster and are impossible on macOS/CPU entirely.
- **GPU-only distributions** — the `nvidia-*` CUDA runtime components, plus `triton`, `flash-attn`, `deepspeed`. They require an NVIDIA GPU and CUDA toolchain a laptop doesn't have, and have no wheel at all on macOS.

A `constraint-dependencies` entry binds a version only if the package enters the resolution — it never forces an install. So these pins never help a local setup and can only ever make `uv sync` unsatisfiable the moment the package is pulled in.

## What

- Add `isNonLocalConstraint` / `filterNonLocalConstraints` in `libs/localenv`, applied in `parseConstraints`. Filtering there covers both the live-fetch and cache-fallback paths and leaves the cached artifact bytes untouched, so the policy re-applies on every read rather than being frozen into the cache.
- The filter runs upstream of both consumers of `Constraints.ConstraintDeps` (`mergeToolUv` and the conflict-warning detection), so they stay consistent.
- Matching is **fail-open**: an entry that can't be confidently parsed (e.g. an environment marker) is kept, never dropped. Name matching is PEP 503-normalized.
- A plain `torch~=2.7.0` pin is **kept** — it resolves to a macOS/CPU wheel; only the `+local` torch builds are dropped.

## Verification

- Unit tests for the predicate (each drop case + keeps including plain `torch~=2.7.0` and PEP 503 normalization), the filter (order preserved, nil preserved), and `parseConstraints`.
- New acceptance case `acceptance/localenv/filter-nonlocal-constraints` asserts the merged `pyproject.toml` keeps only the installable pins.
- `go test ./libs/localenv/` and `go test ./acceptance -run TestAccept/localenv` green; `gofmt` and `go vet` clean.

This pull request and its description were written by Isaac.
