### PR TITLE
libs/fileset: cover leading-slash anchoring in glob patterns

### DIFF
--- a/libs/fileset/glob_test.go
+++ b/libs/fileset/glob_test.go
@@ -2,7 +2,9 @@ package fileset
 
 import (
 	"io/fs"
+	"os"
 	"path"
+	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
@@ -131,4 +133,33 @@ func TestGlobFilesetDoubleQuotesWithFilePatterns(t *testing.T) {
 	files, err := g.Files()
 	require.NoError(t, err)
 	require.ElementsMatch(t, entries, collectRelativePaths(files))
+}
+
+// A pattern with a leading slash is anchored to the fileset root, the same way
+// git treats it in .gitignore. Without the slash the pattern matches a directory
+// of that name at any depth. sync.include relies on this to select, say, a
+// top-level "resources" directory without also picking up "vendor/resources".
+func TestGlobFilesetLeadingSlashAnchorsToRoot(t *testing.T) {
+	tmpDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "dir"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "nested", "dir"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "dir", "a.txt"), []byte("a"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "nested", "dir", "b.txt"), []byte("b"), 0o644))
+
+	root := vfs.MustNew(tmpDir)
+
+	g, err := NewGlobSet(root, []string{"/dir/"})
+	require.NoError(t, err)
+	files, err := g.Files()
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{filepath.Join("dir", "a.txt")}, collectRelativePaths(files))
+
+	g, err = NewGlobSet(root, []string{"dir/"})
+	require.NoError(t, err)
+	files, err = g.Files()
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{
+		filepath.Join("dir", "a.txt"),
+		filepath.Join("nested", "dir", "b.txt"),
+	}, collectRelativePaths(files))
 }


### PR DESCRIPTION
## Changes

Adds a test for how `NewGlobSet` treats a leading slash in an include pattern.

`NewGlobSet` compiles patterns with `go-gitignore`, so gitignore anchoring
rules apply: `/dir/` matches only a `dir` at the fileset root, while `dir/`
matches a directory of that name at any depth. `glob_test.go` covered
recursive patterns, directory patterns and quoted file patterns, but nothing
pinned that anchored/unanchored distinction.

The new test asserts both halves against a temporary tree holding `dir/` and
`nested/dir/`.

## Why

`sync.include` passes user patterns straight through to `NewGlobSet`
(`bundle.GetSyncIncludePatterns` → `sync.NewFileList` → `fileset.NewGlobSet`),
so this anchoring is user-visible bundle behaviour: it is what lets someone
include a top-level directory without also sweeping in same-named directories
nested elsewhere in the tree.

It is currently unprotected. Normalising the pattern slightly differently in
`NewGlobSet` — for example trimming the leading slash before compiling —
silently widens every anchored include, and the existing suite stays green. I
checked that by making exactly that change locally: only the new test fails.

This came up while looking at #3456, which reports anchored `sync.include`
patterns matching nested directories. I could not reproduce that against
`main` — the behaviour is correct today, at the pattern level and end to end
through `NewGlobSet` — so this PR only locks the current behaviour in rather
than changing anything. I have left a note on the issue with the details.

## Tests

`go test ./libs/fileset/` — all green, including the new
`TestGlobFilesetLeadingSlashAnchorsToRoot`.

Test-only change, so no changelog fragment.
