### PR TITLE
apps: git-back scaffolded apps when init runs inside a Git repo

### DIFF
--- a/.nextchanges/cli/apps-init-git-autodetect.md
+++ b/.nextchanges/cli/apps-init-git-autodetect.md
@@ -1,0 +1,1 @@
+`databricks apps init` now scaffolds a git-backed `databricks.yml` (`git_repository` + `git_source`) when run inside a Git repository with an origin remote, so the app deploys from the repo instead of uploading local files.

--- a/cmd/apps/gitsource.go
+++ b/cmd/apps/gitsource.go
@@ -1,0 +1,159 @@
+package apps
+
+import (
+	"context"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/databricks/cli/libs/git"
+	"github.com/databricks/cli/libs/log"
+	"github.com/databricks/databricks-sdk-go"
+)
+
+// gitScaffoldSource holds the git-backed deployment fields rendered into a
+// scaffolded databricks.yml when `apps init` runs inside a Git repository.
+// A zero value means "no Git source" and the template falls back to a plain
+// workspace source_code_path.
+type gitScaffoldSource struct {
+	// URL is the https clone URL of the origin remote, with credentials and any
+	// trailing ".git" stripped (e.g. https://github.com/my-org/my-repo).
+	URL string
+	// Provider is the Databricks git provider enum matching URL's host
+	// (e.g. gitHub). Empty when the host maps to no known provider.
+	Provider string
+	// Branch is the repository's current branch.
+	Branch string
+	// SourceCodePath is the app's location relative to the repo root, forward-slashed.
+	// "./" when the app is at the repo root.
+	SourceCodePath string
+}
+
+// active reports whether a git-backed source was detected. url, provider, and
+// branch are required together: git_repository needs url+provider, and a deploy
+// needs a ref. When any is missing the scaffold keeps its plain source_code_path.
+func (g gitScaffoldSource) active() bool {
+	return g.URL != "" && g.Provider != "" && g.Branch != ""
+}
+
+// detectGitScaffoldSource derives git-backed deployment fields from the Git
+// repository that will contain the scaffolded app at destDir. It returns a zero
+// value (and never an error) when there is nothing safe to point a git-backed
+// deploy at: destDir is not inside a Git repo, the repo has no origin remote,
+// the origin host maps to no known provider, the branch is unknown (detached
+// HEAD), or the app would live outside the detected repo.
+func detectGitScaffoldSource(ctx context.Context, destDir string, w *databricks.WorkspaceClient) gitScaffoldSource {
+	absDest, err := filepath.Abs(destDir)
+	if err != nil {
+		log.Debugf(ctx, "git-source detection: resolving %q: %v", destDir, err)
+		return gitScaffoldSource{}
+	}
+
+	// A brand-new subdirectory does not exist yet at detection time, so probe
+	// from its parent (which does) to find the enclosing repo. In-place scaffolds
+	// ("." into an existing repo) probe the directory itself.
+	probe := absDest
+	if _, statErr := os.Stat(probe); statErr != nil {
+		probe = filepath.Dir(absDest)
+	}
+
+	info, err := git.FetchRepositoryInfo(ctx, probe, w)
+	if err != nil {
+		log.Debugf(ctx, "git-source detection: %v", err)
+		return gitScaffoldSource{}
+	}
+	if info.WorktreeRoot == "" || info.OriginURL == "" || info.CurrentBranch == "" {
+		return gitScaffoldSource{}
+	}
+
+	repoURL, provider := normalizeGitOrigin(info.OriginURL)
+	if repoURL == "" || provider == "" {
+		return gitScaffoldSource{}
+	}
+
+	sourcePath := "./"
+	if rel, relErr := filepath.Rel(info.WorktreeRoot, absDest); relErr == nil {
+		rel = filepath.ToSlash(rel)
+		if rel == ".." || strings.HasPrefix(rel, "../") {
+			// The app would live outside the detected repo; a git-backed deploy
+			// from this origin could not find it.
+			return gitScaffoldSource{}
+		}
+		if rel != "." {
+			sourcePath = rel
+		}
+	}
+
+	return gitScaffoldSource{
+		URL:            repoURL,
+		Provider:       provider,
+		Branch:         info.CurrentBranch,
+		SourceCodePath: sourcePath,
+	}
+}
+
+// normalizeGitOrigin converts a raw git remote URL into an https clone URL and
+// the matching Databricks git provider. It handles https/ssh URLs and scp-style
+// remotes (git@host:owner/repo.git). It returns empty strings when the host maps
+// to no known provider, since git_repository requires url and provider together.
+func normalizeGitOrigin(raw string) (repoURL, provider string) {
+	host, path := splitGitRemote(strings.TrimSpace(raw))
+	if host == "" {
+		return "", ""
+	}
+	provider = providerForHost(host)
+	if provider == "" {
+		return "", ""
+	}
+	path = strings.Trim(strings.TrimSuffix(path, ".git"), "/")
+	if path == "" {
+		return "", ""
+	}
+	return "https://" + host + "/" + path, provider
+}
+
+// splitGitRemote extracts the host and repository path from a git remote URL,
+// supporting both scheme URLs (https://, ssh://) and scp-style (git@host:path).
+func splitGitRemote(raw string) (host, path string) {
+	if raw == "" {
+		return "", ""
+	}
+	if !strings.Contains(raw, "://") {
+		// scp-style: [user@]host:owner/repo(.git)
+		if at := strings.LastIndex(raw, "@"); at != -1 {
+			raw = raw[at+1:]
+		}
+		hostPart, pathPart, ok := strings.Cut(raw, ":")
+		if !ok {
+			return "", ""
+		}
+		return hostPart, pathPart
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", ""
+	}
+	return u.Hostname(), strings.TrimPrefix(u.Path, "/")
+}
+
+// providerForHost maps a git host to its Databricks git provider enum value.
+// Unknown/self-hosted hosts return "" — the provider cannot be inferred safely,
+// so the scaffold falls back to a plain source_code_path.
+func providerForHost(host string) string {
+	switch strings.ToLower(host) {
+	case "github.com":
+		return "gitHub"
+	case "gitlab.com":
+		return "gitLab"
+	case "bitbucket.org":
+		return "bitbucketCloud"
+	case "dev.azure.com":
+		return "azureDevOpsServices"
+	default:
+		if strings.HasSuffix(strings.ToLower(host), ".visualstudio.com") {
+			return "azureDevOpsServices"
+		}
+		return ""
+	}
+}

--- a/cmd/apps/gitsource_test.go
+++ b/cmd/apps/gitsource_test.go
@@ -1,0 +1,132 @@
+package apps
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProviderForHost(t *testing.T) {
+	cases := map[string]string{
+		"github.com":             "gitHub",
+		"GitHub.com":             "gitHub",
+		"gitlab.com":             "gitLab",
+		"bitbucket.org":          "bitbucketCloud",
+		"dev.azure.com":          "azureDevOpsServices",
+		"myorg.visualstudio.com": "azureDevOpsServices",
+		"git.internal.corp":      "",
+		"github.example.com":     "",
+		"":                       "",
+	}
+	for host, want := range cases {
+		assert.Equal(t, want, providerForHost(host), "host=%q", host)
+	}
+}
+
+func TestNormalizeGitOrigin(t *testing.T) {
+	cases := []struct {
+		name         string
+		raw          string
+		wantURL      string
+		wantProvider string
+	}{
+		{"https", "https://github.com/my-org/my-repo", "https://github.com/my-org/my-repo", "gitHub"},
+		{"https dot git", "https://github.com/my-org/my-repo.git", "https://github.com/my-org/my-repo", "gitHub"},
+		{"https trailing slash", "https://github.com/my-org/my-repo/", "https://github.com/my-org/my-repo", "gitHub"},
+		{"scp ssh", "git@github.com:my-org/my-repo.git", "https://github.com/my-org/my-repo", "gitHub"},
+		{"ssh scheme", "ssh://git@github.com/my-org/my-repo.git", "https://github.com/my-org/my-repo", "gitHub"},
+		{"gitlab", "https://gitlab.com/my-org/my-repo.git", "https://gitlab.com/my-org/my-repo", "gitLab"},
+		{"azure", "git@ssh.dev.azure.com:v3/org/proj/repo", "", ""}, // ssh.dev.azure.com is not dev.azure.com
+		{"unknown host", "https://git.internal.corp/my-org/my-repo.git", "", ""},
+		{"empty path", "https://github.com/", "", ""},
+		{"empty", "", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotURL, gotProvider := normalizeGitOrigin(tc.raw)
+			assert.Equal(t, tc.wantURL, gotURL)
+			assert.Equal(t, tc.wantProvider, gotProvider)
+		})
+	}
+}
+
+// writeGitRepo lays down a minimal .git directory (config + HEAD) that
+// git.FetchRepositoryInfo reads for local paths. headRef is the raw HEAD
+// contents, e.g. "ref: refs/heads/main" for a branch or a bare SHA for a
+// detached checkout.
+func writeGitRepo(t *testing.T, dir, originURL, headRef string) {
+	t.Helper()
+	gitDir := filepath.Join(dir, ".git")
+	require.NoError(t, os.MkdirAll(gitDir, 0o755))
+
+	config := "[core]\n\trepositoryformatversion = 0\n"
+	if originURL != "" {
+		config += "[remote \"origin\"]\n\turl = " + originURL + "\n"
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(gitDir, "config"), []byte(config), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(gitDir, "HEAD"), []byte(headRef), 0o644))
+}
+
+func TestDetectGitScaffoldSource(t *testing.T) {
+	t.Run("repo root in-place", func(t *testing.T) {
+		dir := t.TempDir()
+		writeGitRepo(t, dir, "https://github.com/my-org/my-repo.git", "ref: refs/heads/main")
+
+		got := detectGitScaffoldSource(t.Context(), dir, nil)
+		assert.Equal(t, gitScaffoldSource{
+			URL:            "https://github.com/my-org/my-repo",
+			Provider:       "gitHub",
+			Branch:         "main",
+			SourceCodePath: "./",
+		}, got)
+		assert.True(t, got.active())
+	})
+
+	t.Run("app in subdirectory", func(t *testing.T) {
+		dir := t.TempDir()
+		writeGitRepo(t, dir, "git@github.com:my-org/my-repo.git", "ref: refs/heads/feature")
+		sub := filepath.Join(dir, "apps", "my-app")
+		require.NoError(t, os.MkdirAll(sub, 0o755))
+
+		got := detectGitScaffoldSource(t.Context(), sub, nil)
+		assert.Equal(t, "apps/my-app", got.SourceCodePath)
+		assert.Equal(t, "https://github.com/my-org/my-repo", got.URL)
+		assert.Equal(t, "feature", got.Branch)
+	})
+
+	t.Run("not-yet-created subdir probes parent", func(t *testing.T) {
+		dir := t.TempDir()
+		writeGitRepo(t, dir, "https://github.com/my-org/my-repo.git", "ref: refs/heads/main")
+		// The subdir does not exist yet, mirroring `apps init --name my-app`.
+		got := detectGitScaffoldSource(t.Context(), filepath.Join(dir, "my-app"), nil)
+		assert.Equal(t, "my-app", got.SourceCodePath)
+		assert.True(t, got.active())
+	})
+
+	t.Run("no repository", func(t *testing.T) {
+		got := detectGitScaffoldSource(t.Context(), t.TempDir(), nil)
+		assert.Equal(t, gitScaffoldSource{}, got)
+		assert.False(t, got.active())
+	})
+
+	t.Run("no origin remote", func(t *testing.T) {
+		dir := t.TempDir()
+		writeGitRepo(t, dir, "", "ref: refs/heads/main")
+		assert.Equal(t, gitScaffoldSource{}, detectGitScaffoldSource(t.Context(), dir, nil))
+	})
+
+	t.Run("unknown provider host", func(t *testing.T) {
+		dir := t.TempDir()
+		writeGitRepo(t, dir, "https://git.internal.corp/my-org/my-repo.git", "ref: refs/heads/main")
+		assert.Equal(t, gitScaffoldSource{}, detectGitScaffoldSource(t.Context(), dir, nil))
+	})
+
+	t.Run("detached HEAD has no branch", func(t *testing.T) {
+		dir := t.TempDir()
+		writeGitRepo(t, dir, "https://github.com/my-org/my-repo.git", "0000000000000000000000000000000000000000")
+		assert.Equal(t, gitScaffoldSource{}, detectGitScaffoldSource(t.Context(), dir, nil))
+	})
+}

--- a/cmd/apps/init.go
+++ b/cmd/apps/init.go
@@ -353,6 +353,9 @@ type templateVars struct {
 	Bundle         tmplBundle
 	DotEnv         dotEnvVars
 	AppEnv         string
+	// Git carries git-backed deployment fields when `apps init` runs inside a
+	// Git repository. Zero value means the scaffold uses a plain source_code_path.
+	Git gitScaffoldSource
 	// Plugins maps plugin name to its metadata
 	// Missing keys return nil, enabling {{if .plugins.analytics}} conditionals.
 	Plugins map[string]*pluginVar
@@ -1403,12 +1406,22 @@ func runCreate(ctx context.Context, opts createOptions) error {
 		plugins[name] = pv
 	}
 
+	// Detect a Git-backed source when scaffolding inside a Git repository, so
+	// the bundle deploys from the repo/ref instead of uploading local files.
+	// Falls back to a plain source_code_path when there is no repo to point at.
+	gitSource := detectGitScaffoldSource(ctx, destDir, cmdctx.WorkspaceClient(ctx))
+	if gitSource.active() {
+		log.Debugf(ctx, "Scaffolding git-backed deploy: %s (%s) @ %s, path %s",
+			gitSource.URL, gitSource.Provider, gitSource.Branch, gitSource.SourceCodePath)
+	}
+
 	// Template variables with generated content
 	vars := templateVars{
 		ProjectName:    opts.name,
 		AppDescription: opts.description,
 		Profile:        profile,
 		WorkspaceHost:  workspaceHost,
+		Git:            gitSource,
 		Bundle: tmplBundle{
 			Variables:       bundleVars,
 			Resources:       bundleRes,
@@ -1877,6 +1890,15 @@ func templateData(vars templateVars) map[string]any {
 		"dotEnv": map[string]any{
 			"content": vars.DotEnv.Content,
 			"example": vars.DotEnv.Example,
+		},
+		// git is always present so {{.git.url}} is a defined (possibly empty)
+		// value under missingkey=zero; an empty url selects the source_code_path
+		// branch in the template.
+		"git": map[string]any{
+			"url":            vars.Git.URL,
+			"provider":       vars.Git.Provider,
+			"branch":         vars.Git.Branch,
+			"sourceCodePath": vars.Git.SourceCodePath,
 		},
 		"appEnv": vars.AppEnv,
 


### PR DESCRIPTION
## Changes

`databricks apps init` now detects the Git repository that will contain the new app and scaffolds a **git-backed** `databricks.yml` — a `git_repository` (origin URL + inferred provider) and `git_source` (current branch + repo-relative `source_code_path`) — instead of a plain `source_code_path` upload.

- New `cmd/apps/gitsource.go`: `detectGitScaffoldSource` walks up from the scaffold destination via `git.FetchRepositoryInfo`, normalizes the origin remote to an https URL, and maps the host to a Databricks git provider (`gitHub`, `gitLab`, `bitbucketCloud`, `azureDevOpsServices`).
- `cmd/apps/init.go`: the detected fields are threaded into the template context (a `git` map), so the AppKit `databricks.yml.tmpl` can render the block conditionally.

Detection is conservative and falls back to `source_code_path` when there is nothing safe to point a deploy at: no repo, no origin remote, an unrecognized/self-hosted provider host, a detached HEAD, or a destination outside the repo. It therefore never emits an unusable git block.

## Why

Git-backed deployment (deploy from a repo/ref rather than uploading local files) is the recommended path for Databricks Apps — it is reproducible, reviewable, and rollback-able. Today a scaffolded app defaults to a local `source_code_path` and the git block is a commented placeholder the user must fill in by hand, so almost nobody adopts it. Auto-detecting the repo the user is already standing in makes git-backed the default with zero extra steps, while degrading cleanly to the old behavior everywhere else.

Pairs with the AppKit template change in databricks/appkit#556 (the template renders the `git_repository`/`git_source` block from these fields). Backward compatible: an older CLI renders the git fields empty and the template keeps `source_code_path`.

## Tests

- Unit tests in `cmd/apps/gitsource_test.go` cover provider inference, origin-URL normalization (https, `.git` suffix, scp-style ssh, credential stripping, unknown hosts), and `detectGitScaffoldSource` across repo-root/in-place, subdirectory, not-yet-created subdir, no-repo, no-origin, unknown-provider, and detached-HEAD cases.
- Verified end-to-end that the paired AppKit template renders valid YAML in both the git-detected and no-git branches.

This pull request and its description were written by Isaac.