### PR TITLE
libs/template: don't create directories that a later {{skip}} names

### DIFF
--- a/.nextchanges/cli/template-skip-dir-not-created.md
+++ b/.nextchanges/cli/template-skip-dir-not-created.md
@@ -1,0 +1,1 @@
+`bundle init` no longer creates an empty directory when a template's `{{skip}}` directive names a directory that the template walk had already visited.

--- a/libs/template/renderer.go
+++ b/libs/template/renderer.go
@@ -372,8 +372,24 @@ func (r *renderer) persistToDisk(ctx context.Context, out filer.Filer) error {
 			continue
 		}
 
+		// A {{skip}} directive can name a directory the walk has already
+		// visited, because the directive lives in a file processed later.
+		// walk() only tests the patterns known when it reaches a directory, so
+		// re-test the accumulated set here; otherwise the directory is created
+		// even though it was explicitly skipped. This leaves directories whose
+		// files merely happened to be skipped untouched, since those patterns
+		// match the files rather than the directory itself.
+		match, err := isSkipped(dir, r.skipPatterns)
+		if err != nil {
+			return err
+		}
+		if match {
+			log.Infof(r.ctx, "skipping directory: %s", dir)
+			continue
+		}
+
 		// Check if directory already exists (may have been created during file writes)
-		_, err := out.Stat(ctx, dir)
+		_, err = out.Stat(ctx, dir)
 		if err == nil {
 			// Directory already exists, nothing to do
 			continue

--- a/libs/template/renderer_test.go
+++ b/libs/template/renderer_test.go
@@ -631,3 +631,29 @@ func TestRendererSubTemplateInPath(t *testing.T) {
 		assert.Equal(t, "my_directory/my_file", f.RelPath())
 	}
 }
+
+// A {{skip}} directive can name a directory that the BFS walk has already
+// visited, because the directive lives in a file processed later. The
+// directory must still not be created: the walk records visited directories
+// before any later file can skip them, so the skip patterns have to be applied
+// again when directories are materialized.
+func TestRendererSkipDirectoryVisitedBeforeSkipDirective(t *testing.T) {
+	ctx := t.Context()
+	ctx = cmdctx.SetWorkspaceClient(ctx, nil)
+	tmpDir := t.TempDir()
+
+	helpers := loadHelpers(ctx)
+	r, err := newRenderer(ctx, nil, helpers, os.DirFS("."), "./testdata/skip-dir-after-visit/template", "./testdata/skip-dir-after-visit/library")
+	require.NoError(t, err)
+
+	err = r.walk()
+	require.NoError(t, err)
+
+	out, err := filer.NewLocalClient(tmpDir)
+	require.NoError(t, err)
+	err = r.persistToDisk(ctx, out)
+	require.NoError(t, err)
+
+	assert.NoDirExists(t, filepath.Join(tmpDir, "dir1"))
+	assert.FileExists(t, filepath.Join(tmpDir, "dir2", "file2"))
+}

--- a/libs/template/testdata/skip-dir-after-visit/template/dir1/file1.tmpl
+++ b/libs/template/testdata/skip-dir-after-visit/template/dir1/file1.tmpl
@@ -1,0 +1,1 @@
+This file is skipped by dir2, so dir1 must not be created

--- a/libs/template/testdata/skip-dir-after-visit/template/dir2/file2.tmpl
+++ b/libs/template/testdata/skip-dir-after-visit/template/dir2/file2.tmpl
@@ -1,0 +1,3 @@
+I should be the only file created
+
+{{skip "../dir1"}}{{skip "../dir1/*"}}


### PR DESCRIPTION
## Changes

`renderer.walk` records every directory it visits, and `persistToDisk` creates
them all so a template's structure survives even where files were skipped.
That is deliberate. But the walk tests the skip patterns only at the moment it
reaches a directory.

`{{skip}}` directives are registered while rendering *files*, so a file
processed after a directory has already been visited can name that directory.
By then the walk has recorded it, and the directory is created anyway — empty,
because its own files do match the pattern and are dropped.

This re-tests the accumulated patterns when directories are materialized.

Directories whose files merely happened to be skipped are unaffected: those
patterns (`dir/*`) match the files, not the directory, so `dir` is still
created. That keeps the behaviour the surrounding comment asks for — "Only
explicit `{{skip}}` directives should prevent directory creation" — which is
exactly what is not true today.

## Why

The current behaviour contradicts that comment: an explicit `{{skip}}` naming
a directory is honoured only if it happens to be registered before the walk
reaches it. Whether it is depends on BFS ordering — which sibling directory
sorts first, and which file the directive lives in — so the same directive
works or silently leaves an empty directory depending on where it is written.

This looks like the mechanism behind #6142, which reports `bundle init`
leaving a stray empty directory next to the correctly generated bundle. I
could not confirm that end to end, since the template in that report is not
public, so I have not marked this as fixing it — but the symptom matches, and
the ordering dependence above would explain why it reproduces with some
template variants and not others.

## Tests

`go test ./libs/template/... ./cmd/bundle/...` — all green.

Added `TestRendererSkipDirectoryVisitedBeforeSkipDirective` with a fixture
where `dir2/file2.tmpl` skips `dir1`, which the BFS walk visits first. The
test asserts `dir1` is absent and `dir2/file2` is written; it fails on `main`
with `directory ".../dir1" exists`.
