### PR TITLE
Print deploy results before post-deploy script & migration

### DIFF
--- a/acceptance/bundle/migrate/auto-migrate-clean/output.txt
+++ b/acceptance/bundle/migrate/auto-migrate-clean/output.txt
@@ -17,10 +17,10 @@ direct_drymigrate_warnings false
 >>> [CLI] bundle deploy
 Warn: Direct engine requested in bundle.engine setting at [TEST_TMP_DIR]/databricks.yml:3:11 but the existing state uses "terraform". Deploying on "terraform"; will attempt to migrate the state to the direct engine after this deploy.
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files...
-Migrating state to direct deployment engine (opted in via bundle.engine setting at [TEST_TMP_DIR]/databricks.yml:3:11)...
-Migrated 1 resource to direct deployment engine.
 Files: 3 uploaded, 0 deleted
 Resources: 0 created, 0 changed, 0 deleted, 1 unchanged
+Migrating state to direct deployment engine (opted in via bundle.engine setting at [TEST_TMP_DIR]/databricks.yml:3:11)...
+Migrated 1 resource to direct deployment engine.
 
 >>> print_migration_telemetry
 direct_migrated_via_config true

--- a/acceptance/bundle/migrate/auto-migrate-direct-only-envvar/output.txt
+++ b/acceptance/bundle/migrate/auto-migrate-direct-only-envvar/output.txt
@@ -13,10 +13,10 @@ Resources: 1 created, 0 changed, 0 deleted, 0 unchanged
 >>> DATABRICKS_BUNDLE_ENGINE=direct [CLI] bundle deploy
 Warn: Direct engine requested in DATABRICKS_BUNDLE_ENGINE environment variable but the existing state uses "terraform". Deploying on "terraform"; will attempt to migrate the state to the direct engine after this deploy.
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files...
-Migrating state to direct deployment engine (opted in via DATABRICKS_BUNDLE_ENGINE environment variable)...
-Migrated 1 resource to direct deployment engine.
 Files: 3 uploaded, 0 deleted
 Resources: 0 created, 0 changed, 0 deleted, 2 unchanged
+Migrating state to direct deployment engine (opted in via DATABRICKS_BUNDLE_ENGINE environment variable)...
+Migrated 1 resource to direct deployment engine.
 
 >>> print_migration_telemetry
 direct_migrated_via_env true

--- a/acceptance/bundle/migrate/auto-migrate-direct-only/output.txt
+++ b/acceptance/bundle/migrate/auto-migrate-direct-only/output.txt
@@ -23,10 +23,10 @@ json.plan.resources.instance_pools.pool.action = "skip";
 >>> [CLI] bundle deploy
 Warn: Direct engine requested in bundle.engine setting at [TEST_TMP_DIR]/databricks.yml:3:11 but the existing state uses "terraform". Deploying on "terraform"; will attempt to migrate the state to the direct engine after this deploy.
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files...
-Migrating state to direct deployment engine (opted in via bundle.engine setting at [TEST_TMP_DIR]/databricks.yml:3:11)...
-Migrated 1 resource to direct deployment engine.
 Files: 3 uploaded, 0 deleted
 Resources: 0 created, 0 changed, 0 deleted, 2 unchanged
+Migrating state to direct deployment engine (opted in via bundle.engine setting at [TEST_TMP_DIR]/databricks.yml:3:11)...
+Migrated 1 resource to direct deployment engine.
 
 >>> print_migration_telemetry
 direct_migrated_via_config true

--- a/acceptance/bundle/migrate/auto-migrate-empty-tfstate/output.txt
+++ b/acceptance/bundle/migrate/auto-migrate-empty-tfstate/output.txt
@@ -3,9 +3,9 @@
 >>> [CLI] bundle deploy
 Warn: Direct engine requested in bundle.engine setting at [TEST_TMP_DIR]/databricks.yml:3:11 but the existing state uses "terraform". Deploying on "terraform"; will attempt to migrate the state to the direct engine after this deploy.
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files...
-Removing empty terraform state; direct engine will be used on the next deploy (opted in via bundle.engine setting at [TEST_TMP_DIR]/databricks.yml:3:11)...
 Files: 4 uploaded, 0 deleted
 Resources: 0 created, 0 changed, 0 deleted, 0 unchanged
+Removing empty terraform state; direct engine will be used on the next deploy (opted in via bundle.engine setting at [TEST_TMP_DIR]/databricks.yml:3:11)...
 
 === Terraform state is renamed to .backup; no resources.json (empty state, nothing to persist)
 

--- a/acceptance/bundle/migrate/auto-migrate-envvar/output.txt
+++ b/acceptance/bundle/migrate/auto-migrate-envvar/output.txt
@@ -14,10 +14,10 @@ direct_drymigrate_warnings false
 >>> DATABRICKS_BUNDLE_ENGINE=direct [CLI] bundle deploy
 Warn: Direct engine requested in DATABRICKS_BUNDLE_ENGINE environment variable but the existing state uses "terraform". Deploying on "terraform"; will attempt to migrate the state to the direct engine after this deploy.
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files...
-Migrating state to direct deployment engine (opted in via DATABRICKS_BUNDLE_ENGINE environment variable)...
-Migrated 1 resource to direct deployment engine.
 Files: 2 uploaded, 0 deleted
 Resources: 0 created, 0 changed, 0 deleted, 1 unchanged
+Migrating state to direct deployment engine (opted in via DATABRICKS_BUNDLE_ENGINE environment variable)...
+Migrated 1 resource to direct deployment engine.
 
 >>> print_migration_telemetry
 direct_migrated_via_env true

--- a/acceptance/bundle/migrate/auto-migrate-push-failure/output.txt
+++ b/acceptance/bundle/migrate/auto-migrate-push-failure/output.txt
@@ -14,10 +14,10 @@ direct_drymigrate_warnings false
 >>> DATABRICKS_BUNDLE_ENGINE=direct [CLI] bundle deploy
 Warn: Direct engine requested in DATABRICKS_BUNDLE_ENGINE environment variable but the existing state uses "terraform". Deploying on "terraform"; will attempt to migrate the state to the direct engine after this deploy.
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files...
-Migrating state to direct deployment engine (opted in via DATABRICKS_BUNDLE_ENGINE environment variable)...
-Warn: automatic migration to direct engine failed: pushing direct state to workspace: access denied: /Workspace/Users/[USERNAME]/.bundle/test-bundle/default/state/resources.json
 Files: 2 uploaded, 0 deleted
 Resources: 0 created, 0 changed, 0 deleted, 1 unchanged
+Migrating state to direct deployment engine (opted in via DATABRICKS_BUNDLE_ENGINE environment variable)...
+Warn: automatic migration to direct engine failed: pushing direct state to workspace: access denied: /Workspace/Users/[USERNAME]/.bundle/test-bundle/default/state/resources.json
 
 >>> print_migration_telemetry
 direct_migrate_commit_error true
@@ -33,10 +33,10 @@ direct_migrate_commit_error true
 >>> DATABRICKS_BUNDLE_ENGINE=direct [CLI] bundle deploy
 Warn: Direct engine requested in DATABRICKS_BUNDLE_ENGINE environment variable but the existing state uses "terraform". Deploying on "terraform"; will attempt to migrate the state to the direct engine after this deploy.
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files...
-Migrating state to direct deployment engine (opted in via DATABRICKS_BUNDLE_ENGINE environment variable)...
-Migrated 1 resource to direct deployment engine.
 Files: 2 uploaded, 0 deleted
 Resources: 0 created, 0 changed, 0 deleted, 1 unchanged
+Migrating state to direct deployment engine (opted in via DATABRICKS_BUNDLE_ENGINE environment variable)...
+Migrated 1 resource to direct deployment engine.
 
 >>> print_migration_telemetry
 direct_migrated_via_env true

--- a/acceptance/bundle/migrate/auto-migrate-tfbackup-failure/output.txt
+++ b/acceptance/bundle/migrate/auto-migrate-tfbackup-failure/output.txt
@@ -14,10 +14,10 @@ direct_drymigrate_warnings false
 >>> DATABRICKS_BUNDLE_ENGINE=direct [CLI] bundle deploy
 Warn: Direct engine requested in DATABRICKS_BUNDLE_ENGINE environment variable but the existing state uses "terraform". Deploying on "terraform"; will attempt to migrate the state to the direct engine after this deploy.
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files...
-Migrating state to direct deployment engine (opted in via DATABRICKS_BUNDLE_ENGINE environment variable)...
-Warn: automatic migration to direct engine failed: pushing direct state to workspace: deleting remote terraform state: Fault injected by test.
 Files: 2 uploaded, 0 deleted
 Resources: 0 created, 0 changed, 0 deleted, 1 unchanged
+Migrating state to direct deployment engine (opted in via DATABRICKS_BUNDLE_ENGINE environment variable)...
+Warn: automatic migration to direct engine failed: pushing direct state to workspace: deleting remote terraform state: Fault injected by test.
 
 >>> print_migration_telemetry
 direct_migrate_commit_error true

--- a/acceptance/bundle/scripts/output.txt
+++ b/acceptance/bundle/scripts/output.txt
@@ -43,11 +43,11 @@ Executing 'predeploy' script
 from myscript.py 0 predeploy: hello stdout!
 from myscript.py 0 predeploy: hello stderr!
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/scripts/default/files...
+Files: 11 uploaded, 0 deleted
+Resources: 0 created, 0 changed, 0 deleted, 0 unchanged
 Executing 'postdeploy' script
 from myscript.py 0 postdeploy: hello stdout!
 from myscript.py 0 postdeploy: hello stderr!
-Files: 11 uploaded, 0 deleted
-Resources: 0 created, 0 changed, 0 deleted, 0 unchanged
 
 >>> EXITCODE=0 POSTDEPLOY_EXITCODE=1 errcode [CLI] bundle deploy
 Executing 'preinit' script
@@ -66,12 +66,12 @@ Executing 'predeploy' script
 from myscript.py 0 predeploy: hello stdout!
 from myscript.py 0 predeploy: hello stderr!
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/scripts/default/files...
+Files: 1 uploaded, 0 deleted
+Resources: 0 created, 0 changed, 0 deleted, 0 unchanged
 Executing 'postdeploy' script
 from myscript.py 1 postdeploy: hello stdout!
 from myscript.py 1 postdeploy: hello stderr!
 Error: failed to execute script: exit status 1
 
-Files: 1 uploaded, 0 deleted
-Resources: 0 created, 0 changed, 0 deleted, 0 unchanged
 
 Exit code: 1

--- a/acceptance/bundle/scripts/restricted-execution/output.txt
+++ b/acceptance/bundle/scripts/restricted-execution/output.txt
@@ -12,10 +12,10 @@ postbuild value_from_env
 Executing 'predeploy' script
 predeploy value_from_env
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/scripts_with_restricted_execution/default/files...
-Executing 'postdeploy' script
-postdeploy value_from_env
 Files: 3 uploaded, 0 deleted
 Resources: 0 created, 0 changed, 0 deleted, 0 unchanged
+Executing 'postdeploy' script
+postdeploy value_from_env
 
 === With DATABRICKS_BUNDLE_RESTRICTED_CODE_EXECUTION=1, no envs are accessible
 >>> DATABRICKS_BUNDLE_RESTRICTED_CODE_EXECUTION=1 errcode [CLI] bundle deploy

--- a/acceptance/fips/output.txt
+++ b/acceptance/fips/output.txt
@@ -1,5 +1,6 @@
 
 >>> go version -m [CLI]
-	build	-tags=fips140v1.0
-	build	DefaultGODEBUG=fips140=on
-	build	GOFIPS140=v1.0.0-c2097c7c
+contains error: 'DefaultGODEBUG=fips140=on' not found in the output.
+contains error: 'GOFIPS140=v1.0.0' not found in the output.
+
+Exit code: 1

--- a/acceptance/fips/output.txt
+++ b/acceptance/fips/output.txt
@@ -1,6 +1,5 @@
 
 >>> go version -m [CLI]
-contains error: 'DefaultGODEBUG=fips140=on' not found in the output.
-contains error: 'GOFIPS140=v1.0.0' not found in the output.
-
-Exit code: 1
+	build	-tags=fips140v1.0
+	build	DefaultGODEBUG=fips140=on
+	build	GOFIPS140=v1.0.0-c2097c7c

--- a/bundle/phases/deploy.go
+++ b/bundle/phases/deploy.go
@@ -311,16 +311,17 @@ func Deploy(ctx context.Context, b *bundle.Bundle, outputHandler sync.OutputHand
 		return
 	}
 
-	bundle.ApplyContext(ctx, b, scripts.Execute(config.ScriptPostDeploy))
-
-	// Report what was deployed, mirroring "bundle plan". Printed last so it does not
-	// precede (and appear to vouch for) the postdeploy script's output. Printed even
-	// if that script fails: the resources were already applied successfully by then,
-	// so the counts are accurate, and the script's error still propagates. Earlier
-	// failures report the files only, since the plan counts would then describe what
-	// was intended rather than what was applied.
+	// Report what was deployed, mirroring "bundle plan". Printed before the
+	// postdeploy script so the deploy's own report is not interleaved with
+	// post-deploy output: the script's lines and the migration's below both follow
+	// it, and neither reads as belonging to the deploy. The resources were applied
+	// above, so the counts are accurate however the script turns out, and its error
+	// still propagates. Earlier failures report the files only, since the plan
+	// counts would then describe what was intended rather than what was applied.
 	filesReported = true
 	logDeploySummary(ctx, b, plan)
+
+	bundle.ApplyContext(ctx, b, scripts.Execute(config.ScriptPostDeploy))
 
 	// Migrate the state to the direct engine, if the user opted in (via
 	// bundle.engine or DATABRICKS_BUNDLE_ENGINE) and a dry-run of the migration
@@ -335,7 +336,7 @@ func Deploy(ctx context.Context, b *bundle.Bundle, outputHandler sync.OutputHand
 	// Gated on the deploy alone, which the early return above already guarantees
 	// — not on the postdeploy script. The resources were applied before that
 	// script ran, so the state is worth migrating even if it failed, the same
-	// reasoning that prints the summary regardless.
+	// reasoning that prints the summary ahead of it.
 	if !stateEngine.IsDirect() {
 		statemgmt.MigrateToDirect(ctx, b, requestedEngine)
 	}

--- a/bundle/phases/deploy.go
+++ b/bundle/phases/deploy.go
@@ -322,10 +322,11 @@ func Deploy(ctx context.Context, b *bundle.Bundle, outputHandler sync.OutputHand
 	filesReported = true
 	logDeploySummary(ctx, b, plan)
 
-	// Dry-run the migration to the direct engine and record the outcome in
-	// telemetry. If the user opted in (via bundle.engine or
-	// DATABRICKS_BUNDLE_ENGINE) and the dry-run is clean, the migration is
-	// committed; otherwise nothing is written and the deploy is unaffected.
+	// Migrate the state to the direct engine, if the user opted in (via
+	// bundle.engine or DATABRICKS_BUNDLE_ENGINE) and a dry-run of the migration
+	// comes back clean. Without the opt-in, or when the dry-run reports problems,
+	// nothing is written: only the outcome is recorded in telemetry, and the
+	// deploy is unaffected.
 	//
 	// Last, after the deploy has reported what it did: this is post-deploy work,
 	// and its warnings read as belonging to the deploy if they precede the

--- a/bundle/phases/deploy.go
+++ b/bundle/phases/deploy.go
@@ -77,7 +77,7 @@ func approvalForDeploy(ctx context.Context, b *bundle.Bundle, plan *deployplan.P
 	return cmdio.AskYesOrNo(ctx, "Would you like to proceed?")
 }
 
-func deployCore(ctx context.Context, b *bundle.Bundle, plan *deployplan.Plan, stateEngine engine.EngineType, requestedEngine engine.EngineSetting) {
+func deployCore(ctx context.Context, b *bundle.Bundle, plan *deployplan.Plan, stateEngine engine.EngineType) {
 	// Apply resources and capture post-apply state.
 	// For direct: Finalize flushes the WAL to disk and returns the state;
 	// called even if Apply failed so partial progress is saved.
@@ -116,15 +116,6 @@ func deployCore(ctx context.Context, b *bundle.Bundle, plan *deployplan.Plan, st
 		metadata.Upload(),
 		statemgmt.UploadStateForYamlSync(stateEngine),
 	)
-
-	// Once the deploy is complete, dry-run the migration to the direct engine
-	// and record the outcome in telemetry. If the user has opted in to the
-	// direct engine (via bundle.engine or DATABRICKS_BUNDLE_ENGINE) and the
-	// dry-run is clean, the migration is committed; otherwise nothing is
-	// written and the deploy is unaffected.
-	if !stateEngine.IsDirect() && !logdiag.HasError(ctx) {
-		statemgmt.MigrateToDirect(ctx, b, requestedEngine)
-	}
 }
 
 // logFileSummary reports what the file sync did. Separate from the resource summary
@@ -310,7 +301,7 @@ func Deploy(ctx context.Context, b *bundle.Bundle, outputHandler sync.OutputHand
 		return
 	}
 	if haveApproval {
-		deployCore(ctx, b, plan, stateEngine, requestedEngine)
+		deployCore(ctx, b, plan, stateEngine)
 	} else {
 		cmdio.LogString(ctx, "Deployment cancelled!")
 		return
@@ -330,6 +321,23 @@ func Deploy(ctx context.Context, b *bundle.Bundle, outputHandler sync.OutputHand
 	// was intended rather than what was applied.
 	filesReported = true
 	logDeploySummary(ctx, b, plan)
+
+	// Dry-run the migration to the direct engine and record the outcome in
+	// telemetry. If the user opted in (via bundle.engine or
+	// DATABRICKS_BUNDLE_ENGINE) and the dry-run is clean, the migration is
+	// committed; otherwise nothing is written and the deploy is unaffected.
+	//
+	// Last, after the deploy has reported what it did: this is post-deploy work,
+	// and its warnings read as belonging to the deploy if they precede the
+	// summary.
+	//
+	// Gated on the deploy alone, which the early return above already guarantees
+	// — not on the postdeploy script. The resources were applied before that
+	// script ran, so the state is worth migrating even if it failed, the same
+	// reasoning that prints the summary regardless.
+	if !stateEngine.IsDirect() {
+		statemgmt.MigrateToDirect(ctx, b, requestedEngine)
+	}
 }
 
 func RunPlan(ctx context.Context, b *bundle.Bundle, engine engine.EngineType) *deployplan.Plan {


### PR DESCRIPTION
## Why

The migration's output preceded the deploy's own summary, so its warnings read as belonging to the deploy:

```
Uploading bundle files to /Workspace/Users/.../files...
Warn: post-deploy dry-run migration to direct: unknown permission level "BOGUS" for secret scope
Created secret_scopes.my_scope
Files: 5 uploaded, 0 deleted
Resources: 2 created, 0 changed, 0 deleted, 0 unchanged
```
