### PR TITLE
direct: raise resource generator recursion cap from 4 to 10

### DIFF
--- a/acceptance/bundle/resources/model_serving_endpoints/drift/write_only/databricks.yml
+++ b/acceptance/bundle/resources/model_serving_endpoints/drift/write_only/databricks.yml
@@ -17,6 +17,19 @@ resources:
               openai_config:
                 # Write-only secret: the backend stores it and never echoes it back.
                 openai_api_key_plaintext: sk-test-plaintext-key
+          - name: prod-custom
+            external_model:
+              name: my-custom-model
+              provider: custom
+              task: llm/v1/chat
+              custom_provider_config:
+                custom_provider_url: https://custom-provider.example
+                api_key_auth:
+                  key: Authorization
+                  # Write-only secret nested a level deeper than the sibling *_config
+                  # plaintext keys; only reachable now that the generator descends past
+                  # the old depth-4 cap into the auth wrapper.
+                  value_plaintext: custom-plaintext-key
         traffic_config:
           routes:
             - served_model_name: prod

--- a/acceptance/bundle/resources/model_serving_endpoints/drift/write_only/output.txt
+++ b/acceptance/bundle/resources/model_serving_endpoints/drift/write_only/output.txt
@@ -27,6 +27,13 @@ Plan: 0 to add, 0 to change, 0 to delete, 1 unchanged
     "new": "sk-test-plaintext-key",
     "remote": ""
   },
+  "config.served_entities[1].external_model.custom_provider_config.api_key_auth.value_plaintext": {
+    "action": "skip",
+    "reason": "spec:input_only",
+    "old": "custom-plaintext-key",
+    "new": "custom-plaintext-key",
+    "remote": ""
+  },
   "description": {
     "action": "skip",
     "reason": "empty",
@@ -63,6 +70,21 @@ Resources: 0 created, 0 changed, 0 deleted, 1 unchanged
             "task": "llm/v1/chat"
           },
           "name": "prod"
+        },
+        {
+          "external_model": {
+            "custom_provider_config": {
+              "api_key_auth": {
+                "key": "Authorization",
+                "value_plaintext": "custom-plaintext-key"
+              },
+              "custom_provider_url": "https://custom-provider.example"
+            },
+            "name": "my-custom-model",
+            "provider": "custom",
+            "task": "llm/v1/chat"
+          },
+          "name": "prod-custom"
         }
       ],
       "traffic_config": {

--- a/bundle/direct/dresources/resources.generated.yml
+++ b/bundle/direct/dresources/resources.generated.yml
@@ -224,6 +224,10 @@ resources:
         reason: spec:input_only
       - field: config.served_entities[*].external_model.cohere_config.cohere_api_key_plaintext
         reason: spec:input_only
+      - field: config.served_entities[*].external_model.custom_provider_config.api_key_auth.value_plaintext
+        reason: spec:input_only
+      - field: config.served_entities[*].external_model.custom_provider_config.bearer_token_auth.token_plaintext
+        reason: spec:input_only
       - field: config.served_entities[*].external_model.databricks_model_serving_config.databricks_api_token_plaintext
         reason: spec:input_only
       - field: config.served_entities[*].external_model.google_cloud_vertex_ai_config.private_key_plaintext

--- a/bundle/direct/dresources/resources.yml
+++ b/bundle/direct/dresources/resources.yml
@@ -322,12 +322,6 @@ resources:
       # has to be manual again.
       - field: telemetry_config.table_names
         reason: input_only
-      # Write-only secrets: the backend stores them and returns the reference field, not the plaintext.
-      # custom_provider_config is not in the OpenAPI spec so the generator cannot reach it.
-      - field: config.served_entities[*].external_model.custom_provider_config.api_key_auth.value_plaintext
-        reason: input_only
-      - field: config.served_entities[*].external_model.custom_provider_config.bearer_token_auth.token_plaintext
-        reason: input_only
     ignore_local_changes:
       - field: budget_policy_id
         reason: no_update_api

--- a/bundle/direct/tools/generate_resources.py
+++ b/bundle/direct/tools/generate_resources.py
@@ -73,7 +73,11 @@ def get_field_behaviors(schemas, type_name, resource_name=None, array_element_ty
         array_element_types = {}
 
     def extract(schema, prefix, visited, depth, inherited):
-        if depth > 4:
+        # Bound recursion as a runaway guard only; `visited` already guarantees
+        # termination (each type is expanded at most once). Real fields reach depth 5
+        # (e.g. external_model.custom_provider_config.bearer_token_auth.token_plaintext),
+        # so keep ample headroom above that.
+        if depth > 10:
             return {}
         results = {}
         for name, prop in schema.get("fields", {}).items():

--- a/bundle/direct/tools/generate_resources.py
+++ b/bundle/direct/tools/generate_resources.py
@@ -77,8 +77,9 @@ def get_field_behaviors(schemas, type_name, resource_name=None, array_element_ty
         # termination (each type is expanded at most once). Real fields reach depth 5
         # (e.g. external_model.custom_provider_config.bearer_token_auth.token_plaintext),
         # so keep ample headroom above that.
-        if depth > 10:
-            return {}
+        max_depth = 10
+        if depth > max_depth:
+            raise Exception(f"Nested field found at depth {depth} ({max_depth=})")
         results = {}
         for name, prop in schema.get("fields", {}).items():
             path = f"{prefix}.{name}" if prefix else name


### PR DESCRIPTION
## Changes

- Increase resource field depth cap from 4 to 10
- Auto-generate the spec:input_only for a depth 5 field

## Why

#6366 allowed field behaviour from nested fields, but `custom_provider_config` fields were still skipped.
The cap of depth 4 was arbitrary and 10 is sufficient to prevent runaway.

## Tests

Existing ones pass, added `custom_provider_config` to exercise it e2e

Before bumping max_depth to 10 the `task generate-direct-resources` would fail like this:

```
Traceback (most recent call last):
  File "/Users/jan.rose/pub/cli.worktrees/review-pr-6366/bundle/direct/tools/generate_resources.py", line 225, in <module>
    main()
  File "/Users/jan.rose/pub/cli.worktrees/review-pr-6366/bundle/direct/tools/generate_resources.py", line 214, in main
    all_behaviors = get_field_behaviors(schemas, type_name, resource, array_element_types)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jan.rose/pub/cli.worktrees/review-pr-6366/bundle/direct/tools/generate_resources.py", line 110, in get_field_behaviors
    return extract(schemas[type_name], "", set(), 0, inherited)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jan.rose/pub/cli.worktrees/review-pr-6366/bundle/direct/tools/generate_resources.py", line 105, in extract
    results.update(extract(schemas[elem_type], f"{path}[*]", visited, depth + 1, propagate))
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jan.rose/pub/cli.worktrees/review-pr-6366/bundle/direct/tools/generate_resources.py", line 97, in extract
    results.update(extract(schemas[ref], path, visited, depth + 1, propagate))
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jan.rose/pub/cli.worktrees/review-pr-6366/bundle/direct/tools/generate_resources.py", line 105, in extract
    results.update(extract(schemas[elem_type], f"{path}[*]", visited, depth + 1, propagate))
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jan.rose/pub/cli.worktrees/review-pr-6366/bundle/direct/tools/generate_resources.py", line 97, in extract
    results.update(extract(schemas[ref], path, visited, depth + 1, propagate))
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jan.rose/pub/cli.worktrees/review-pr-6366/bundle/direct/tools/generate_resources.py", line 97, in extract
    results.update(extract(schemas[ref], path, visited, depth + 1, propagate))
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jan.rose/pub/cli.worktrees/review-pr-6366/bundle/direct/tools/generate_resources.py", line 82, in extract
    raise Exception(f"Nested field found at depth {depth} ({max_depth=})")
Exception: Nested field found at depth 5 (max_depth=4)
task: Failed to run task "generate-direct-resources": exit status 1
```
