### PR TITLE
Add --state-path flag to bundle config-remote-sync

### DIFF
--- a/acceptance/bundle/config-remote-sync/state_path/databricks.yml.tmpl
+++ b/acceptance/bundle/config-remote-sync/state_path/databricks.yml.tmpl
@@ -1,0 +1,19 @@
+bundle:
+  name: test-bundle-$UNIQUE_NAME
+
+resources:
+  jobs:
+    my_job:
+      max_concurrent_runs: 1
+      tasks:
+        - task_key: main
+          notebook_task:
+            notebook_path: /Users/{{workspace_user_name}}/notebook
+          new_cluster:
+            spark_version: $DEFAULT_SPARK_VERSION
+            node_type_id: $NODE_TYPE_ID
+            num_workers: 1
+
+targets:
+  default:
+    mode: development

--- a/acceptance/bundle/config-remote-sync/state_path/other.yml.tmpl
+++ b/acceptance/bundle/config-remote-sync/state_path/other.yml.tmpl
@@ -3,7 +3,7 @@ bundle:
 
 resources:
   jobs:
-    other_job:
+    my_job:
       max_concurrent_runs: 1
       tasks:
         - task_key: main

--- a/acceptance/bundle/config-remote-sync/state_path/other.yml.tmpl
+++ b/acceptance/bundle/config-remote-sync/state_path/other.yml.tmpl
@@ -1,0 +1,19 @@
+bundle:
+  name: other-bundle-$UNIQUE_NAME
+
+resources:
+  jobs:
+    other_job:
+      max_concurrent_runs: 1
+      tasks:
+        - task_key: main
+          notebook_task:
+            notebook_path: /Users/{{workspace_user_name}}/notebook
+          new_cluster:
+            spark_version: $DEFAULT_SPARK_VERSION
+            node_type_id: $NODE_TYPE_ID
+            num_workers: 1
+
+targets:
+  default:
+    mode: development

--- a/acceptance/bundle/config-remote-sync/state_path/out.direct.txt
+++ b/acceptance/bundle/config-remote-sync/state_path/out.direct.txt
@@ -1,5 +1,9 @@
+Error: no deployed jobs resource with id [MY_JOB_ID]; deployed jobs ids in state: [NUMID]
 
->>> [CLI] bundle config-remote-sync --state-path /Workspace/Users/[USERNAME]/.bundle/other-bundle/default/state --select-ids jobs:[MY_JOB_ID]
+Exit code: 1
+Error: no deployed jobs resource with id [MY_JOB_ID]; the deployment state contains no resources with ids (the bundle may not be deployed, or its resource state is missing)
+
+Exit code: 1
 Error: no deployed jobs resource with id [MY_JOB_ID]; the deployment state contains no resources with ids (the bundle may not be deployed, or its resource state is missing)
 
 Exit code: 1

--- a/acceptance/bundle/config-remote-sync/state_path/out.direct.txt
+++ b/acceptance/bundle/config-remote-sync/state_path/out.direct.txt
@@ -1,0 +1,5 @@
+
+>>> [CLI] bundle config-remote-sync --state-path /Workspace/Users/[USERNAME]/.bundle/other-bundle/default/state --select-ids jobs:[MY_JOB_ID]
+Error: no deployed jobs resource with id [MY_JOB_ID]; the deployment state contains no resources with ids (the bundle may not be deployed, or its resource state is missing)
+
+Exit code: 1

--- a/acceptance/bundle/config-remote-sync/state_path/out.terraform.txt
+++ b/acceptance/bundle/config-remote-sync/state_path/out.terraform.txt
@@ -1,5 +1,9 @@
+Error: no deployed jobs resource with id [MY_JOB_ID]; deployed jobs ids in state: [NUMID]
 
->>> [CLI] bundle config-remote-sync --state-path /Workspace/Users/[USERNAME]/.bundle/other-bundle/default/state --select-ids jobs:[MY_JOB_ID]
+Exit code: 1
+Error: state snapshot not available: resources state snapshot not found remotely at resources-config-sync-snapshot.json: state snapshot not found
+
+Exit code: 1
 Error: state snapshot not available: resources state snapshot not found remotely at resources-config-sync-snapshot.json: state snapshot not found
 
 Exit code: 1

--- a/acceptance/bundle/config-remote-sync/state_path/out.terraform.txt
+++ b/acceptance/bundle/config-remote-sync/state_path/out.terraform.txt
@@ -1,0 +1,5 @@
+
+>>> [CLI] bundle config-remote-sync --state-path /Workspace/Users/[USERNAME]/.bundle/other-bundle/default/state --select-ids jobs:[MY_JOB_ID]
+Error: state snapshot not available: resources state snapshot not found remotely at resources-config-sync-snapshot.json: state snapshot not found
+
+Exit code: 1

--- a/acceptance/bundle/config-remote-sync/state_path/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/state_path/out.test.toml
@@ -1,0 +1,3 @@
+Cloud = false
+GOOS.windows = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/state_path/output.txt
+++ b/acceptance/bundle/config-remote-sync/state_path/output.txt
@@ -1,0 +1,36 @@
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle-[UNIQUE_NAME]/default/files...
+Created jobs.my_job
+Files: 5 uploaded, 0 deleted
+Resources: 1 created, 0 changed, 0 deleted, 0 unchanged
+
+=== Modify the job remotely
+
+=== --state-path at the deployment's own state folder detects the drift
+Detected changes in 1 resource(s):
+
+Resource: resources.jobs.my_job
+  max_concurrent_runs: replace
+
+
+
+=== A relative --state-path is rejected before any state is read
+>>> [CLI] bundle config-remote-sync --state-path relative/state
+Error: --state-path must be an absolute workspace path, got "relative/state"
+
+Exit code: 1
+
+=== A ~-relative --state-path is rejected too
+>>> [CLI] bundle config-remote-sync --state-path ~/.bundle/test/default/state
+Error: --state-path must be an absolute workspace path, got "~/.bundle/test/default/state"
+
+Exit code: 1
+
+=== --state-path elsewhere does not see the deployment
+
+>>> [CLI] bundle destroy --auto-approve
+The following resources will be deleted:
+  delete resources.jobs.my_job
+
+All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/test-bundle-[UNIQUE_NAME]/default
+
+Destroy: 1 deleted

--- a/acceptance/bundle/config-remote-sync/state_path/output.txt
+++ b/acceptance/bundle/config-remote-sync/state_path/output.txt
@@ -1,11 +1,15 @@
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle-[UNIQUE_NAME]/default/files...
 Created jobs.my_job
-Files: 5 uploaded, 0 deleted
+Files: 7 uploaded, 0 deleted
+Resources: 1 created, 0 changed, 0 deleted, 0 unchanged
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/other-bundle-[UNIQUE_NAME]/default/files...
+Created jobs.other_job
+Files: 1 uploaded, 0 deleted
 Resources: 1 created, 0 changed, 0 deleted, 0 unchanged
 
 === Modify the job remotely
 
-=== --state-path at the deployment's own state folder detects the drift
+=== --state-path at this deployment's own state folder detects the drift
 Detected changes in 1 resource(s):
 
 Resource: resources.jobs.my_job
@@ -13,19 +17,44 @@ Resource: resources.jobs.my_job
 
 
 
-=== A relative --state-path is rejected before any state is read
+=== The same folder without a /Workspace prefix resolves identically
+Detected changes in 1 resource(s):
+
+Resource: resources.jobs.my_job
+  max_concurrent_runs: replace
+
+
+
+=== Reading another deployment's state does not poison this bundle's own cache
+sync against the other deployment's state failed as expected (its state has no jobs:[MY_JOB_ID])
+this bundle still reads its own state:
+Detected changes in 1 resource(s):
+
+Resource: resources.jobs.my_job
+  max_concurrent_runs: replace
+
+
+
+=== A dev-mode target is not blocked from reading a state folder it does not own
+neither foreign path was rejected by the dev-mode uniqueness check
+
+=== Rejected values
 >>> [CLI] bundle config-remote-sync --state-path relative/state
 Error: --state-path must be an absolute workspace path, got "relative/state"
 
-Exit code: 1
-
-=== A ~-relative --state-path is rejected too
 >>> [CLI] bundle config-remote-sync --state-path ~/.bundle/test/default/state
-Error: --state-path must be an absolute workspace path, got "~/.bundle/test/default/state"
+Error: --state-path must be an absolute workspace path, got "~/.bundle/test/default/state": pass the path of the deployment to sync, not one relative to the current user's home
 
-Exit code: 1
+>>> [CLI] bundle config-remote-sync --state-path /Volumes/main/default/vol/state
+Error: --state-path does not support Volumes paths, got "/Volumes/main/default/vol/state"
 
-=== --state-path elsewhere does not see the deployment
+>>> withdir other [CLI] bundle destroy --auto-approve
+The following resources will be deleted:
+  delete resources.jobs.other_job
+
+All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/other-bundle-[UNIQUE_NAME]/default
+
+Destroy: 1 deleted
 
 >>> [CLI] bundle destroy --auto-approve
 The following resources will be deleted:

--- a/acceptance/bundle/config-remote-sync/state_path/output.txt
+++ b/acceptance/bundle/config-remote-sync/state_path/output.txt
@@ -3,7 +3,7 @@ Created jobs.my_job
 Files: 7 uploaded, 0 deleted
 Resources: 1 created, 0 changed, 0 deleted, 0 unchanged
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/other-bundle-[UNIQUE_NAME]/default/files...
-Created jobs.other_job
+Created jobs.my_job
 Files: 1 uploaded, 0 deleted
 Resources: 1 created, 0 changed, 0 deleted, 0 unchanged
 
@@ -23,6 +23,10 @@ Detected changes in 1 resource(s):
 Resource: resources.jobs.my_job
   max_concurrent_runs: replace
 
+
+
+=== Reading another deployment's state reports no change of its own making
+No changes detected.
 
 
 === Reading another deployment's state does not poison this bundle's own cache
@@ -50,7 +54,7 @@ Error: --state-path does not support Volumes paths, got "/Volumes/main/default/v
 
 >>> withdir other [CLI] bundle destroy --auto-approve
 The following resources will be deleted:
-  delete resources.jobs.other_job
+  delete resources.jobs.my_job
 
 All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/other-bundle-[UNIQUE_NAME]/default
 

--- a/acceptance/bundle/config-remote-sync/state_path/script
+++ b/acceptance/bundle/config-remote-sync/state_path/script
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+envsubst < databricks.yml.tmpl > databricks.yml
+
+cleanup() {
+  trace $CLI bundle destroy --auto-approve
+}
+trap cleanup EXIT
+
+deployed_state="/Workspace/Users/${CURRENT_USER_NAME}/.bundle/test-bundle-${UNIQUE_NAME}/default/state"
+other_state="/Workspace/Users/${CURRENT_USER_NAME}/.bundle/other-bundle/default/state"
+
+$CLI bundle deploy
+job_id="$(read_id.py my_job)"
+
+title "Modify the job remotely"
+echo
+edit_resource.py jobs $job_id <<INNER
+r["max_concurrent_runs"] = 5
+INNER
+
+# The local cache is flushed before each sync so the state has to come from the
+# workspace path under test rather than from the deploy that just ran.
+title "--state-path at the deployment's own state folder detects the drift"
+echo
+rm -rf .databricks
+$CLI bundle config-remote-sync --state-path "$deployed_state" --select-ids "jobs:$job_id"
+
+title "A relative --state-path is rejected before any state is read"
+errcode trace $CLI bundle config-remote-sync --state-path relative/state
+
+title "A ~-relative --state-path is rejected too"
+errcode trace $CLI bundle config-remote-sync --state-path '~/.bundle/test/default/state'
+
+title "--state-path elsewhere does not see the deployment"
+echo
+rm -rf .databricks
+errcode trace $CLI bundle config-remote-sync --state-path "$other_state" --select-ids "jobs:$job_id" > out.$DATABRICKS_BUNDLE_ENGINE.txt 2>&1

--- a/acceptance/bundle/config-remote-sync/state_path/script
+++ b/acceptance/bundle/config-remote-sync/state_path/script
@@ -1,16 +1,20 @@
 #!/bin/bash
 
 envsubst < databricks.yml.tmpl > databricks.yml
+mkdir -p other
+envsubst < other.yml.tmpl > other/databricks.yml
 
 cleanup() {
+  trace withdir other $CLI bundle destroy --auto-approve
   trace $CLI bundle destroy --auto-approve
 }
 trap cleanup EXIT
 
-deployed_state="/Workspace/Users/${CURRENT_USER_NAME}/.bundle/test-bundle-${UNIQUE_NAME}/default/state"
-other_state="/Workspace/Users/${CURRENT_USER_NAME}/.bundle/other-bundle/default/state"
+own_state="/Workspace/Users/${CURRENT_USER_NAME}/.bundle/test-bundle-${UNIQUE_NAME}/default/state"
+other_state="/Workspace/Users/${CURRENT_USER_NAME}/.bundle/other-bundle-${UNIQUE_NAME}/default/state"
 
 $CLI bundle deploy
+withdir other $CLI bundle deploy
 job_id="$(read_id.py my_job)"
 
 title "Modify the job remotely"
@@ -19,20 +23,30 @@ edit_resource.py jobs $job_id <<INNER
 r["max_concurrent_runs"] = 5
 INNER
 
-# The local cache is flushed before each sync so the state has to come from the
-# workspace path under test rather than from the deploy that just ran.
-title "--state-path at the deployment's own state folder detects the drift"
+# Nothing below flushes .databricks: the deploy above populated it, and the override
+# has to win over that cache rather than be silently defeated by it.
+title "--state-path at this deployment's own state folder detects the drift"
 echo
-rm -rf .databricks
-$CLI bundle config-remote-sync --state-path "$deployed_state" --select-ids "jobs:$job_id"
+$CLI bundle config-remote-sync --state-path "$own_state" --select-ids "jobs:$job_id"
 
-title "A relative --state-path is rejected before any state is read"
-errcode trace $CLI bundle config-remote-sync --state-path relative/state
-
-title "A ~-relative --state-path is rejected too"
-errcode trace $CLI bundle config-remote-sync --state-path '~/.bundle/test/default/state'
-
-title "--state-path elsewhere does not see the deployment"
+title "The same folder without a /Workspace prefix resolves identically"
 echo
-rm -rf .databricks
-errcode trace $CLI bundle config-remote-sync --state-path "$other_state" --select-ids "jobs:$job_id" > out.$DATABRICKS_BUNDLE_ENGINE.txt 2>&1
+$CLI bundle config-remote-sync --state-path "/Users/${CURRENT_USER_NAME}/.bundle/test-bundle-${UNIQUE_NAME}/default/state" --select-ids "jobs:$job_id"
+
+title "Reading another deployment's state does not poison this bundle's own cache"
+echo
+errcode $CLI bundle config-remote-sync --state-path "$other_state" --select-ids "jobs:$job_id" > out.$DATABRICKS_BUNDLE_ENGINE.txt 2>&1
+echo "sync against the other deployment's state failed as expected (its state has no jobs:$job_id)"
+echo "this bundle still reads its own state:"
+$CLI bundle config-remote-sync
+
+title "A dev-mode target is not blocked from reading a state folder it does not own"
+echo
+errcode $CLI bundle config-remote-sync --state-path "/Workspace/Users/someone-else@example.com/.bundle/b/default/state" --select-ids "jobs:$job_id" 2>&1 | contains.py "!uniqueness when using 'mode: development'" >> out.$DATABRICKS_BUNDLE_ENGINE.txt
+errcode $CLI bundle config-remote-sync --state-path "/Workspace/Shared/.bundle/b/default/state" --select-ids "jobs:$job_id" 2>&1 | contains.py "!uniqueness when using 'mode: development'" >> out.$DATABRICKS_BUNDLE_ENGINE.txt
+echo "neither foreign path was rejected by the dev-mode uniqueness check"
+
+title "Rejected values"
+musterr trace $CLI bundle config-remote-sync --state-path relative/state
+musterr trace $CLI bundle config-remote-sync --state-path '~/.bundle/test/default/state'
+musterr trace $CLI bundle config-remote-sync --state-path /Volumes/main/default/vol/state

--- a/acceptance/bundle/config-remote-sync/state_path/script
+++ b/acceptance/bundle/config-remote-sync/state_path/script
@@ -33,6 +33,13 @@ title "The same folder without a /Workspace prefix resolves identically"
 echo
 $CLI bundle config-remote-sync --state-path "/Users/${CURRENT_USER_NAME}/.bundle/test-bundle-${UNIQUE_NAME}/default/state" --select-ids "jobs:$job_id"
 
+title "Reading another deployment's state reports no change of its own making"
+echo
+# The other deployment declares the same resource with the same fields, so a clean
+# diff is empty. Anything reported here is derived from this bundle's own defaults
+# rather than from the state folder that was passed.
+$CLI bundle config-remote-sync --state-path "$other_state"
+
 title "Reading another deployment's state does not poison this bundle's own cache"
 echo
 errcode $CLI bundle config-remote-sync --state-path "$other_state" --select-ids "jobs:$job_id" > out.$DATABRICKS_BUNDLE_ENGINE.txt 2>&1

--- a/acceptance/bundle/config-remote-sync/state_path/test.toml
+++ b/acceptance/bundle/config-remote-sync/state_path/test.toml
@@ -1,5 +1,5 @@
 RecordRequests = false
-Ignore = [".databricks", "databricks.yml"]
+Ignore = [".databricks", "databricks.yml", "other"]
 
 Env.DATABRICKS_BUNDLE_ENABLE_EXPERIMENTAL_YAML_SYNC = "true"
 

--- a/acceptance/bundle/config-remote-sync/state_path/test.toml
+++ b/acceptance/bundle/config-remote-sync/state_path/test.toml
@@ -1,0 +1,6 @@
+RecordRequests = false
+Ignore = [".databricks", "databricks.yml"]
+
+Env.DATABRICKS_BUNDLE_ENABLE_EXPERIMENTAL_YAML_SYNC = "true"
+
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/cmd/bundle/config_remote_sync.go
+++ b/cmd/bundle/config_remote_sync.go
@@ -2,20 +2,26 @@ package bundle
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"maps"
+	"os"
+	"path/filepath"
 	"runtime"
 	"slices"
 	"strings"
 
 	"github.com/databricks/cli/bundle"
 	"github.com/databricks/cli/bundle/configsync"
+	"github.com/databricks/cli/bundle/env"
 	"github.com/databricks/cli/bundle/statemgmt"
 	"github.com/databricks/cli/cmd/bundle/utils"
 	"github.com/databricks/cli/cmd/root"
 	"github.com/databricks/cli/libs/cmdctx"
+	envlib "github.com/databricks/cli/libs/env"
 	"github.com/databricks/cli/libs/flags"
 	"github.com/databricks/cli/libs/log"
 	"github.com/databricks/cli/libs/telemetry"
@@ -66,6 +72,14 @@ Examples:
 			return err
 		}
 
+		// Scope the local state cache to the state folder being read. The cache is
+		// otherwise keyed on bundle root and target alone, so another deployment's
+		// state would land in the default location and be picked up as this bundle's
+		// own by later commands, including deploy.
+		if statePath != "" {
+			cmd.SetContext(envlib.Set(cmd.Context(), env.TempDirVariable, stateCacheDir(statePath)))
+		}
+
 		stats := configsync.Stats{Save: save}
 
 		// Emit telemetry on every exit path, including failures inside
@@ -84,13 +98,21 @@ Examples:
 			AlwaysPull: true,
 			InitFunc: func(b *bundle.Bundle) {
 				b.SkipLocalFileValidation = true
-
-				// InitFunc runs before phases.Initialize, so this assignment takes
-				// precedence over DefineDefaultWorkspacePaths (which only fills an
-				// empty state_path) while still passing through PrependWorkspacePrefix.
-				if statePath != "" {
-					b.Config.Workspace.StatePath = statePath
+			},
+			// Applied after phases.Initialize so the dev-mode uniqueness check does not
+			// reject a state folder this command only reads: it belongs to the
+			// deployment being synced, not to whoever runs the command.
+			PostInitFunc: func(ctx context.Context, b *bundle.Bundle) error {
+				if statePath == "" {
+					return nil
 				}
+				// Assigned through a mutator so the value also lands in the dynamic
+				// config tree. Later phases convert dyn->typed on entry, which would
+				// otherwise restore the default before the state snapshot is read.
+				bundle.ApplyFuncContext(ctx, b, func(context.Context, *bundle.Bundle) {
+					b.Config.Workspace.StatePath = normalizeStatePath(statePath)
+				})
+				return nil
 			},
 			PostStateFunc: func(ctx context.Context, b *bundle.Bundle, stateDesc *statemgmt.StateDesc) error {
 				stats.Engine = stateDesc.Engine
@@ -199,15 +221,38 @@ Examples:
 	return cmd
 }
 
-// validateStatePathFlag rejects a --state-path that would resolve against whoever runs
-// the command. A caller-relative state folder is the failure this flag exists to
-// override, so silently expanding "~" or a relative path here would reintroduce it.
+// validateStatePathFlag rejects a --state-path this command cannot resolve to one
+// deployment's state folder. "~" is refused rather than expanded: it resolves to the
+// home of whoever runs the command, which is the resolution this flag exists to override.
 func validateStatePathFlag(statePath string) error {
-	if statePath == "" {
+	switch {
+	case statePath == "":
 		return nil
-	}
-	if strings.HasPrefix(statePath, "~") || !strings.HasPrefix(statePath, "/") {
+	case strings.HasPrefix(statePath, "~"):
+		return fmt.Errorf("--state-path must be an absolute workspace path, got %q: pass the path of the deployment to sync, not one relative to the current user's home", statePath)
+	case !strings.HasPrefix(statePath, "/"):
 		return fmt.Errorf("--state-path must be an absolute workspace path, got %q", statePath)
+	case strings.HasPrefix(statePath, "/Volumes/"):
+		return fmt.Errorf("--state-path does not support Volumes paths, got %q", statePath)
 	}
 	return nil
+}
+
+// stateCacheDir returns the local cache directory to use for an overridden state path.
+// It is keyed on the state folder so state read from another deployment can never occupy
+// the location this bundle caches its own state in, and stays outside the bundle tree so
+// a plain deploy in the same directory cannot pick it up. Deterministic, so repeat runs
+// against the same state folder still reuse the cache.
+func stateCacheDir(statePath string) string {
+	sum := sha256.Sum256([]byte(normalizeStatePath(statePath)))
+	return filepath.Join(os.TempDir(), "databricks-bundle-state", hex.EncodeToString(sum[:8]))
+}
+
+// normalizeStatePath applies the /Workspace prefixing that PrependWorkspacePrefix gives
+// a configured state_path. That mutator has already run by the time the flag is applied.
+func normalizeStatePath(statePath string) string {
+	if strings.HasPrefix(statePath, "/Workspace/") {
+		return statePath
+	}
+	return "/Workspace" + statePath
 }

--- a/cmd/bundle/config_remote_sync.go
+++ b/cmd/bundle/config_remote_sync.go
@@ -8,6 +8,7 @@ import (
 	"maps"
 	"runtime"
 	"slices"
+	"strings"
 
 	"github.com/databricks/cli/bundle"
 	"github.com/databricks/cli/bundle/configsync"
@@ -25,6 +26,7 @@ import (
 func newConfigRemoteSyncCommand() *cobra.Command {
 	var save bool
 	var selectIDs []string
+	var statePath string
 
 	cmd := &cobra.Command{
 		Use:   "config-remote-sync",
@@ -44,16 +46,24 @@ Examples:
   databricks bundle config-remote-sync --save
 
   # Restrict the sync to a single resource by its type and deployed resource ID
-  databricks bundle config-remote-sync --select-ids jobs:123456789 --save`,
+  databricks bundle config-remote-sync --select-ids jobs:123456789 --save
+
+  # Read the deployment state from an explicit workspace location
+  databricks bundle config-remote-sync --state-path /Workspace/Shared/.bundle/my_bundle/dev/state`,
 		Hidden: true, // Used by DABs in the Workspace only
 	}
 
 	cmd.Flags().BoolVar(&save, "save", false, "Write updated config files to disk")
 	cmd.Flags().StringSliceVar(&selectIDs, "select-ids", nil, "Sync only the given resources, each as <type>:<id> (e.g. jobs:123456789). Can be repeated or comma-separated.")
+	cmd.Flags().StringVar(&statePath, "state-path", "", "Absolute workspace path of the deployment state folder to read, overriding workspace.state_path. Use when the state does not live under the path this command resolves by default, e.g. because the bundle was deployed by another user.")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		if runtime.GOOS == "windows" {
 			return errors.New("config-remote-sync command is not supported on Windows")
+		}
+
+		if err := validateStatePathFlag(statePath); err != nil {
+			return err
 		}
 
 		stats := configsync.Stats{Save: save}
@@ -74,6 +84,13 @@ Examples:
 			AlwaysPull: true,
 			InitFunc: func(b *bundle.Bundle) {
 				b.SkipLocalFileValidation = true
+
+				// InitFunc runs before phases.Initialize, so this assignment takes
+				// precedence over DefineDefaultWorkspacePaths (which only fills an
+				// empty state_path) while still passing through PrependWorkspacePrefix.
+				if statePath != "" {
+					b.Config.Workspace.StatePath = statePath
+				}
 			},
 			PostStateFunc: func(ctx context.Context, b *bundle.Bundle, stateDesc *statemgmt.StateDesc) error {
 				stats.Engine = stateDesc.Engine
@@ -180,4 +197,17 @@ Examples:
 	}
 
 	return cmd
+}
+
+// validateStatePathFlag rejects a --state-path that would resolve against whoever runs
+// the command. A caller-relative state folder is the failure this flag exists to
+// override, so silently expanding "~" or a relative path here would reintroduce it.
+func validateStatePathFlag(statePath string) error {
+	if statePath == "" {
+		return nil
+	}
+	if strings.HasPrefix(statePath, "~") || !strings.HasPrefix(statePath, "/") {
+		return fmt.Errorf("--state-path must be an absolute workspace path, got %q", statePath)
+	}
+	return nil
 }

--- a/cmd/bundle/config_remote_sync.go
+++ b/cmd/bundle/config_remote_sync.go
@@ -2,20 +2,18 @@ package bundle
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"maps"
 	"os"
-	"path/filepath"
 	"runtime"
 	"slices"
 	"strings"
 
 	"github.com/databricks/cli/bundle"
 	"github.com/databricks/cli/bundle/configsync"
+	"github.com/databricks/cli/bundle/deploy/metadata"
 	"github.com/databricks/cli/bundle/env"
 	"github.com/databricks/cli/bundle/statemgmt"
 	"github.com/databricks/cli/cmd/bundle/utils"
@@ -72,12 +70,19 @@ Examples:
 			return err
 		}
 
-		// Scope the local state cache to the state folder being read. The cache is
-		// otherwise keyed on bundle root and target alone, so another deployment's
-		// state would land in the default location and be picked up as this bundle's
-		// own by later commands, including deploy.
+		// Materialize the state being read into a scratch directory: it has to be on
+		// disk to be opened, and the default location is keyed on bundle root and
+		// target alone, so another deployment's state would be left there for later
+		// commands, including deploy, to pick up as this bundle's own. Nothing needs
+		// it to persist, since the state is always re-read and never written back.
 		if statePath != "" {
-			cmd.SetContext(envlib.Set(cmd.Context(), env.TempDirVariable, stateCacheDir(statePath)))
+			parent, _ := env.TempDir(cmd.Context())
+			stateDir, err := os.MkdirTemp(parent, "databricks-bundle-state-")
+			if err != nil {
+				return err
+			}
+			defer os.RemoveAll(stateDir)
+			cmd.SetContext(envlib.Set(cmd.Context(), env.TempDirVariable, stateDir))
 		}
 
 		stats := configsync.Stats{Save: save}
@@ -112,6 +117,10 @@ Examples:
 				bundle.ApplyFuncContext(ctx, b, func(context.Context, *bundle.Bundle) {
 					b.Config.Workspace.StatePath = normalizeStatePath(statePath)
 				})
+				// deployment.metadata_file_path is derived from state_path at the end of
+				// phases.Initialize, which ran before this override. Recompute it, or the
+				// diff reports the default location as a change on every resource.
+				bundle.ApplySeqContext(ctx, b, metadata.AnnotateJobs(), metadata.AnnotatePipelines())
 				return nil
 			},
 			PostStateFunc: func(ctx context.Context, b *bundle.Bundle, stateDesc *statemgmt.StateDesc) error {
@@ -236,16 +245,6 @@ func validateStatePathFlag(statePath string) error {
 		return fmt.Errorf("--state-path does not support Volumes paths, got %q", statePath)
 	}
 	return nil
-}
-
-// stateCacheDir returns the local cache directory to use for an overridden state path.
-// It is keyed on the state folder so state read from another deployment can never occupy
-// the location this bundle caches its own state in, and stays outside the bundle tree so
-// a plain deploy in the same directory cannot pick it up. Deterministic, so repeat runs
-// against the same state folder still reuse the cache.
-func stateCacheDir(statePath string) string {
-	sum := sha256.Sum256([]byte(normalizeStatePath(statePath)))
-	return filepath.Join(os.TempDir(), "databricks-bundle-state", hex.EncodeToString(sum[:8]))
 }
 
 // normalizeStatePath applies the /Workspace prefixing that PrependWorkspacePrefix gives


### PR DESCRIPTION
## Changes

Add a `--state-path` flag to `bundle config-remote-sync` that overrides `workspace.state_path`, so the command reads the deployment state from an explicit workspace location instead of the one it derives from the bundle config.

The value must be an absolute workspace path; relative, `~`-prefixed, and `/Volumes/` values are rejected up front. A value without a `/Workspace` prefix is normalized the same way a configured `state_path` is.

Scoped to this command: no change to `bundle deploy` or to any shared bundle code.

## Why

When `workspace.root_path` is not set explicitly, it defaults to `~/.bundle/<name>/<target>`, and `~` expands to the home directory of whoever runs the command. That makes the resolved state location a property of the caller rather than of the deployment: a user who did not deploy the bundle resolves an empty state folder under their own home, so `--select-ids` finds no deployed resource and the sync fails.

The state folder is the single lever for this — `resources.json`, `terraform.tfstate`, the config snapshot and `metadata.json` are all siblings under `workspace.state_path` and all read through the same filer — so one flag pins every read to the folder the deployment actually wrote.

Two details worth calling out, both found in review:

- The override is applied in `PostInitFunc`, after `phases.Initialize`. Applying it earlier means `ValidateTargetMode` sees it, and for `mode: development` `findNonUserPath` rejects any `state_path` that does not contain the *current* user's name — which is exactly the cross-user case this flag exists to enable. This command only ever reads that folder, so dev-mode uniqueness of it is not meaningful here. It is assigned through a mutator so the value also reaches the dynamic config tree; later phases convert dyn to typed on entry and would otherwise restore the default before the state snapshot is read.
- State has to be on disk to be opened, and the default location for that is keyed on bundle root and target alone — so a redirected read would otherwise leave another deployment's state in this bundle's own cache, where later commands, including `deploy`, would pick it up as their own. With the flag set, the state is materialized into a per-invocation scratch directory that is removed on exit. Nothing needs it to persist: `AlwaysPull` re-reads the remote state every run and the state is opened read-only.
- `deployment.metadata_file_path` is derived from `state_path` by the annotators at the end of `phases.Initialize`, which runs before the override. It is recomputed afterwards, otherwise the diff reports the default location as a change on every job and pipeline — and `--save` would write that into the user's YAML.

## Tests

New hermetic acceptance test `bundle/config-remote-sync/state_path`, covering both engines. It deploys two bundles so the cross-deployment cases are real, and deliberately never flushes `.databricks`, so the override has to win over a populated cache rather than being handed an empty one:

- `--state-path` at the deployment's own state folder detects remote drift; the same folder without a `/Workspace` prefix resolves identically.
- Reading another deployment's state reports that deployment's resource ids, and afterwards the bundle's own unflagged sync still reads its own state.
- Reading a second deployment that declares the same resource identically reports no changes, pinning that nothing is derived from this bundle's own defaults.
- A dev-mode target is not blocked from a state folder under another user's home, or a shared one.
- Relative, `~`-prefixed and `/Volumes/` values are rejected before any state is read.

Verified the test fails without each fix: sharing the local cache reproduces `lineage mismatch in state files` and then a silent fallback to it, applying the override before `phases.Initialize` reproduces the dev-mode rejection, and skipping the annotator replay reproduces `metadata_file_path: add`.

_This PR was written by Claude Code._
