### PR TITLE
Make the auto-migration notice friendlier when direct is the default

### DIFF
--- a/acceptance/bundle/migrate/auto-migrate-default/output.txt
+++ b/acceptance/bundle/migrate/auto-migrate-default/output.txt
@@ -12,7 +12,12 @@ direct_drymigrate_warnings false
 
 === Redeploy with nothing set: direct is the default, so auto-migration triggers
 >>> [CLI] bundle deploy
-Warn: Direct engine selected via default but the existing state uses "terraform". Deploying on "terraform"; will attempt to migrate the state to the direct engine after this deploy.
+Notice: the direct deployment engine is the default as of CLI v1.14.0.
+
+This bundle will be automatically migrated to use the direct deployment engine after this deployment.
+
+Learn more: https://docs.databricks.com/dev-tools/bundles/direct
+
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files...
 Files: 2 uploaded, 0 deleted
 Resources: 0 created, 0 changed, 0 deleted, 1 unchanged

--- a/cmd/bundle/utils/process.go
+++ b/cmd/bundle/utils/process.go
@@ -207,7 +207,16 @@ func ProcessBundleRet(cmd *cobra.Command, opts ProcessOptions) (b *bundle.Bundle
 		// `bundle debug states`, which would otherwise print the same hint
 		// even though they will not migrate.
 		if opts.Deploy && b.MigratingToDirect {
-			log.Warnf(ctx, "Direct engine selected via %s but the existing state uses %q. Deploying on %q; will attempt to migrate the state to the direct engine after this deploy.", requiredEngine.Source, stateDesc.Engine, stateDesc.Engine)
+			if requiredEngine.IsDefault {
+				// The user did not ask for direct; it is the default. Frame the
+				// auto-migration as an informational notice rather than a warning,
+				// and do not claim the user selected anything.
+				cmdio.LogString(ctx, "Notice: the direct deployment engine is the default as of CLI v1.14.0.\n\n"+
+					"This bundle will be automatically migrated to use the direct deployment engine after this deployment.\n\n"+
+					"Learn more: https://docs.databricks.com/dev-tools/bundles/direct\n")
+			} else {
+				log.Warnf(ctx, "Direct engine selected via %s but the existing state uses %q. Deploying on %q; will attempt to migrate the state to the direct engine after this deploy.", requiredEngine.Source, stateDesc.Engine, stateDesc.Engine)
+			}
 		}
 
 		// --select is only supported by the direct engine, which tracks resource


### PR DESCRIPTION
A bundle with terraform state printed a `Warn:` on every deploy saying the direct engine was "selected via default" — framing expected behavior as a problem and claiming a choice the user didn't make. This turns that case (`EngineSetting.IsDefault`, added in #6379) into an informational notice with a docs link. Explicit opt-ins keep the existing warning.

This pull request and its description were written by Isaac.
