### PR TITLE
acc: build CLI with FIPS toolchain so `go test` matches release

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -302,6 +302,12 @@ func testAccept(t *testing.T, inprocessMode bool, singleTest string) int {
 		t.Logf("Writing coverage to %s", coverDir)
 	}
 
+	// Build the CLI with the FIPS toolchain so a plain `go test` produces the
+	// same FIPS binary as `task` (which sets GOFIPS140 in its env) and the
+	// release pipeline; without it acceptance/fips fails outside `task`. The
+	// build below inherits os.Environ(), so setting it here is enough.
+	t.Setenv("GOFIPS140", readGOFIPS140(t, cwd))
+
 	execPath := ""
 	cliVersion := ""
 
@@ -1286,40 +1292,27 @@ func BuildCLI(t *testing.T, buildDir, coverDir, osName, arch string) string {
 		args = append(args, "-buildvcs=false")
 	}
 
-	// Build with the FIPS toolchain so a plain `go test` produces the same FIPS
-	// binary as `task` and the release build; otherwise acceptance/fips (which
-	// asserts the FIPS build settings) fails outside `task`.
-	version, err := gofips140Version()
-	require.NoError(t, err)
-	RunCommand(t, args, "..", []string{"GOOS=" + osName, "GOARCH=" + arch, "GOFIPS140=" + version})
+	RunCommand(t, args, "..", []string{"GOOS=" + osName, "GOARCH=" + arch})
 	return execPath
 }
 
-// gofips140Version returns the GOFIPS140 version the Taskfile pins for `task`
+// readGOFIPS140 returns the GOFIPS140 version the Taskfile pins for `task`
 // builds; the release pipeline pins the same value independently in
-// .goreleaser.yaml. Read once and cached, since BuildCLI runs per OS/arch and
-// the value is constant within a run. The path is relative to the acceptance
-// package dir, which is `go test`'s working directory.
-var gofips140Version = sync.OnceValues(func() (string, error) {
-	path := filepath.Join("..", "Taskfile.yml")
+// .goreleaser.yaml.
+func readGOFIPS140(t *testing.T, cwd string) string {
+	path := filepath.Join(cwd, "..", "Taskfile.yml")
 	data, err := os.ReadFile(path)
-	if err != nil {
-		return "", fmt.Errorf("reading %s (acceptance tests must run with cwd=acceptance/): %w", path, err)
-	}
+	require.NoError(t, err)
 
 	var taskfile struct {
 		Env struct {
 			GOFIPS140 string `yaml:"GOFIPS140"`
 		} `yaml:"env"`
 	}
-	if err := yaml.Unmarshal(data, &taskfile); err != nil {
-		return "", fmt.Errorf("parsing %s: %w", path, err)
-	}
-	if taskfile.Env.GOFIPS140 == "" {
-		return "", fmt.Errorf("GOFIPS140 not set in %s", path)
-	}
-	return taskfile.Env.GOFIPS140, nil
-})
+	require.NoError(t, yaml.Unmarshal(data, &taskfile))
+	require.NotEmpty(t, taskfile.Env.GOFIPS140, "GOFIPS140 not set in Taskfile.yml")
+	return taskfile.Env.GOFIPS140
+}
 
 // CreateReleaseArtifacts builds release artifacts for the given OS using amd64 and arm64 architectures,
 // archives them into zip files, and returns the directory containing the release artifacts.

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -1286,18 +1286,21 @@ func BuildCLI(t *testing.T, buildDir, coverDir, osName, arch string) string {
 		args = append(args, "-buildvcs=false")
 	}
 
-	// Build with the FIPS toolchain so `go test` ships the same binary the
-	// Taskfile and release pipeline do; otherwise acceptance/fips (which asserts
-	// the FIPS build settings) fails on a plain `go test` run.
-	RunCommand(t, args, "..", []string{"GOOS=" + osName, "GOARCH=" + arch, "GOFIPS140=" + readGOFIPS140(t)})
+	// Build with the FIPS toolchain so a plain `go test` produces the same FIPS
+	// binary as `task` and the release build; otherwise acceptance/fips (which
+	// asserts the FIPS build settings) fails outside `task`.
+	repoRoot := ".."
+	RunCommand(t, args, repoRoot, []string{"GOOS=" + osName, "GOARCH=" + arch, "GOFIPS140=" + readGOFIPS140(t, repoRoot)})
 	return execPath
 }
 
-// readGOFIPS140 returns the GOFIPS140 version pinned in the repo Taskfile, the
-// single source of truth also used by the release pipeline.
-func readGOFIPS140(t *testing.T) string {
-	data, err := os.ReadFile(filepath.Join("..", "Taskfile.yml"))
-	require.NoError(t, err)
+// readGOFIPS140 returns the GOFIPS140 version the Taskfile pins for `task`
+// builds. The release pipeline pins the same value independently in
+// .goreleaser.yaml.
+func readGOFIPS140(t *testing.T, repoRoot string) string {
+	path := filepath.Join(repoRoot, "Taskfile.yml")
+	data, err := os.ReadFile(path)
+	require.NoError(t, err, "reading %s (acceptance tests must run with cwd=acceptance/)", path)
 
 	var taskfile struct {
 		Env struct {

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/databricks/cli/libs/testdiff"
 	"github.com/databricks/cli/libs/testserver"
 	"github.com/stretchr/testify/require"
+	"go.yaml.in/yaml/v3"
 )
 
 var (
@@ -1285,8 +1286,27 @@ func BuildCLI(t *testing.T, buildDir, coverDir, osName, arch string) string {
 		args = append(args, "-buildvcs=false")
 	}
 
-	RunCommand(t, args, "..", []string{"GOOS=" + osName, "GOARCH=" + arch})
+	// Build with the FIPS toolchain so `go test` ships the same binary the
+	// Taskfile and release pipeline do; otherwise acceptance/fips (which asserts
+	// the FIPS build settings) fails on a plain `go test` run.
+	RunCommand(t, args, "..", []string{"GOOS=" + osName, "GOARCH=" + arch, "GOFIPS140=" + readGOFIPS140(t)})
 	return execPath
+}
+
+// readGOFIPS140 returns the GOFIPS140 version pinned in the repo Taskfile, the
+// single source of truth also used by the release pipeline.
+func readGOFIPS140(t *testing.T) string {
+	data, err := os.ReadFile(filepath.Join("..", "Taskfile.yml"))
+	require.NoError(t, err)
+
+	var taskfile struct {
+		Env struct {
+			GOFIPS140 string `yaml:"GOFIPS140"`
+		} `yaml:"env"`
+	}
+	require.NoError(t, yaml.Unmarshal(data, &taskfile))
+	require.NotEmpty(t, taskfile.Env.GOFIPS140, "GOFIPS140 not set in Taskfile.yml")
+	return taskfile.Env.GOFIPS140
 }
 
 // CreateReleaseArtifacts builds release artifacts for the given OS using amd64 and arm64 architectures,

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -1289,28 +1289,37 @@ func BuildCLI(t *testing.T, buildDir, coverDir, osName, arch string) string {
 	// Build with the FIPS toolchain so a plain `go test` produces the same FIPS
 	// binary as `task` and the release build; otherwise acceptance/fips (which
 	// asserts the FIPS build settings) fails outside `task`.
-	repoRoot := ".."
-	RunCommand(t, args, repoRoot, []string{"GOOS=" + osName, "GOARCH=" + arch, "GOFIPS140=" + readGOFIPS140(t, repoRoot)})
+	version, err := gofips140Version()
+	require.NoError(t, err)
+	RunCommand(t, args, "..", []string{"GOOS=" + osName, "GOARCH=" + arch, "GOFIPS140=" + version})
 	return execPath
 }
 
-// readGOFIPS140 returns the GOFIPS140 version the Taskfile pins for `task`
-// builds. The release pipeline pins the same value independently in
-// .goreleaser.yaml.
-func readGOFIPS140(t *testing.T, repoRoot string) string {
-	path := filepath.Join(repoRoot, "Taskfile.yml")
+// gofips140Version returns the GOFIPS140 version the Taskfile pins for `task`
+// builds; the release pipeline pins the same value independently in
+// .goreleaser.yaml. Read once and cached, since BuildCLI runs per OS/arch and
+// the value is constant within a run. The path is relative to the acceptance
+// package dir, which is `go test`'s working directory.
+var gofips140Version = sync.OnceValues(func() (string, error) {
+	path := filepath.Join("..", "Taskfile.yml")
 	data, err := os.ReadFile(path)
-	require.NoError(t, err, "reading %s (acceptance tests must run with cwd=acceptance/)", path)
+	if err != nil {
+		return "", fmt.Errorf("reading %s (acceptance tests must run with cwd=acceptance/): %w", path, err)
+	}
 
 	var taskfile struct {
 		Env struct {
 			GOFIPS140 string `yaml:"GOFIPS140"`
 		} `yaml:"env"`
 	}
-	require.NoError(t, yaml.Unmarshal(data, &taskfile))
-	require.NotEmpty(t, taskfile.Env.GOFIPS140, "GOFIPS140 not set in Taskfile.yml")
-	return taskfile.Env.GOFIPS140
-}
+	if err := yaml.Unmarshal(data, &taskfile); err != nil {
+		return "", fmt.Errorf("parsing %s: %w", path, err)
+	}
+	if taskfile.Env.GOFIPS140 == "" {
+		return "", fmt.Errorf("GOFIPS140 not set in %s", path)
+	}
+	return taskfile.Env.GOFIPS140, nil
+})
 
 // CreateReleaseArtifacts builds release artifacts for the given OS using amd64 and arm64 architectures,
 // archives them into zip files, and returns the directory containing the release artifacts.


### PR DESCRIPTION
## Changes
Build the CLI binary with the FIPS toolchain in `BuildCLI`, reading the pinned `GOFIPS140` version from `Taskfile.yml`. Previously the FIPS build settings were only set via the Taskfile's global `env:`, so a plain `go test ./acceptance` produced a non-FIPS binary and `acceptance/fips` failed.

## Why
The `acceptance/fips` test is a sanity check that we ship a FIPS build. It only passed when run through `task`, which exports `GOFIPS140`. Setting it in the root `test.toml` doesn't help because it's a build-time toolchain env, not a runtime one — it has to be applied where the test builds the binary. Reading it from `Taskfile.yml` keeps a single source of truth.

## Tests
`go test ./acceptance -run TestAccept/fips` now passes both with and without `GOFIPS140` set in the environment.
