### PR TITLE
Do not count gone resource in destroyed count

### DIFF
--- a/.nextchanges/bundles/destroy-count-excludes-gone.md
+++ b/.nextchanges/bundles/destroy-count-excludes-gone.md
@@ -1,0 +1,1 @@
+`bundle destroy` no longer counts resources that are already gone remotely in its `Destroy: N deleted` summary. Such deletes only clean up stale state and are not listed under the deletion prompt, so they are now excluded from the count as well, matching the terraform engine.

--- a/acceptance/bundle/resources/cluster_policies/permissions/out_of_band_deletion/output.txt
+++ b/acceptance/bundle/resources/cluster_policies/permissions/out_of_band_deletion/output.txt
@@ -55,4 +55,4 @@ The following resources will be deleted:
 
 All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/test_cluster_policy_permissions_recreate/default
 
-Destroy: 1 deleted
+Destroy: 0 deleted

--- a/acceptance/bundle/resources/genie_spaces/recreate_when_gone/output.txt
+++ b/acceptance/bundle/resources/genie_spaces/recreate_when_gone/output.txt
@@ -16,4 +16,4 @@ Plan: 1 to add, 0 to change, 0 to delete, 0 unchanged
 >>> [CLI] bundle destroy --auto-approve
 All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/recreate-gone-genie-space-[UNIQUE_NAME]/default
 
-Destroy: 1 deleted
+Destroy: 0 deleted

--- a/acceptance/bundle/resources/jobs/remote_delete/destroy/out.destroy.direct.txt
+++ b/acceptance/bundle/resources/jobs/remote_delete/destroy/out.destroy.direct.txt
@@ -1,5 +1,0 @@
-
->>> errcode [CLI] bundle destroy --auto-approve
-All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/test-bundle/default
-
-Destroy: 1 deleted

--- a/acceptance/bundle/resources/jobs/remote_delete/destroy/out.destroy.terraform.txt
+++ b/acceptance/bundle/resources/jobs/remote_delete/destroy/out.destroy.terraform.txt
@@ -1,5 +1,0 @@
-
->>> errcode [CLI] bundle destroy --auto-approve
-All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/test-bundle/default
-
-Destroy: 0 deleted

--- a/acceptance/bundle/resources/jobs/remote_delete/destroy/output.txt
+++ b/acceptance/bundle/resources/jobs/remote_delete/destroy/output.txt
@@ -11,3 +11,8 @@ Files: 4 uploaded, 0 deleted
 Resources: 1 created, 0 changed, 0 deleted, 0 unchanged
 
 >>> [CLI] jobs delete [NUMID]
+
+>>> errcode [CLI] bundle destroy --auto-approve
+All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/test-bundle/default
+
+Destroy: 0 deleted

--- a/acceptance/bundle/resources/jobs/remote_delete/destroy/script
+++ b/acceptance/bundle/resources/jobs/remote_delete/destroy/script
@@ -2,4 +2,4 @@ trace $CLI bundle plan
 trace $CLI bundle deploy
 job_id=`$CLI bundle summary -o json | jq -r .resources.jobs.foo.id`
 trace $CLI jobs delete $job_id
-trace errcode $CLI bundle destroy --auto-approve &> out.destroy.$DATABRICKS_BUNDLE_ENGINE.txt
+trace errcode $CLI bundle destroy --auto-approve

--- a/acceptance/bundle/resources/permissions/genie_spaces/out_of_band_deletion/output.txt
+++ b/acceptance/bundle/resources/permissions/genie_spaces/out_of_band_deletion/output.txt
@@ -75,4 +75,4 @@ The following resources will be deleted:
 
 All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/test-bundle/default
 
-Destroy: 1 deleted
+Destroy: 0 deleted

--- a/bundle/phases/destroy.go
+++ b/bundle/phases/destroy.go
@@ -163,12 +163,12 @@ func destroyCore(ctx context.Context, b *bundle.Bundle, plan *deployplan.Plan, e
 	if !logdiag.HasError(ctx) && b.Quiet < bundle.QuietAll {
 		// Count top-level resources only, matching the approval list above (which
 		// skips children); this also keeps the count stable across engines. Gone
-		// resources are included: they are excluded from the approval prompt because
-		// they are not destructive, but destroying them does remove them from state,
-		// and "bundle deploy" likewise counts them as deleted.
+		// resources are excluded to match that list: they were already deleted
+		// remotely, so applying their Delete only cleans up stale state and is not
+		// a destruction to report.
 		deleted := 0
 		for _, a := range plan.GetActions() {
-			if a.ActionType == deployplan.Delete && !a.IsChildResource() {
+			if a.ActionType == deployplan.Delete && !a.IsChildResource() && !a.Gone {
 				deleted++
 			}
 		}


### PR DESCRIPTION
## Changes
Do not count gone resource in destroyed count

## Why
Such resources were incorrectly reported in bundle destroy summary which led to confusion

## Tests
Covered by existing tests

<!-- If your PR needs to be included in the release notes for next release,
add a changelog fragment: create .nextchanges/<section>/<name>.md with a
one-line description (e.g. .nextchanges/cli/quickstart.md). See .nextchanges/README.md. -->
