### PR TITLE
direct: remove the WAL Open created when its header cannot be written

### DIFF
--- a/bundle/direct/dstate/state.go
+++ b/bundle/direct/dstate/state.go
@@ -316,7 +316,16 @@ func (db *DeploymentState) unlockedOpen(ctx context.Context, path string, withRe
 			StateVersion: currentStateVersion,
 			CLIVersion:   build.GetInfo().Version,
 		}
-		return appendJSONLine(db.walFile, walHead)
+		if err := appendJSONLine(db.walFile, walHead); err != nil {
+			// Remove the WAL created just above: O_EXCL means it is ours, and
+			// without a header it carries nothing to recover. Leaving it makes
+			// every later open fail, with recovery on the header parse and
+			// without it on the unexpected WAL file.
+			db.walFile.Close()
+			db.walFile = nil
+			os.Remove(walPath)
+			return fmt.Errorf("failed to write WAL header to %s: %w", walPath, err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Follow-up to https://github.com/databricks/cli/pull/6330.

If writing the WAL header fails, Open leaves behind the file it just created. `O_EXCL` means the file is ours and a WAL without a header carries nothing to recover, but leaving it makes every later open fail: on the header parse with recovery, and on the unexpected WAL file without it.