### PR TITLE
acc: show that direct engine ignores suspend_timeout_duration updates

### DIFF
--- a/acceptance/bundle/resources/postgres_endpoints/update_suspend_timeout/databricks.yml.tmpl
+++ b/acceptance/bundle/resources/postgres_endpoints/update_suspend_timeout/databricks.yml.tmpl
@@ -1,0 +1,28 @@
+bundle:
+  name: update-postgres-endpoint-suspend-$UNIQUE_NAME
+
+sync:
+  paths: []
+
+resources:
+  postgres_projects:
+    my_project:
+      project_id: test-pg-proj-$UNIQUE_NAME
+      display_name: "Test Project for Endpoint Suspend Timeout Update"
+      pg_version: 16
+      history_retention_duration: 604800s
+
+  postgres_branches:
+    main:
+      parent: ${resources.postgres_projects.my_project.id}
+      branch_id: main
+      no_expiry: true
+
+  postgres_endpoints:
+    my_endpoint:
+      parent: ${resources.postgres_branches.main.id}
+      endpoint_id: my-endpoint
+      endpoint_type: ENDPOINT_TYPE_READ_ONLY
+      autoscaling_limit_min_cu: 0.5
+      autoscaling_limit_max_cu: 8
+      suspend_timeout_duration: 300s

--- a/acceptance/bundle/resources/postgres_endpoints/update_suspend_timeout/out.deploy.direct.txt
+++ b/acceptance/bundle/resources/postgres_endpoints/update_suspend_timeout/out.deploy.direct.txt
@@ -1,0 +1,5 @@
+
+>>> [CLI] bundle deploy
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/update-postgres-endpoint-suspend-[UNIQUE_NAME]/default/files...
+Files: 0 uploaded, 0 deleted
+Resources: 0 created, 0 changed, 0 deleted, 3 unchanged

--- a/acceptance/bundle/resources/postgres_endpoints/update_suspend_timeout/out.deploy.terraform.txt
+++ b/acceptance/bundle/resources/postgres_endpoints/update_suspend_timeout/out.deploy.terraform.txt
@@ -1,0 +1,6 @@
+
+>>> [CLI] bundle deploy
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/update-postgres-endpoint-suspend-[UNIQUE_NAME]/default/files...
+Updated postgres_endpoints.my_endpoint
+Files: 0 uploaded, 0 deleted
+Resources: 0 created, 1 changed, 0 deleted, 2 unchanged

--- a/acceptance/bundle/resources/postgres_endpoints/update_suspend_timeout/out.endpoint.direct.txt
+++ b/acceptance/bundle/resources/postgres_endpoints/update_suspend_timeout/out.endpoint.direct.txt
@@ -1,0 +1,13 @@
+{
+  "endpoint_id": "my-endpoint",
+  "name": "projects/test-pg-proj-[UNIQUE_NAME]/branches/main/endpoints/my-endpoint",
+  "parent": "projects/test-pg-proj-[UNIQUE_NAME]/branches/main",
+  "uid": "[ENDPOINT_UID]",
+  "status": {
+    "endpoint_id": "my-endpoint",
+    "endpoint_type": "ENDPOINT_TYPE_READ_ONLY",
+    "autoscaling_limit_min_cu": 0.5,
+    "autoscaling_limit_max_cu": 8,
+    "suspend_timeout_duration": "300s"
+  }
+}

--- a/acceptance/bundle/resources/postgres_endpoints/update_suspend_timeout/out.endpoint.terraform.txt
+++ b/acceptance/bundle/resources/postgres_endpoints/update_suspend_timeout/out.endpoint.terraform.txt
@@ -1,0 +1,13 @@
+{
+  "endpoint_id": "my-endpoint",
+  "name": "projects/test-pg-proj-[UNIQUE_NAME]/branches/main/endpoints/my-endpoint",
+  "parent": "projects/test-pg-proj-[UNIQUE_NAME]/branches/main",
+  "uid": "[ENDPOINT_UID]",
+  "status": {
+    "endpoint_id": "my-endpoint",
+    "endpoint_type": "ENDPOINT_TYPE_READ_ONLY",
+    "autoscaling_limit_min_cu": 0.5,
+    "autoscaling_limit_max_cu": 8,
+    "suspend_timeout_duration": "600s"
+  }
+}

--- a/acceptance/bundle/resources/postgres_endpoints/update_suspend_timeout/out.plan.direct.txt
+++ b/acceptance/bundle/resources/postgres_endpoints/update_suspend_timeout/out.plan.direct.txt
@@ -1,0 +1,3 @@
+
+>>> [CLI] bundle plan
+Plan: 0 to add, 0 to change, 0 to delete, 3 unchanged

--- a/acceptance/bundle/resources/postgres_endpoints/update_suspend_timeout/out.plan.terraform.txt
+++ b/acceptance/bundle/resources/postgres_endpoints/update_suspend_timeout/out.plan.terraform.txt
@@ -1,0 +1,5 @@
+
+>>> [CLI] bundle plan
+update postgres_endpoints.my_endpoint
+
+Plan: 0 to add, 1 to change, 0 to delete, 2 unchanged

--- a/acceptance/bundle/resources/postgres_endpoints/update_suspend_timeout/out.test.toml
+++ b/acceptance/bundle/resources/postgres_endpoints/update_suspend_timeout/out.test.toml
@@ -1,0 +1,4 @@
+Cloud = true
+CloudEnvs.azure = false
+CloudEnvs.gcp = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/resources/postgres_endpoints/update_suspend_timeout/output.txt
+++ b/acceptance/bundle/resources/postgres_endpoints/update_suspend_timeout/output.txt
@@ -1,0 +1,47 @@
+
+=== Initial deployment with suspend_timeout_duration: 300s
+>>> [CLI] bundle deploy
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/update-postgres-endpoint-suspend-[UNIQUE_NAME]/default/files...
+Created postgres_branches.main
+Created postgres_endpoints.my_endpoint
+Created postgres_projects.my_project
+Files: 0 uploaded, 0 deleted
+Resources: 3 created, 0 changed, 0 deleted, 0 unchanged
+
+>>> [CLI] postgres get-endpoint projects/test-pg-proj-[UNIQUE_NAME]/branches/main/endpoints/my-endpoint
+{
+  "endpoint_id": "my-endpoint",
+  "name": "projects/test-pg-proj-[UNIQUE_NAME]/branches/main/endpoints/my-endpoint",
+  "parent": "projects/test-pg-proj-[UNIQUE_NAME]/branches/main",
+  "uid": "[ENDPOINT_UID]",
+  "status": {
+    "endpoint_id": "my-endpoint",
+    "endpoint_type": "ENDPOINT_TYPE_READ_ONLY",
+    "autoscaling_limit_min_cu": 0.5,
+    "autoscaling_limit_max_cu": 8,
+    "suspend_timeout_duration": "300s"
+  }
+}
+
+=== Change suspend_timeout_duration to 600s
+>>> update_file.py databricks.yml suspend_timeout_duration: 300s suspend_timeout_duration: 600s
+
+>>> [CLI] postgres get-endpoint projects/test-pg-proj-[UNIQUE_NAME]/branches/main/endpoints/my-endpoint
+
+>>> [CLI] bundle destroy --auto-approve
+The following resources will be deleted:
+  delete resources.postgres_branches.main
+  delete resources.postgres_endpoints.my_endpoint
+  delete resources.postgres_projects.my_project
+
+This action will result in the deletion of the following Lakebase projects along with
+all their branches, databases, and endpoints. All data stored in them will be permanently lost:
+  delete resources.postgres_projects.my_project
+
+This action will result in the deletion of the following Lakebase branches.
+All data stored in them will be permanently lost:
+  delete resources.postgres_branches.main
+
+All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/update-postgres-endpoint-suspend-[UNIQUE_NAME]/default
+
+Destroy: 3 deleted

--- a/acceptance/bundle/resources/postgres_endpoints/update_suspend_timeout/script
+++ b/acceptance/bundle/resources/postgres_endpoints/update_suspend_timeout/script
@@ -1,0 +1,27 @@
+envsubst < databricks.yml.tmpl > databricks.yml
+
+cleanup() {
+   trace $CLI bundle destroy --auto-approve
+   rm -f out.requests.txt
+}
+trap cleanup EXIT
+
+endpoint_name="projects/test-pg-proj-${UNIQUE_NAME}/branches/main/endpoints/my-endpoint"
+
+title "Initial deployment with suspend_timeout_duration: 300s"
+trace $CLI bundle deploy
+rm -f out.requests.txt
+trace $CLI postgres get-endpoint "${endpoint_name}" | endpoint_fields
+
+title "Change suspend_timeout_duration to 600s"
+trace update_file.py databricks.yml "suspend_timeout_duration: 300s" "suspend_timeout_duration: 600s"
+
+# The engines diverge from here on, so each step goes to a per-engine file.
+# Terraform plans and applies the change. The direct engine plans nothing:
+# structdiff compares duration.Duration field by field, and that type holds a
+# single unexported protobuf pointer, so 300s and 600s look equal to it. The
+# edit is silently dropped and the endpoint keeps its old value.
+trace $CLI bundle plan &> out.plan.$DATABRICKS_BUNDLE_ENGINE.txt
+trace $CLI bundle deploy &> out.deploy.$DATABRICKS_BUNDLE_ENGINE.txt
+rm -f out.requests.txt
+trace $CLI postgres get-endpoint "${endpoint_name}" | endpoint_fields > out.endpoint.$DATABRICKS_BUNDLE_ENGINE.txt

--- a/acceptance/bundle/resources/postgres_endpoints/update_suspend_timeout/test.toml
+++ b/acceptance/bundle/resources/postgres_endpoints/update_suspend_timeout/test.toml
@@ -1,0 +1,1 @@
+Badness = "Direct engine ignores suspend_timeout_duration updates: structdiff compares duration.Duration field by field and that type holds a single unexported protobuf pointer, so any two values look equal"


### PR DESCRIPTION
## Changes

Acceptance test that demonstrates an existing bug: editing a duration field is silently dropped by the direct engine.

Changing `suspend_timeout_duration` from `300s` to `600s` on a postgres endpoint plans `0 to change` and leaves the endpoint at `300s`. Terraform plans `1 to change` and applies it.

Cause: `structdiff` compares `duration.Duration` field by field, and that type holds a single unexported protobuf pointer, so any two values look equal to it. Same for `types/time.Time`. Only `nil` <-> set transitions are detected.

The goldens encode the current (wrong) direct behaviour, so the fix will show up as a diff on `out.plan.direct.txt` / `out.endpoint.direct.txt`.

Prior art: #4480 implemented this fix but went stale and was auto-closed.

## Tests

New acceptance test.

This pull request and its description were written by Isaac.