### PR TITLE
Report ssh_tunnel_event booleans explicitly in telemetry

### DIFF
--- a/experimental/ssh/internal/client/client_internal_test.go
+++ b/experimental/ssh/internal/client/client_internal_test.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -551,4 +552,17 @@ func TestBuildSshTunnelEventReportsErrorCategory(t *testing.T) {
 
 	assert.False(t, got.IsSuccess)
 	assert.Equal(t, protos.SshTunnelErrorCategoryIDECommandNotOnPath, got.ErrorCategory)
+}
+
+// A failed first attempt is the case the telemetry exists to measure, so assert
+// the outcome fields reach the payload as an explicit false rather than being
+// dropped as zero values.
+func TestBuildSshTunnelEventReportsFailure(t *testing.T) {
+	got := buildSshTunnelEvent(ClientOptions{ClusterID: "abc-123"}, connectOutcome{})
+
+	assert.False(t, got.IsSuccess)
+
+	b, err := json.Marshal(got)
+	require.NoError(t, err)
+	assert.Contains(t, string(b), `"is_success":false`)
 }

--- a/libs/telemetry/protos/ssh_tunnel.go
+++ b/libs/telemetry/protos/ssh_tunnel.go
@@ -67,6 +67,13 @@ const (
 
 // SshTunnelEvent is emitted when a user establishes an SSH tunnel connection
 // via the Databricks CLI.
+//
+// Every bool below is populated on every event, so none of them carry
+// omitempty: a genuine false must stay distinguishable from an older CLI that
+// did not report the field. Events sent before CLI v1.14.0 omitted false
+// entirely and land in the table as NULL, so queries spanning that cutover must
+// count NULL as false (e.g. a failed connection is `is_success IS NULL` for
+// pre-v1.14.0 rows and `is_success = false` after).
 type SshTunnelEvent struct {
 	// Type of compute: dedicated cluster or serverless.
 	ComputeType SshTunnelComputeType `json:"compute_type,omitempty"`
@@ -81,26 +88,26 @@ type SshTunnelEvent struct {
 	ClientMode SshTunnelClientMode `json:"client_mode,omitempty"`
 
 	// Whether this is a reconnection to an existing session.
-	IsReconnect bool `json:"is_reconnect,omitempty"`
+	IsReconnect bool `json:"is_reconnect"`
 
 	// Whether the cluster was auto-started by the CLI.
-	AutoStartCluster bool `json:"auto_start_cluster,omitempty"`
+	AutoStartCluster bool `json:"auto_start_cluster"`
 
 	// Whether a custom base environment was set via --base-environment.
 	// Only the presence is recorded: the flag value can be an env.yaml path
 	// or display name carrying PII, so the value itself is not logged.
-	HasBaseEnvironment bool `json:"has_base_environment,omitempty"`
+	HasBaseEnvironment bool `json:"has_base_environment"`
 
 	// Time in milliseconds spent starting the SSH server.
 	// Zero if server was already running.
 	ServerStartTimeMs int64 `json:"server_start_time_ms"`
 
 	// Whether the connection was successful.
-	IsSuccess bool `json:"is_success,omitempty"`
+	IsSuccess bool `json:"is_success"`
 
 	// Whether a serverless usage policy was set via --usage-policy-id.
 	// Only the presence is recorded, not the policy ID itself.
-	HasUsagePolicy bool `json:"has_usage_policy,omitempty"`
+	HasUsagePolicy bool `json:"has_usage_policy"`
 
 	// Why the connection attempt failed, or TYPE_UNSPECIFIED on success. Deliberately
 	// without omitempty: the field is what identifies a failure's cause, so an empty value

--- a/libs/telemetry/protos/ssh_tunnel_test.go
+++ b/libs/telemetry/protos/ssh_tunnel_test.go
@@ -1,0 +1,45 @@
+package protos
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A failed connection is the zero value of every bool, so omitempty would drop
+// the fields entirely and make the failure indistinguishable from an unreported
+// one. This pins the wire payload for that case.
+func TestSshTunnelEventEncodesFailureExplicitly(t *testing.T) {
+	b, err := json.Marshal(SshTunnelEvent{})
+	require.NoError(t, err)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(b, &got))
+
+	for _, field := range []string{
+		"is_success",
+		"is_reconnect",
+		"auto_start_cluster",
+		"has_base_environment",
+		"has_usage_policy",
+	} {
+		assert.Equal(t, false, got[field], "%s must be sent as false, not omitted", field)
+	}
+}
+
+// Guards fields added later: a bool that can legitimately be false must not
+// carry omitempty, or its false case arrives as NULL and cannot be counted.
+func TestSshTunnelEventBoolFieldsOmitOmitempty(t *testing.T) {
+	typ := reflect.TypeFor[SshTunnelEvent]()
+	for field := range typ.Fields() {
+		if field.Type.Kind() != reflect.Bool {
+			continue
+		}
+		tag := field.Tag.Get("json")
+		assert.NotContains(t, tag, "omitempty",
+			"%s has omitempty; a false value would be indistinguishable from not reported", field.Name)
+	}
+}


### PR DESCRIPTION
## Changes

Drop `omitempty` from all five `bool` fields on `SshTunnelEvent`
(`libs/telemetry/protos/ssh_tunnel.go`): `IsSuccess`, `IsReconnect`,
`AutoStartCluster`, `HasBaseEnvironment`, `HasUsagePolicy`.

## Why

`omitempty` drops the zero value, so a failed `ssh connect` sent no `is_success`
field at all and landed in the telemetry table as NULL rather than `false`.
Filtering on `is_success = false` returned zero rows across all history — any
straightforward "are users hitting errors?" query reported a clean bill of health
while the real IDE-mode failure rate was 40-55%.

All five bools are populated unconditionally in `buildSshTunnelEvent`, so each
has a meaningful `false`. The other four were equally unrepresentable and matter
for funnel analysis, so they are fixed in the same pass rather than left to be
rediscovered. `ServerStartTimeMs` in the same struct already omitted the tag,
which is what confirmed this was a field-level mistake rather than an intended
encoding.

Historical rows cannot be backfilled, so the struct doc comment records the
cutover: queries spanning it must count NULL as failure for pre-fix data.

No changelog fragment — `experimental/` changes don't get one until the feature
graduates, and the payload isn't user-visible.

## Tests

- New `libs/telemetry/protos/ssh_tunnel_test.go`: pins the zero-value wire
  payload, plus a reflection guard that fails if a future `bool` on this struct
  arrives with `omitempty`.
- New `TestBuildSshTunnelEventReportsFailure` covers the failure path in
  `experimental/ssh/internal/client`; the existing table test only ever passed
  `true`.
- Both new tests were confirmed to fail against the pre-fix tag, with
  `actual: <nil>` — the exact NULL this fixes.
- Verified end-to-end on the full `FrontendLog` envelope as uploaded to
  `/telemetry-ext`: `"is_success": false` is now transmitted.
- `task lint-go` (0 issues, all 3 modules), `task test-exp-ssh`, telemetry and
  ssh acceptance tests pass. One pre-existing failure in
  `bundle/templates/lakeflow-integrations`, unrelated: it fails identically on
  unmodified `origin/main` (blocked PyPI fetch in my sandbox).

_This PR was written by Claude Code._