### PR TITLE
acc: Remove superfluous vector search test.toml

### DIFF
--- a/acceptance/bundle/resources/vector_search_indexes/schema_normalization/test.toml
+++ b/acceptance/bundle/resources/vector_search_indexes/schema_normalization/test.toml
@@ -1,1 +1,0 @@
-Cloud = false


### PR DESCRIPTION
Not needed because parent's `CloudSlow = true` flipped `Cloud` to `true`.

Follow-up (#6354) will stop that behaviour (CloudSlow should only affect `Cloud = true`).

However, this test _should_ actually be `Cloud = true` so this config can be removed.