### PR TITLE
aitools: expose supports_project_scope in `aitools list --output json`

### DIFF
--- a/cmd/aitools/list.go
+++ b/cmd/aitools/list.go
@@ -87,6 +87,9 @@ type agentEntry struct {
 	// Detected is the CLI's presence verdict (Agent.IsPreselected), so consumers get
 	// the same answer the CLI would act on.
 	Detected bool `json:"detected"`
+	// SupportsProjectScope mirrors agents.Agent.SupportsProjectScope so consumers can
+	// offer a project-scoped install without hardcoding which agents allow it.
+	SupportsProjectScope bool `json:"supports_project_scope"`
 	// Installed maps CLI scope -> the install found there; always present, empty
 	// when nothing is installed, matching the skills shape.
 	Installed map[string]installInfo `json:"installed"`
@@ -231,10 +234,11 @@ func buildAgentEntries(ctx context.Context, states map[string]*installer.Install
 	entries := make([]agentEntry, 0, len(agents.Registry))
 	for _, a := range agents.Registry {
 		entry := agentEntry{
-			Name:        a.Name,
-			DisplayName: a.DisplayName,
-			Managed:     a.Plugin != nil,
-			Detected:    a.IsPreselected(ctx),
+			Name:                 a.Name,
+			DisplayName:          a.DisplayName,
+			Managed:              a.Plugin != nil,
+			Detected:             a.IsPreselected(ctx),
+			SupportsProjectScope: a.SupportsProjectScope,
 		}
 
 		// Always emit an installed map, empty when nothing is installed, so the

--- a/cmd/aitools/list_test.go
+++ b/cmd/aitools/list_test.go
@@ -114,11 +114,12 @@ func TestRenderListJSONWithAgents(t *testing.T) {
 		Summary: map[string]scopeSummary{installer.ScopeGlobal: {Installed: 0, Total: 0}},
 		Agents: []agentEntry{
 			{
-				Name:        "claude-code",
-				DisplayName: "Claude Code",
-				Managed:     true,
-				Detected:    true,
-				Installed:   map[string]installInfo{installer.ScopeGlobal: {Delivery: "plugin", Version: "0.2.6"}},
+				Name:                 "claude-code",
+				DisplayName:          "Claude Code",
+				Managed:              true,
+				Detected:             true,
+				SupportsProjectScope: true,
+				Installed:            map[string]installInfo{installer.ScopeGlobal: {Delivery: "plugin", Version: "0.2.6"}},
 			},
 			{
 				Name:        "cursor",
@@ -146,6 +147,7 @@ func TestRenderListJSONWithAgents(t *testing.T) {
 	assert.Equal(t, "Claude Code", first["display_name"])
 	assert.Equal(t, true, first["managed"])
 	assert.Equal(t, true, first["detected"])
+	assert.Equal(t, true, first["supports_project_scope"])
 	installed := first["installed"].(map[string]any)
 	global := installed["global"].(map[string]any)
 	assert.Equal(t, "0.2.6", global["version"])
@@ -156,6 +158,7 @@ func TestRenderListJSONWithAgents(t *testing.T) {
 	second := agentsRaw[1].(map[string]any)
 	assert.Contains(t, second, "installed")
 	assert.Empty(t, second["installed"])
+	assert.Equal(t, false, second["supports_project_scope"])
 }
 
 func TestBuildAgentEntries(t *testing.T) {
@@ -182,17 +185,22 @@ func TestBuildAgentEntries(t *testing.T) {
 	assert.Equal(t, "Claude Code", byName["claude-code"].DisplayName)
 	assert.Equal(t, "0.2.6", byName["claude-code"].Installed[installer.ScopeGlobal].Version)
 	assert.Equal(t, "databricks plugin · v0.2.6 · up to date", agentStatusLabel(byName["claude-code"], "0.2.6"))
+	// SupportsProjectScope is wired straight from the registry: claude-code allows
+	// project scope, whereas the managed/skills-only global-only agents below do not.
+	assert.True(t, byName["claude-code"].SupportsProjectScope)
 
 	require.Contains(t, byName, "codex")
 	assert.True(t, byName["codex"].Managed)
 	assert.Equal(t, "0.2.5", byName["codex"].Installed[installer.ScopeGlobal].Version)
 	assert.Equal(t, "databricks plugin · v0.2.5 · update available", agentStatusLabel(byName["codex"], "0.2.6"))
+	assert.False(t, byName["codex"].SupportsProjectScope)
 
 	// The JSON output carries an entry for every registry agent, including
 	// skills-only agents like Cursor and managed agents with no recorded install.
 	require.Contains(t, byName, "cursor")
 	assert.False(t, byName["cursor"].Managed)
 	assert.Empty(t, byName["cursor"].Installed)
+	assert.False(t, byName["cursor"].SupportsProjectScope)
 
 	require.Contains(t, byName, "copilot")
 	assert.True(t, byName["copilot"].Managed)


### PR DESCRIPTION
## Changes

Adds a `supports_project_scope` boolean to every agent entry in the `agents` list
of `databricks aitools list --output json`.

- New `SupportsProjectScope bool \`json:"supports_project_scope"\`` field on
  `agentEntry` in `cmd/aitools/list.go`, populated in `buildAgentEntries` directly
  from the registry's `agents.Agent.SupportsProjectScope`.
- The field is always emitted (no `omitempty`), matching the existing `managed`
  and `detected` bools, so the JSON shape stays stable.

The value is `true` for the project-scope-capable agents (Claude Code, Pi,
Gemini CLI, Goose) and `false` for the rest.

## Why
(can the CLI install a plugin) and `detected` (is the agent present), but nothing
told a consumer whether an agent is *allowed* to have project-scoped skills. That
capability lived only on the internal `agents.Agent.SupportsProjectScope` field.

The only project-scope signal in the JSON was a `"project"` key inside an agent's
`installed` map, which appears only when something is already installed there — so
consumers could infer capability positively but never learn it up front. Exposing
`supports_project_scope` lets the extension offer a project-scoped install without
hardcoding the agent list, mirroring how `managed` surfaces `Plugin != nil`.

## Tests
Extended the existing unit tests in `cmd/aitools/list_test.go`:

- `TestRenderListJSONWithAgents` — asserts the JSON key round-trips (`true` for
  the claude-code fixture, `false` for the cursor entry), locking the contract.
- `TestBuildAgentEntries` — asserts the value is wired from the real registry:
  `true` for claude-code, `false` for codex (managed, global-only) and cursor
  (skills-only, global-only), so the test tracks reality if an agent's capability
  changes.

<!-- If your PR needs to be included in the release notes for next release,
add a changelog fragment: create .nextchanges/<section>/<name>.md with a
one-line description (e.g. .nextchanges/cli/quickstart.md). See .nextchanges/README.md. -->
