### PR TITLE
nextchanges: Add NEXTCHANGES_DIR env to changelog-preview

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -297,6 +297,8 @@ tasks:
 
   changelog-preview:
     desc: Print the CHANGELOG.md section the next release would add from .nextchanges/
+    env:
+      NEXTCHANGES_DIR: .nextchanges/
     cmds:
       # Validate placement first so a misplaced fragment fails loudly instead of
       # being silently skipped by the renderer (see validate_nextchanges.py).


### PR DESCRIPTION
Set env variable so `task changelog-preview` works outside of CI