### PR TITLE
Fix 'deployment_source.source_code_path cannot be set on UpdateApp' error when updating apps

### DIFF
--- a/.nextchanges/bundles/fix-app-source-code-path-regression.md
+++ b/.nextchanges/bundles/fix-app-source-code-path-regression.md
@@ -1,0 +1,1 @@
+Fix `bundle deploy` failing with `deployment_source.source_code_path cannot be set on UpdateApp` (400) when updating an app that has an active deployment ([#6401](https://github.com/databricks/cli/issues/6401)).

--- a/acceptance/bundle/apps/source_code_path_update/app/app.py
+++ b/acceptance/bundle/apps/source_code_path_update/app/app.py
@@ -1,0 +1,1 @@
+print("Simple test app")

--- a/acceptance/bundle/apps/source_code_path_update/app/app.py
+++ b/acceptance/bundle/apps/source_code_path_update/app/app.py
@@ -1,1 +1,16 @@
-print("Simple test app")
+import os
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(200)
+        self.end_headers()
+        self.wfile.write(b"OK")
+
+    def log_message(self, *_):
+        pass
+
+
+port = int(os.environ.get("APP_PORT", "8080"))
+HTTPServer(("0.0.0.0", port), Handler).serve_forever()

--- a/acceptance/bundle/apps/source_code_path_update/app/app.yml
+++ b/acceptance/bundle/apps/source_code_path_update/app/app.yml
@@ -1,0 +1,1 @@
+command: ["python", "app.py"]

--- a/acceptance/bundle/apps/source_code_path_update/databricks.yml.tmpl
+++ b/acceptance/bundle/apps/source_code_path_update/databricks.yml.tmpl
@@ -1,0 +1,14 @@
+bundle:
+  name: app-scp-update-$UNIQUE_NAME
+
+workspace:
+  root_path: "~/.bundle/app-scp-update-$UNIQUE_NAME"
+
+resources:
+  apps:
+    my_app:
+      name: app-$UNIQUE_NAME
+      description: "first description"
+      source_code_path: ./app
+      lifecycle:
+        started: true

--- a/acceptance/bundle/apps/source_code_path_update/out.test.toml
+++ b/acceptance/bundle/apps/source_code_path_update/out.test.toml
@@ -1,0 +1,2 @@
+Cloud = true
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/apps/source_code_path_update/out.test.toml
+++ b/acceptance/bundle/apps/source_code_path_update/out.test.toml
@@ -1,2 +1,3 @@
 Cloud = true
+CloudSlow = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/apps/source_code_path_update/output.txt
+++ b/acceptance/bundle/apps/source_code_path_update/output.txt
@@ -1,0 +1,24 @@
+
+=== Initial deploy — creates app with active deployment
+>>> [CLI] bundle deploy
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/app-scp-update-[UNIQUE_NAME]/files...
+✓ Deployment succeeded
+Created apps.my_app
+Files: 7 uploaded, 0 deleted
+Resources: 1 created, 0 changed, 0 deleted, 0 unchanged
+
+=== Redeploy from saved plan after description change
+>>> [CLI] bundle deploy --plan plan.json
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/app-scp-update-[UNIQUE_NAME]/files...
+✓ Deployment succeeded
+Updated apps.my_app
+Files: 4 uploaded, 0 deleted
+Resources: 0 created, 1 changed, 0 deleted, 0 unchanged
+
+>>> [CLI] bundle destroy --auto-approve
+The following resources will be deleted:
+  delete resources.apps.my_app
+
+All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/app-scp-update-[UNIQUE_NAME]
+
+Destroy: 1 deleted

--- a/acceptance/bundle/apps/source_code_path_update/output.txt
+++ b/acceptance/bundle/apps/source_code_path_update/output.txt
@@ -1,18 +1,17 @@
 
-=== Initial deploy — creates app with active deployment
+=== Initial deploy — lifecycle.started starts compute and creates active deployment
 >>> [CLI] bundle deploy
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/app-scp-update-[UNIQUE_NAME]/files...
-✓ Deployment succeeded
 Created apps.my_app
 Files: 7 uploaded, 0 deleted
 Resources: 1 created, 0 changed, 0 deleted, 0 unchanged
 
+=== Run app to redeploy (reproduces the issue precondition of having an active deployment)
 === Redeploy from saved plan after description change
 >>> [CLI] bundle deploy --plan plan.json
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/app-scp-update-[UNIQUE_NAME]/files...
-✓ Deployment succeeded
 Updated apps.my_app
-Files: 4 uploaded, 0 deleted
+Files: 6 uploaded, 0 deleted
 Resources: 0 created, 1 changed, 0 deleted, 0 unchanged
 
 >>> [CLI] bundle destroy --auto-approve

--- a/acceptance/bundle/apps/source_code_path_update/script
+++ b/acceptance/bundle/apps/source_code_path_update/script
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Regression test for https://github.com/databricks/cli/issues/6401
+#
+# bundle deploy must not send source_code_path in the UpdateApp request body when
+# redeploying an app that already has an active deployment. The bug only manifests
+# when using a saved plan (bundle deploy --plan), because that path goes through
+# InitForApply which JSON-round-trips the AppState, causing the SDK's marshal to
+# add "SourceCodePath" to apps.App.ForceSendFields, which then forces
+# "source_code_path": "" into the update body (rejected by the API with 400).
+
+envsubst < databricks.yml.tmpl > databricks.yml
+
+cleanup() {
+  trace $CLI bundle destroy --auto-approve
+}
+trap cleanup EXIT
+
+title "Initial deploy — creates app with active deployment"
+trace $CLI bundle deploy
+
+title "Redeploy from saved plan after description change"
+sed -i.bak 's/description: "first description"/description: "second description"/' databricks.yml
+$CLI bundle plan -o json > plan.json
+trace $CLI bundle deploy --plan plan.json

--- a/acceptance/bundle/apps/source_code_path_update/script
+++ b/acceptance/bundle/apps/source_code_path_update/script
@@ -2,11 +2,12 @@
 # Regression test for https://github.com/databricks/cli/issues/6401
 #
 # bundle deploy must not send source_code_path in the UpdateApp request body when
-# redeploying an app that already has an active deployment. The bug only manifests
-# when using a saved plan (bundle deploy --plan), because that path goes through
-# InitForApply which JSON-round-trips the AppState, causing the SDK's marshal to
-# add "SourceCodePath" to apps.App.ForceSendFields, which then forces
-# "source_code_path": "" into the update body (rejected by the API with 400).
+# redeploying an app that already has an active deployment.
+#
+# The bug manifests in the bundle deploy --plan flow: InitForApply JSON-round-trips
+# AppState through apps.App.UnmarshalJSON, which adds "SourceCodePath" to
+# apps.App.ForceSendFields; without the fix that forces "source_code_path": ""
+# into the UpdateApp body, which the API rejects with 400.
 
 envsubst < databricks.yml.tmpl > databricks.yml
 
@@ -15,10 +16,20 @@ cleanup() {
 }
 trap cleanup EXIT
 
-title "Initial deploy — creates app with active deployment"
+title "Initial deploy — lifecycle.started starts compute and creates active deployment"
 trace $CLI bundle deploy
 
+title "Run app to redeploy (reproduces the issue precondition of having an active deployment)"
+# Compute is already ACTIVE from the first deploy; bundle run just redeploys.
+# Route variable progress messages and the dynamic URL to a log so output.txt is stable.
+$CLI bundle run my_app &> LOG.run_app
+
 title "Redeploy from saved plan after description change"
+# Changing a non-deploy-only field (description) so DoUpdate is called.
 sed -i.bak 's/description: "first description"/description: "second description"/' databricks.yml
-$CLI bundle plan -o json > plan.json
+# Route bundle plan stderr (diagnostics) to a log so output.txt stays clean.
+$CLI bundle plan -o json > plan.json 2> LOG.plan
+# bundle deploy --plan triggers InitForApply, which JSON-round-trips AppState.
+# Without the fix, apps.App.ForceSendFields ends up containing "SourceCodePath",
+# causing "source_code_path": "" to be sent in the UpdateApp body (API returns 400).
 trace $CLI bundle deploy --plan plan.json

--- a/acceptance/bundle/apps/source_code_path_update/test.toml
+++ b/acceptance/bundle/apps/source_code_path_update/test.toml
@@ -1,11 +1,21 @@
 Cloud = true
+CloudSlow = true
 RecordRequests = false
 
 # This regression is in the direct engine only (the bug is in InitForApply
-# which is only called for saved-plan deploys on the direct engine).
+# which is only called for bundle deploy --plan on the direct engine).
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]
 
-Ignore = [".databricks", "databricks.yml", "databricks.yml.bak", "plan.json"]
+Ignore = [".databricks", "databricks.yml", "databricks.yml.bak", "plan.json", "LOG.*"]
 
-# Apps can take longer to deploy on cloud.
-TimeoutCloud = "5m"
+# Apps can take longer to start up and deploy on cloud.
+TimeoutCloud = "10m"
+
+# logProgress ("✓ <message>") emits deployment progress lines whose count and
+# content vary between the local test server (single "Deployment succeeded") and
+# a real workspace (multiple intermediate states: "Shutting down app...",
+# "App started successfully", etc.). Remove all of them from the output so that
+# the golden is stable across both environments.
+[[Repls]]
+Old = '✓ [^\n]+\n'
+New = ''

--- a/acceptance/bundle/apps/source_code_path_update/test.toml
+++ b/acceptance/bundle/apps/source_code_path_update/test.toml
@@ -1,0 +1,11 @@
+Cloud = true
+RecordRequests = false
+
+# This regression is in the direct engine only (the bug is in InitForApply
+# which is only called for saved-plan deploys on the direct engine).
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]
+
+Ignore = [".databricks", "databricks.yml", "databricks.yml.bak", "plan.json"]
+
+# Apps can take longer to deploy on cloud.
+TimeoutCloud = "5m"

--- a/bundle/direct/dresources/app.go
+++ b/bundle/direct/dresources/app.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -109,10 +110,16 @@ func (r *ResourceApp) DoRead(ctx context.Context, id string) (*AppRemote, error)
 // appRequestBody returns config.App with the deploy-only fields cleared. source_code_path
 // and git_source became part of apps.App in SDK v0.175, but DABs applies them through the
 // Deploy API (see manageLifecycle), so they must not ride along in create/update bodies.
+// ForceSendFields is cloned and stripped of SourceCodePath because the SDK's JSON
+// unmarshal (used when loading the plan) adds every present basic-type field to
+// ForceSendFields, which would otherwise force "source_code_path": "" into the body.
 func appRequestBody(config *AppState) apps.App {
 	app := config.App
 	app.SourceCodePath = ""
 	app.GitSource = nil
+	app.ForceSendFields = slices.DeleteFunc(slices.Clone(app.ForceSendFields), func(s string) bool {
+		return s == "SourceCodePath"
+	})
 	return app
 }
 

--- a/bundle/direct/dresources/app_test.go
+++ b/bundle/direct/dresources/app_test.go
@@ -1,6 +1,7 @@
 package dresources
 
 import (
+	"encoding/json"
 	"reflect"
 	"slices"
 	"strings"
@@ -169,4 +170,39 @@ func TestAppDoUpdate_UpdateMaskHasAllFields(t *testing.T) {
 	for _, field := range UpdateMaskFields {
 		assert.Contains(t, allFields, field, "field %s is in UpdateMaskFields but not in apps.App struct", field)
 	}
+}
+
+// TestAppRequestBody_StripsSourceCodePathFromForceSendFields verifies that
+// appRequestBody removes SourceCodePath from ForceSendFields even when the plan
+// JSON round-trip has forced it in — reproduces the v1.14.0 regression where
+// "source_code_path": "" was sent in the UpdateApp body, causing a 400.
+func TestAppRequestBody_StripsSourceCodePathFromForceSendFields(t *testing.T) {
+	config := &AppState{
+		App: apps.App{
+			Name:           "my-app",
+			SourceCodePath: "/Workspace/Users/me/app",
+			// Simulate ForceSendFields as populated by marshal.Unmarshal when the
+			// plan entry is deserialized from JSON (ToStructVar calls json.Unmarshal,
+			// which calls apps.App.UnmarshalJSON -> marshal.Unmarshal, which adds
+			// every basic-type field present in the JSON to ForceSendFields).
+			ForceSendFields: []string{"Name", "SourceCodePath"},
+		},
+	}
+
+	body := appRequestBody(config)
+
+	// SourceCodePath must be cleared and absent from ForceSendFields so that
+	// the SDK's marshal.Marshal omits it from the request body.
+	assert.Empty(t, body.SourceCodePath)
+	assert.NotContains(t, body.ForceSendFields, "SourceCodePath")
+
+	// Verify the field is absent from the marshaled JSON (the root cause of the 400).
+	data, err := json.Marshal(body)
+	require.NoError(t, err)
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(data, &m))
+	assert.NotContains(t, m, "source_code_path", "source_code_path must not appear in the UpdateApp request body")
+
+	// Other ForceSendFields entries must be preserved.
+	assert.Contains(t, body.ForceSendFields, "Name")
 }

--- a/libs/testserver/apps.go
+++ b/libs/testserver/apps.go
@@ -37,6 +37,27 @@ func (s *FakeWorkspace) AppsCreateUpdate(req Request, name string) Response {
 		}
 	}
 
+	// The real API rejects source_code_path in the UpdateApp body at any value.
+	if updateReq.App != nil {
+		var rawBody struct {
+			App json.RawMessage `json:"app"`
+		}
+		if err := json.Unmarshal(req.Body, &rawBody); err == nil {
+			var appFields map[string]json.RawMessage
+			if err := json.Unmarshal(rawBody.App, &appFields); err == nil {
+				if _, ok := appFields["source_code_path"]; ok {
+					return Response{
+						StatusCode: http.StatusBadRequest,
+						Body: map[string]string{
+							"error_code": "INVALID_PARAMETER_VALUE",
+							"message":    "deployment_source.source_code_path cannot be set on UpdateApp.",
+						},
+					}
+				}
+			}
+		}
+	}
+
 	defer s.LockUnlock()()
 
 	existing, ok := s.Apps[name]


### PR DESCRIPTION
## Changes
Fix 'deployment_source.source_code_path cannot be set on UpdateApp' error when updating apps

Fixes #6401

## Why
Root cause: The SDK v0.175.0 bump (shipped in v1.14.0) moved SourceCodePath from a DABs-internal AppState field into apps.App directly. During bundle deploy, the plan is serialized to JSON and re-deserialized via json.Unmarshal → apps.App.UnmarshalJSON → SDK's marshal.Unmarshal. The SDK's unmarshal adds every basic-type field present in the JSON to ForceSendFields — including "SourceCodePath". When appRequestBody then set app.SourceCodePath = "", ForceSendFields still forced it into the request body as "source_code_path": "", causing the API's 400.

## Tests
Added an acceptance test

Without the fix it fails with

```
Error: cannot update resources.apps.my_app: updating id=app-[UNIQUE_NAME]:
deployment_source.source_code_path cannot be set on UpdateApp. (400 INVALID_PARAMETER_VALUE)
HTTP Status: 400 Bad Request
API error_code: INVALID_PARAMETER_VALUE
API message: deployment_source.source_code_path cannot be set on UpdateApp.
```

<!-- If your PR needs to be included in the release notes for next release,
add a changelog fragment: create .nextchanges/<section>/<name>.md with a
one-line description (e.g. .nextchanges/cli/quickstart.md). See .nextchanges/README.md. -->
