### PR TITLE
apps: add git source and repo-modifier flags to create/update

### DIFF
--- a/acceptance/cmd/workspace/apps/output.txt
+++ b/acceptance/cmd/workspace/apps/output.txt
@@ -91,18 +91,23 @@ Usage:
   databricks apps update NAME [flags]
 
 Flags:
-      --budget-policy-id string     
-      --compute-max-instances int   Maximum number of app instances.
-      --compute-min-instances int   Minimum number of app instances.
-      --compute-size ComputeSize    Supported values: [LARGE, MEDIUM, XLARGE]
-      --description string          The description of the app.
-      --forward-user-access-token   Forward the user's access token to the app.
-      --git-provider string         Git provider. Case insensitive. Supported values: gitHub, gitHubEnterprise, bitbucketCloud, bitbucketServer, azureDevOpsServices, gitLab, gitLabEnterpriseEdition, awsCodeCommit.
-      --git-url string              URL of the Git repository the app deploys from.
-  -h, --help                        help for update
-      --json JSON                   either inline JSON string or @path/to/file.json with request body (default JSON (0 bytes))
-      --source-code-path string     
-      --space string                Name of the space this app belongs to.
+      --budget-policy-id string       
+      --compute-max-instances int     Maximum number of app instances.
+      --compute-min-instances int     Minimum number of app instances.
+      --compute-size ComputeSize      Supported values: [LARGE, MEDIUM, XLARGE]
+      --description string            The description of the app.
+      --forward-user-access-token     Forward the user's access token to the app.
+      --git-auto-deploy               Automatically redeploy the app on pushes to the configured Git branch. Requires --git-url and --git-provider.
+      --git-branch string             Git branch to deploy from.
+      --git-commit string             Git commit SHA to deploy from.
+      --git-provider string           Git provider. Case insensitive. Supported values: gitHub, gitHubEnterprise, bitbucketCloud, bitbucketServer, azureDevOpsServices, gitLab, gitLabEnterpriseEdition, awsCodeCommit.
+      --git-source-code-path string   Relative path to the app source code within the Git repository. Defaults to the repository root.
+      --git-tag string                Git tag to deploy from.
+      --git-url string                URL of the Git repository the app deploys from.
+  -h, --help                          help for update
+      --json JSON                     either inline JSON string or @path/to/file.json with request body (default JSON (0 bytes))
+      --source-code-path string       
+      --space string                  Name of the space this app belongs to.
       --usage-policy-id string
 
 Global Flags:

--- a/cmd/workspace/apps/git_flags.go
+++ b/cmd/workspace/apps/git_flags.go
@@ -2,7 +2,9 @@ package apps
 
 import (
 	"errors"
+	"fmt"
 
+	"github.com/databricks/cli/libs/cmdctx"
 	"github.com/databricks/databricks-sdk-go/service/apps"
 	"github.com/spf13/cobra"
 )
@@ -10,26 +12,44 @@ import (
 // The apps create/update/deploy commands accept a git repository and a git
 // deployment source, but the code generator emits these nested objects as
 // `// TODO: complex arg` and only exposes them via --json. These overrides add
-// ergonomic top-level flags for the GA git fields so users can point an app at
-// a repo and deploy a specific ref without hand-writing JSON.
+// ergonomic top-level flags for the git fields so users can point an app at a
+// repo and deploy a specific ref without hand-writing JSON.
 //
 // The SDK models GitRepository and GitSource as optional pointers on the
 // request. We leave them nil unless the user sets a git flag; allocating them
 // unconditionally would send an empty object on every non-git create/deploy and
 // change the request the server sees.
 
-// gitRepositoryFlags binds --git-url/--git-provider onto an *apps.GitRepository
-// pointer field (App.GitRepository), used by both create and update. It returns
-// a PreRunE that allocates the struct only when a flag was set.
-func gitRepositoryFlags(cmd *cobra.Command, target **apps.GitRepository) func(*cobra.Command, []string) error {
+// gitRepositoryFlags binds the git repository flags onto an *apps.GitRepository
+// pointer field (App.GitRepository), used by both create and update. url and
+// provider identify the repository; auto-deploy is a modifier on it
+// (push-to-deploy). withCallerCredential adds --caller-git-credential-id (the
+// credential granting the app's service principal repo access); the server
+// rejects it on update, so only create passes true. It returns a PreRunE that
+// allocates the struct only when a flag was set.
+func gitRepositoryFlags(cmd *cobra.Command, target **apps.GitRepository, withCallerCredential bool) func(*cobra.Command, []string) error {
 	var url, provider string
+	var autoDeploy bool
+	var callerCredentialID int64
 	cmd.Flags().StringVar(&url, "git-url", "", "URL of the Git repository the app deploys from.")
 	cmd.Flags().StringVar(&provider, "git-provider", "", "Git provider. Case insensitive. Supported values: gitHub, gitHubEnterprise, bitbucketCloud, bitbucketServer, azureDevOpsServices, gitLab, gitLabEnterpriseEdition, awsCodeCommit.")
+	cmd.Flags().BoolVar(&autoDeploy, "git-auto-deploy", false, "Automatically redeploy the app on pushes to the configured Git branch. Requires --git-url and --git-provider.")
+
+	// caller_credential_id can only be set on create; the server rejects it on
+	// update. The modifier list in the "requires repo" error tracks this so the
+	// message never names a flag the command doesn't have.
+	modifiers := "--git-auto-deploy"
+	if withCallerCredential {
+		cmd.Flags().Int64Var(&callerCredentialID, "caller-git-credential-id", 0, "ID of the caller's Git credential used to grant the app's service principal access to the repository. Create only. Requires --git-url and --git-provider.")
+		modifiers = "--git-auto-deploy and --caller-git-credential-id"
+	}
 
 	return func(cmd *cobra.Command, args []string) error {
 		urlSet := cmd.Flags().Changed("git-url")
 		providerSet := cmd.Flags().Changed("git-provider")
-		if !urlSet && !providerSet {
+		autoDeploySet := cmd.Flags().Changed("git-auto-deploy")
+		credSet := withCallerCredential && cmd.Flags().Changed("caller-git-credential-id")
+		if !urlSet && !providerSet && !autoDeploySet && !credSet {
 			return nil
 		}
 		// The server requires both url and provider together, so fail early
@@ -37,14 +57,31 @@ func gitRepositoryFlags(cmd *cobra.Command, target **apps.GitRepository) func(*c
 		if urlSet != providerSet {
 			return errors.New("--git-url and --git-provider must be set together")
 		}
-		*target = &apps.GitRepository{Url: url, Provider: provider}
+		// auto-deploy and the caller credential are modifiers on the repository;
+		// without url+provider there is no repository to attach them to.
+		if (autoDeploySet || credSet) && !urlSet {
+			return errors.New(modifiers + " require --git-url and --git-provider")
+		}
+		repo := &apps.GitRepository{Url: url, Provider: provider}
+		if autoDeploySet {
+			repo.AutoDeploy = autoDeploy
+			// auto_deploy is omitempty; force-send so --git-auto-deploy=false is
+			// transmitted (e.g. to turn auto-deploy off on update).
+			repo.ForceSendFields = append(repo.ForceSendFields, "AutoDeploy")
+		}
+		if credSet {
+			repo.CallerCredentialId = callerCredentialID
+		}
+		*target = repo
 		return nil
 	}
 }
 
-// gitSourceFlags binds the deploy-time git source flags onto an *apps.GitSource
-// pointer field (AppDeployment.GitSource). It returns a PreRunE that allocates
-// the struct only when a flag was set.
+// gitSourceFlags binds the git source flags onto an *apps.GitSource pointer
+// field: AppDeployment.GitSource on deploy (the ref for one deployment), and
+// App.GitSource on create/update (the app's default deployment source, echoed
+// back as default_git_source). It returns a PreRunE that allocates the struct
+// only when a flag was set.
 func gitSourceFlags(cmd *cobra.Command, target **apps.GitSource) func(*cobra.Command, []string) error {
 	var branch, tag, commit, sourceCodePath string
 	cmd.Flags().StringVar(&branch, "git-branch", "", "Git branch to deploy from.")
@@ -101,12 +138,99 @@ func chainPreRunE(cmd *cobra.Command, fn func(*cobra.Command, []string) error) {
 	}
 }
 
+// requireBranchForAutoDeploy enforces that enabling auto-deploy is paired with a
+// branch: auto-deploy redeploys on pushes to a branch, so a tag, a commit, or no
+// ref at all has nothing to watch. Turning auto-deploy off needs no branch. Both
+// create and update set the branch explicitly here rather than letting the
+// server fall back to the app's existing default_git_source. The check is a
+// no-op on any command without a --git-branch flag to satisfy it.
+func requireBranchForAutoDeploy(cmd *cobra.Command, args []string) error {
+	if !cmd.Flags().Changed("git-auto-deploy") || cmd.Flags().Lookup("git-branch") == nil {
+		return nil
+	}
+	on, err := cmd.Flags().GetBool("git-auto-deploy")
+	if err != nil {
+		return err
+	}
+	if on && !cmd.Flags().Changed("git-branch") {
+		return errors.New("--git-auto-deploy requires --git-branch: auto-deploy redeploys on pushes to a branch")
+	}
+	return nil
+}
+
+// requireRepoForGitSourceOnCreate enforces that a create-time git source is
+// paired with a repository: App.GitSource resolves its ref against
+// App.GitRepository, and on create there is no prior repository to fall back on
+// (unlike update/deploy, which reference the app's already-configured repo).
+// gitRepositoryFlags runs first and rejects url without provider, so checking
+// --git-url alone implies both are set.
+func requireRepoForGitSourceOnCreate(cmd *cobra.Command, args []string) error {
+	srcSet := cmd.Flags().Changed("git-branch") ||
+		cmd.Flags().Changed("git-tag") ||
+		cmd.Flags().Changed("git-commit") ||
+		cmd.Flags().Changed("git-source-code-path")
+	if srcSet && !cmd.Flags().Changed("git-url") {
+		return errors.New("--git-branch, --git-tag, --git-commit, and --git-source-code-path require --git-url and --git-provider on create: the git source resolves against the app's repository")
+	}
+	return nil
+}
+
 func gitCreateOverride(createCmd *cobra.Command, createReq *apps.CreateAppRequest) {
-	chainPreRunE(createCmd, gitRepositoryFlags(createCmd, &createReq.App.GitRepository))
+	chainPreRunE(createCmd, gitRepositoryFlags(createCmd, &createReq.App.GitRepository, true))
+	// App.GitSource is the create-time deployment source (the default ref);
+	// the server persists it and reports it back as default_git_source.
+	chainPreRunE(createCmd, gitSourceFlags(createCmd, &createReq.App.GitSource))
+	chainPreRunE(createCmd, requireBranchForAutoDeploy)
+	chainPreRunE(createCmd, requireRepoForGitSourceOnCreate)
+}
+
+// applyPreservedAutoDeploy carries a currently-enabled auto_deploy forward onto
+// the update request's git_repository. auto_deploy=true survives the omitempty
+// tag, so no ForceSendFields entry is needed; a currently-disabled auto_deploy
+// stays omitted (the server keeps it off).
+func applyPreservedAutoDeploy(repo *apps.GitRepository, currentAutoDeploy bool) {
+	if repo == nil || !currentAutoDeploy {
+		return
+	}
+	repo.AutoDeploy = true
+}
+
+// preserveAutoDeployOnUpdate keeps auto-deploy from being silently torn down
+// when a flag-based update changes the repository without re-asserting it. It
+// runs only on the flag path (not --json, which owns the whole body), only when
+// a repository change is being sent, and only when the user did not pass
+// --git-auto-deploy themselves; in that case it reads the app's current
+// auto_deploy from GetApp and carries it forward.
+func preserveAutoDeployOnUpdate(req *apps.UpdateAppRequest) func(*cobra.Command, []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		if cmd.Flags().Changed("json") || cmd.Flags().Changed("git-auto-deploy") {
+			return nil
+		}
+		if req.App.GitRepository == nil || len(args) == 0 {
+			return nil
+		}
+		ctx := cmd.Context()
+		current, err := cmdctx.WorkspaceClient(ctx).Apps.GetByName(ctx, args[0])
+		if err != nil {
+			return fmt.Errorf("read current app to preserve auto-deploy: %w", err)
+		}
+		if current.GitRepository != nil {
+			applyPreservedAutoDeploy(req.App.GitRepository, current.GitRepository.AutoDeploy)
+		}
+		return nil
+	}
 }
 
 func gitUpdateOverride(updateCmd *cobra.Command, updateReq *apps.UpdateAppRequest) {
-	chainPreRunE(updateCmd, gitRepositoryFlags(updateCmd, &updateReq.App.GitRepository))
+	chainPreRunE(updateCmd, gitRepositoryFlags(updateCmd, &updateReq.App.GitRepository, false))
+	// App.GitSource lets update set the deployment source (e.g. the branch
+	// auto-deploy watches) explicitly instead of leaning on the app's existing
+	// default_git_source.
+	chainPreRunE(updateCmd, gitSourceFlags(updateCmd, &updateReq.App.GitSource))
+	chainPreRunE(updateCmd, requireBranchForAutoDeploy)
+	// Runs last: preserve auto-deploy across a repository change the user made
+	// without re-asserting --git-auto-deploy.
+	chainPreRunE(updateCmd, preserveAutoDeployOnUpdate(updateReq))
 }
 
 func gitDeployOverride(deployCmd *cobra.Command, deployReq *apps.CreateAppDeploymentRequest) {

--- a/cmd/workspace/apps/git_flags_test.go
+++ b/cmd/workspace/apps/git_flags_test.go
@@ -9,13 +9,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// runGitRepositoryFlags wires gitRepositoryFlags onto a fresh command, sets the
-// given flags, runs the PreRunE, and returns the resulting pointer + error.
+// runGitRepositoryFlags wires gitRepositoryFlags (in create mode, so
+// --caller-git-credential-id is available) onto a fresh command, sets the given
+// flags, runs the PreRunE, and returns the resulting pointer + error.
 func runGitRepositoryFlags(t *testing.T, argv []string) (*apps.GitRepository, error) {
 	t.Helper()
 	cmd := &cobra.Command{}
 	var target *apps.GitRepository
-	pre := gitRepositoryFlags(cmd, &target)
+	pre := gitRepositoryFlags(cmd, &target, true)
 	require.NoError(t, cmd.ParseFlags(argv))
 	return target, pre(cmd, nil)
 }
@@ -61,6 +62,221 @@ func TestGitRepositoryFlags(t *testing.T) {
 		_, err := runGitRepositoryFlags(t, []string{"--git-provider", "gitHub"})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "must be set together")
+	})
+
+	t.Run("auto-deploy and caller credential populate the struct", func(t *testing.T) {
+		target, err := runGitRepositoryFlags(t, []string{
+			"--git-url", "https://github.com/databricks/git_app_repo.git",
+			"--git-provider", "gitHub",
+			"--git-auto-deploy",
+			"--caller-git-credential-id", "93488329053511",
+		})
+		require.NoError(t, err)
+		require.NotNil(t, target)
+		assert.True(t, target.AutoDeploy)
+		assert.Equal(t, int64(93488329053511), target.CallerCredentialId)
+	})
+
+	t.Run("auto-deploy=false is force-sent", func(t *testing.T) {
+		target, err := runGitRepositoryFlags(t, []string{
+			"--git-url", "https://github.com/x/y",
+			"--git-provider", "gitHub",
+			"--git-auto-deploy=false",
+		})
+		require.NoError(t, err)
+		require.NotNil(t, target)
+		assert.False(t, target.AutoDeploy)
+		// Otherwise omitempty would drop the field and the server could not
+		// distinguish "disable auto-deploy" from "unset".
+		assert.Contains(t, target.ForceSendFields, "AutoDeploy")
+	})
+
+	t.Run("auto-deploy without url and provider errors", func(t *testing.T) {
+		_, err := runGitRepositoryFlags(t, []string{"--git-auto-deploy"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "require --git-url and --git-provider")
+	})
+
+	t.Run("caller credential without url and provider errors", func(t *testing.T) {
+		_, err := runGitRepositoryFlags(t, []string{"--caller-git-credential-id", "42"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "require --git-url and --git-provider")
+	})
+
+	t.Run("caller credential is create-only", func(t *testing.T) {
+		// The server rejects caller_credential_id on UpdateApp, so update mode
+		// (withCallerCredential=false) must not register the flag at all.
+		cmd := &cobra.Command{}
+		var target *apps.GitRepository
+		gitRepositoryFlags(cmd, &target, false)
+		assert.Nil(t, cmd.Flags().Lookup("caller-git-credential-id"))
+		// The auto-deploy modifier is still available on update.
+		assert.NotNil(t, cmd.Flags().Lookup("git-auto-deploy"))
+	})
+
+	t.Run("update mode reports only auto-deploy in the requires-repo error", func(t *testing.T) {
+		cmd := &cobra.Command{}
+		var target *apps.GitRepository
+		pre := gitRepositoryFlags(cmd, &target, false)
+		require.NoError(t, cmd.ParseFlags([]string{"--git-auto-deploy"}))
+		err := pre(cmd, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--git-auto-deploy require")
+		assert.NotContains(t, err.Error(), "caller-git-credential-id")
+	})
+}
+
+// runAutoDeployBranchRule mimics the create command: it registers both the git
+// repository and git source flags, parses argv, and runs requireBranchForAutoDeploy.
+func runAutoDeployBranchRule(t *testing.T, argv []string) error {
+	t.Helper()
+	cmd := &cobra.Command{}
+	var repo *apps.GitRepository
+	var src *apps.GitSource
+	gitRepositoryFlags(cmd, &repo, true)
+	gitSourceFlags(cmd, &src)
+	require.NoError(t, cmd.ParseFlags(argv))
+	return requireBranchForAutoDeploy(cmd, nil)
+}
+
+func TestRequireBranchForAutoDeploy(t *testing.T) {
+	repo := []string{"--git-url", "https://github.com/x/y", "--git-provider", "gitHub"}
+
+	t.Run("auto-deploy on with a branch is allowed", func(t *testing.T) {
+		err := runAutoDeployBranchRule(t, append(repo, "--git-auto-deploy", "--git-branch", "main"))
+		require.NoError(t, err)
+	})
+
+	t.Run("auto-deploy on without a branch errors", func(t *testing.T) {
+		err := runAutoDeployBranchRule(t, append(repo, "--git-auto-deploy"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "requires --git-branch")
+	})
+
+	t.Run("auto-deploy on with only a tag errors", func(t *testing.T) {
+		err := runAutoDeployBranchRule(t, append(repo, "--git-auto-deploy", "--git-tag", "v1.0.0"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "requires --git-branch")
+	})
+
+	t.Run("auto-deploy off does not require a branch", func(t *testing.T) {
+		err := runAutoDeployBranchRule(t, append(repo, "--git-auto-deploy=false"))
+		require.NoError(t, err)
+	})
+
+	t.Run("auto-deploy unset does not require a branch", func(t *testing.T) {
+		err := runAutoDeployBranchRule(t, repo)
+		require.NoError(t, err)
+	})
+
+	t.Run("no-op when the command has no git-branch flag", func(t *testing.T) {
+		// A command that wires only the repository flags has no branch to
+		// demand, so the rule must stay out of its way.
+		cmd := &cobra.Command{}
+		var target *apps.GitRepository
+		gitRepositoryFlags(cmd, &target, true)
+		require.NoError(t, cmd.ParseFlags([]string{"--git-url", "https://github.com/x/y", "--git-provider", "gitHub", "--git-auto-deploy"}))
+		require.NoError(t, requireBranchForAutoDeploy(cmd, nil))
+	})
+}
+
+// runRepoForGitSourceRule mimics the create command (both flag groups) and runs
+// requireRepoForGitSourceOnCreate.
+func runRepoForGitSourceRule(t *testing.T, argv []string) error {
+	t.Helper()
+	cmd := &cobra.Command{}
+	var repo *apps.GitRepository
+	var src *apps.GitSource
+	gitRepositoryFlags(cmd, &repo, true)
+	gitSourceFlags(cmd, &src)
+	require.NoError(t, cmd.ParseFlags(argv))
+	return requireRepoForGitSourceOnCreate(cmd, nil)
+}
+
+func TestRequireRepoForGitSourceOnCreate(t *testing.T) {
+	repo := []string{"--git-url", "https://github.com/x/y", "--git-provider", "gitHub"}
+
+	t.Run("git source with a repo is allowed", func(t *testing.T) {
+		require.NoError(t, runRepoForGitSourceRule(t, append(repo, "--git-branch", "main")))
+	})
+
+	t.Run("branch without a repo errors", func(t *testing.T) {
+		err := runRepoForGitSourceRule(t, []string{"--git-branch", "main"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "require --git-url and --git-provider on create")
+	})
+
+	t.Run("tag without a repo errors", func(t *testing.T) {
+		err := runRepoForGitSourceRule(t, []string{"--git-tag", "v1.0.0"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "require --git-url and --git-provider on create")
+	})
+
+	t.Run("source-code-path with a ref but no repo errors", func(t *testing.T) {
+		err := runRepoForGitSourceRule(t, []string{"--git-commit", "abc123", "--git-source-code-path", "my-app"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "require --git-url and --git-provider on create")
+	})
+
+	t.Run("no git source flags is a no-op", func(t *testing.T) {
+		require.NoError(t, runRepoForGitSourceRule(t, repo))
+	})
+}
+
+func TestApplyPreservedAutoDeploy(t *testing.T) {
+	t.Run("carries a currently-enabled auto_deploy forward", func(t *testing.T) {
+		repo := &apps.GitRepository{Url: "https://github.com/x/y", Provider: "gitHub"}
+		applyPreservedAutoDeploy(repo, true)
+		assert.True(t, repo.AutoDeploy)
+	})
+
+	t.Run("leaves a currently-disabled auto_deploy off", func(t *testing.T) {
+		repo := &apps.GitRepository{Url: "https://github.com/x/y", Provider: "gitHub"}
+		applyPreservedAutoDeploy(repo, false)
+		assert.False(t, repo.AutoDeploy)
+	})
+
+	t.Run("nil repo is a no-op", func(t *testing.T) {
+		assert.NotPanics(t, func() { applyPreservedAutoDeploy(nil, true) })
+	})
+}
+
+// newPreserveCmd builds an update-like command with the repo flags and a --json
+// flag so the preserve guards can be exercised without a workspace client.
+func newPreserveCmd(t *testing.T, req *apps.UpdateAppRequest, argv []string) *cobra.Command {
+	t.Helper()
+	cmd := &cobra.Command{}
+	cmd.Flags().String("json", "", "")
+	gitRepositoryFlags(cmd, &req.App.GitRepository, false)
+	require.NoError(t, cmd.ParseFlags(argv))
+	return cmd
+}
+
+func TestPreserveAutoDeployOnUpdate_Guards(t *testing.T) {
+	// Each guard returns before the GetApp call, so no client is needed. If a
+	// guard failed to short-circuit, WorkspaceClient(ctx) would panic here.
+	t.Run("skips when --json is set", func(t *testing.T) {
+		req := &apps.UpdateAppRequest{}
+		cmd := newPreserveCmd(t, req, []string{"--json", "{}", "--git-url", "https://github.com/x/y", "--git-provider", "gitHub"})
+		require.NoError(t, preserveAutoDeployOnUpdate(req)(cmd, []string{"my-app"}))
+	})
+
+	t.Run("skips when --git-auto-deploy was passed", func(t *testing.T) {
+		req := &apps.UpdateAppRequest{}
+		cmd := newPreserveCmd(t, req, []string{"--git-url", "https://github.com/x/y", "--git-provider", "gitHub", "--git-auto-deploy"})
+		require.NoError(t, preserveAutoDeployOnUpdate(req)(cmd, []string{"my-app"}))
+	})
+
+	t.Run("skips when no repository change is being sent", func(t *testing.T) {
+		req := &apps.UpdateAppRequest{}
+		cmd := newPreserveCmd(t, req, nil) // GitRepository stays nil
+		require.NoError(t, preserveAutoDeployOnUpdate(req)(cmd, []string{"my-app"}))
+	})
+
+	t.Run("skips when no app name is available", func(t *testing.T) {
+		req := &apps.UpdateAppRequest{}
+		cmd := newPreserveCmd(t, req, []string{"--git-url", "https://github.com/x/y", "--git-provider", "gitHub"})
+		require.NoError(t, preserveAutoDeployOnUpdate(req)(cmd, nil))
 	})
 }
 


### PR DESCRIPTION
## Changes

Follow-up to #6371 (which added `--git-url`/`--git-provider` on create/update and the `apps deploy --git-*` ref flags). This extends the git flag overrides so a git-backed app can be fully configured without hand-written `--json`:

- **`apps create` / `apps update`**: `--git-branch`, `--git-tag`, `--git-commit`, `--git-source-code-path` — populate `App.GitSource` (the app's default deployment ref, which the server persists and returns as `default_git_source`) — plus `--git-auto-deploy` (push-to-deploy).
- **`apps create` only**: `--caller-git-credential-id` — the git credential granting the app's service principal repo access. The server rejects it on `UpdateApp`, so it is create-only.

### Validation
- git-source flags require `--git-url`/`--git-provider` on create (the ref resolves against the app's repository).
- `--git-auto-deploy` requires `--git-branch` (auto-deploy redeploys on pushes to a branch; a tag/commit has nothing to watch). Turning it off needs no branch.
- The repo modifiers require the repository (`--git-url`/`--git-provider`).

### auto_deploy on update
The sync `UpdateApp` replaces `git_repository` wholesale, and the server tears the push webhook down when a repository change omits `auto_deploy=true`. `GetApp` reports `auto_deploy=true` while the webhook is active, so on update the CLI reads the current value and carries it forward when `--git-auto-deploy` is not passed — a URL/provider change no longer silently disables push-to-deploy.

## Tests
- Unit tests for every flag helper and validator (`git_flags_test.go`).
- Acceptance golden regenerated (`apps update` help).
- `golangci-lint`: clean.

This pull request and its description were written by Isaac.
