### PR TITLE
acc: cap the wait in the vector search index schema test

### DIFF
--- a/acceptance/bundle/resources/vector_search_indexes/schema_normalization/out.test.toml
+++ b/acceptance/bundle/resources/vector_search_indexes/schema_normalization/out.test.toml
@@ -1,4 +1,4 @@
 Cloud = true
-CloudSlow = true
+CloudSlow = false
 RequiresUnityCatalog = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/vector_search_indexes/schema_normalization/test.toml
+++ b/acceptance/bundle/resources/vector_search_indexes/schema_normalization/test.toml
@@ -1,0 +1,13 @@
+# The assertion here is that the *backend* rewrites schema_json into Spark type names, which
+# the test server only mimics, so the cloud run is the one that matters -- see #6352, which
+# removed the superfluous Cloud = false. Inheriting CloudSlow = true left it nightly-only at
+# 12-18 minutes per env, all of it waiting for the index. Nothing here needs a queryable index,
+# only the created spec and a clean re-plan, so cap the wait and run it on every PR instead.
+Cloud = true
+CloudSlow = false
+Env.DATABRICKS_BUNDLE_RESOURCE_MAX_WAIT = "30"
+
+# The cap makes deploy warn that it stopped waiting; see ../basic/test.toml.
+[[Repls]]
+Old = 'Warn: [^\n]*Stopped waiting[^\n]*\n'
+New = ''


### PR DESCRIPTION
## Changes

Cap the wait in `vector_search_indexes/schema_normalization` with `DATABRICKS_BUNDLE_RESOURCE_MAX_WAIT=30`, and move it off `CloudSlow` so it runs on every PR.

## Why

#6352 established that this test should run on cloud: the assertion is that the *backend* rewrites `schema_json` into Spark type names, and the test server only mimics that. But inheriting `CloudSlow = true` left it nightly-only, at 12-18 minutes per env — one of the four slowest tests in the nightly on every cloud, effectively all of it waiting for the index to provision.

Nothing here needs a queryable index, only the created spec and a clean re-plan, so the wait can be capped. 18m24s -> 1m18s on aws linux, verified against a real workspace. The golden did not change, which also confirms the backend's normalized schema still matches what the test server produces.

## Tests

`testme-env aws-cli` on the test directory: passes in 78s.
