### PR TITLE
clusters start: no-op when cluster isn't TERMINATED

### DIFF
--- a/.nextchanges/cli/clusters-start-already-running.md
+++ b/.nextchanges/cli/clusters-start-already-running.md
@@ -1,0 +1,1 @@
+`databricks clusters start` no longer errors when the cluster is already RUNNING (or PENDING/RESTARTING/RESIZING). It now prints a short message and exits 0, matching the command's own help text ("If the cluster is not currently in a TERMINATED state, nothing will happen").

--- a/cmd/workspace/clusters/overrides.go
+++ b/cmd/workspace/clusters/overrides.go
@@ -1,9 +1,12 @@
 package clusters
 
 import (
+	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/databricks/cli/libs/cmdio"
+	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/databricks-sdk-go/service/compute"
 	"github.com/spf13/cobra"
 )
@@ -93,8 +96,29 @@ func sparkVersionsOverride(sparkVersionsCmd *cobra.Command) {
 	`)
 }
 
+// The generated "start" command errors out (INVALID_STATE) if the cluster is
+// already RUNNING, PENDING, RESTARTING or RESIZING, even though the command's
+// own help text says "If the cluster is not currently in a TERMINATED state,
+// nothing will happen." This override makes the command match that
+// documented behavior instead of surfacing the API error.
+func startOverride(startCmd *cobra.Command, startReq *compute.StartCluster) {
+	originalRunE := startCmd.RunE
+	startCmd.RunE = func(cmd *cobra.Command, args []string) error {
+		err := originalRunE(cmd, args)
+
+		apiErr, ok := errors.AsType[*apierr.APIError](err)
+		if ok && apiErr.ErrorCode == "INVALID_STATE" {
+			fmt.Fprintf(cmd.OutOrStdout(), "Cluster %s is not in a TERMINATED state, nothing to do.\n", startReq.ClusterId)
+			return nil
+		}
+
+		return err
+	}
+}
+
 func init() {
 	listOverrides = append(listOverrides, listOverride)
 	listNodeTypesOverrides = append(listNodeTypesOverrides, listNodeTypesOverride)
 	sparkVersionsOverrides = append(sparkVersionsOverrides, sparkVersionsOverride)
+	startOverrides = append(startOverrides, startOverride)
 }

--- a/cmd/workspace/clusters/overrides_test.go
+++ b/cmd/workspace/clusters/overrides_test.go
@@ -1,0 +1,45 @@
+package clusters
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/databricks/databricks-sdk-go/apierr"
+	"github.com/databricks/databricks-sdk-go/service/compute"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStartOverride_SwallowsInvalidStateError(t *testing.T) {
+	startReq := &compute.StartCluster{ClusterId: "1234-000000-abcdefg"}
+	cmd := &cobra.Command{}
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		return &apierr.APIError{ErrorCode: "INVALID_STATE", Message: "Cluster is in unexpected state Running."}
+	}
+
+	startOverride(cmd, startReq)
+
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	err := cmd.RunE(cmd, nil)
+
+	require.NoError(t, err)
+	assert.Contains(t, out.String(), startReq.ClusterId)
+}
+
+func TestStartOverride_PropagatesOtherErrors(t *testing.T) {
+	startReq := &compute.StartCluster{ClusterId: "1234-000000-abcdefg"}
+	cmd := &cobra.Command{}
+	wantErr := errors.New("boom")
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		return wantErr
+	}
+
+	startOverride(cmd, startReq)
+
+	err := cmd.RunE(cmd, nil)
+
+	assert.Equal(t, wantErr, err)
+}


### PR DESCRIPTION
## Changes

`databricks clusters start` returns an API error if the target cluster isn't TERMINATED (e.g. it's already RUNNING). The command's own help text says otherwise: "If the cluster is not currently in a TERMINATED state, nothing will happen." This PR makes the command match that text: on `INVALID_STATE`, it prints a short message and exits 0 instead of failing.

## Why

Fixes #1372. Scripts that call `clusters start` to make sure a cluster is up (a common idempotent pattern) currently have to special-case this error themselves. A previous attempt at this fix (#2947) took a similar approach but stalled and auto-closed without maintainer feedback.

## Tests

Added `cmd/workspace/clusters/overrides_test.go`, covering:
- `INVALID_STATE` is swallowed and the command returns nil
- any other error still propagates unchanged

`go build ./cmd/workspace/clusters/...` and `go vet ./cmd/workspace/clusters/...` pass. I don't have a Databricks workspace to run this against a live already-running cluster, so I'd appreciate a maintainer or CI check on that path.
