### PR TITLE
Add AIR Python CLI parity

### DIFF
--- a/.nextchanges/cli/air-log-reliability.md
+++ b/.nextchanges/cli/air-log-reliability.md
@@ -1,0 +1,1 @@
+Improved AIR log fallback, retry-attempt selection, and Unity Catalog volume artifact handling.

--- a/.nextchanges/cli/air-snapshot-profile-parity.md
+++ b/.nextchanges/cli/air-snapshot-profile-parity.md
@@ -1,0 +1,1 @@
+Improved AIR snapshots to honor Git ignore rules and added selected-profile workspace directory overrides.

--- a/.nextchanges/cli/air-status-parity.md
+++ b/.nextchanges/cli/air-status-parity.md
@@ -1,0 +1,1 @@
+Added AIR failure reasons, timeout handling, and pending task display status parity.

--- a/.nextchanges/cli/air-submission-parity.md
+++ b/.nextchanges/cli/air-submission-parity.md
@@ -1,0 +1,1 @@
+Restored AIR requirements YAML support and added Docker image, MLflow artifact location, and provisioned capacity submission fields.

--- a/acceptance/experimental/air/config-help/output.txt
+++ b/acceptance/experimental/air/config-help/output.txt
@@ -50,6 +50,7 @@ config
     parameters                   Free-form values passed through to the workload.
     mlflow_run_name              Name for the MLflow run.
     mlflow_experiment_directory  Workspace directory holding the MLflow experiment.
+    mlflow_artifact_location     DBFS location where MLflow artifacts are written.
     permissions                  Who may view or manage the run, as a list of principal plus level grants.
     usage_policy_name            Usage policy to bill the run to, by name.
     usage_policy_id              Usage policy to bill the run to, by id.
@@ -62,10 +63,33 @@ config.compute
   Which accelerators to run on and how many.
 
   Fields:
-    num_accelerators  Total number of GPUs to allocate.
-    accelerator_type  Which accelerator to run on, e.g. GPU_1xA10.
+    num_accelerators         Total number of GPUs to allocate.
+    accelerator_type         Which accelerator to run on, e.g. GPU_1xA10.
+    provisioned_capacity_id  Pre-provisioned AIR capacity reservation id.
 
 Use "-h config.compute.<field>" for details on a field.
+
+=== new submission fields are documented
+>>> [CLI] experimental air run -h config.mlflow_artifact_location
+config.mlflow_artifact_location
+  DBFS location where MLflow artifacts are written. A /Volumes path is normalized to dbfs:/Volumes/... .
+
+  Type:     string
+  Required: no
+
+>>> [CLI] experimental air run -h config.compute.provisioned_capacity_id
+config.compute.provisioned_capacity_id
+  Pre-provisioned AIR capacity reservation id. Must be 1-255 characters.
+
+  Type:     string
+  Required: no
+
+>>> [CLI] experimental air run -h config.environment.dependencies
+config.environment.dependencies
+  Inline package list or path to a requirements YAML file. Not allowed alongside docker_image.
+
+  Type:     list of strings
+  Required: no
 
 === leaf field
 >>> [CLI] experimental air run -h config.compute.accelerator_type
@@ -103,7 +127,7 @@ config.compute.num_accelerators
 >>> [CLI] experimental air run -h config.compute.acclerator_type
 Error: unknown config field "config.compute.acclerator_type"; did you mean "accelerator_type"?
 
-fields under "config.compute" are: accelerator_type, num_accelerators
+fields under "config.compute" are: accelerator_type, num_accelerators, provisioned_capacity_id
 
 === free-form map keys are not schema fields
 >>> [CLI] experimental air run -h config.parameters.learning_rate

--- a/acceptance/experimental/air/config-help/script
+++ b/acceptance/experimental/air/config-help/script
@@ -12,6 +12,11 @@ trace $CLI experimental air run -h config
 title "nested object lists its fields"
 trace $CLI experimental air run -h config.compute
 
+title "new submission fields are documented"
+trace $CLI experimental air run -h config.mlflow_artifact_location
+trace $CLI experimental air run -h config.compute.provisioned_capacity_id
+trace $CLI experimental air run -h config.environment.dependencies
+
 title "leaf field"
 trace $CLI experimental air run -h config.compute.accelerator_type
 

--- a/acceptance/experimental/air/run-submit-deps/output.txt
+++ b/acceptance/experimental/air/run-submit-deps/output.txt
@@ -56,6 +56,62 @@ Tip: use --watch to stream logs until the run completes.
   }
 }
 
-=== a requirements.yaml file path is rejected; deps must be inline
+=== submit with file-backed dependencies
 >>> [CLI] experimental air run -f run-file.yaml
-Error: invalid config run-file.yaml: environment.dependencies must be a list of packages or reference a requirements.txt (see https://docs.databricks.com/aws/en/machine-learning/ai-runtime/cli/yaml-config#reference). A direct file reference is not supported
+Submitting experiment: deps-file-smoke
+Submitted workload with Job Run ID: 555
+View job run at: [DATABRICKS_URL]/jobs/runs/555
+
+Tip: use --watch to stream logs until the run completes.
+
+=== requirements.yaml is uploaded beside the launch config
+>>> print_requests.py //api/2.0/workspace-files/import-file --oneline --sort --unique --keep
+{"method": "POST", "path": "/api/2.0/workspace-files/import-file/Workspace/Users/[USERNAME]/.air/cli_launch/deps-file-smoke/deps-file-smoke_[RUN_ID]/command.sh", "q": {"overwrite": "true"}, "raw_body": "python train.py"}
+{"method": "POST", "path": "/api/2.0/workspace-files/import-file/Workspace/Users/[USERNAME]/.air/cli_launch/deps-file-smoke/deps-file-smoke_[RUN_ID]/requirements.yaml", "q": {"overwrite": "true"}, "raw_body": "version: 5\ndependencies:\n  - numpy\n  - torch==2.3.0\n"}
+{"method": "POST", "path": "/api/2.0/workspace-files/import-file/Workspace/Users/[USERNAME]/.air/cli_launch/deps-file-smoke/deps-file-smoke_[RUN_ID]/training_config.yaml", "q": {"overwrite": "true"}, "raw_body": "experiment_name: deps-file-smoke\ncommand: python train.py\ncompute:\n  accelerator_type: GPU_1xH100\n  num_accelerators: 1\n  provisioned_capacity_id: capacity-123\nenvironment:\n  dependencies: ./reqs.yaml\nmlflow_artifact_location: /Volumes/main/default/air-artifacts\n"}
+
+=== file deps, artifact location, and capacity id reach the submit payload
+>>> print_requests.py //api/2.2/jobs/runs/submit
+{
+  "method": "POST",
+  "path": "/api/2.2/jobs/runs/submit",
+  "body": {
+    "environments": [
+      {
+        "environment_key": "default",
+        "spec": {
+          "dependencies": [
+            "numpy",
+            "torch==2.3.0"
+          ],
+          "environment_version": "5"
+        }
+      }
+    ],
+    "idempotency_token": "[UUID]",
+    "run_name": "deps-file-smoke",
+    "tasks": [
+      {
+        "ai_runtime_task": {
+          "deployments": [
+            {
+              "command_path": "/Workspace/Users/[USERNAME]/.air/cli_launch/deps-file-smoke/deps-file-smoke_[RUN_ID]/command.sh",
+              "compute": {
+                "accelerator_count": 1,
+                "accelerator_type": "GPU_1xH100",
+                "provisioned_capacity_id": "capacity-123"
+              }
+            }
+          ],
+          "experiment": "deps-file-smoke",
+          "mlflow_artifact_location": "dbfs:/Volumes/main/default/air-artifacts"
+        },
+        "environment_key": "default",
+        "max_retries": 3,
+        "retry_on_timeout": true,
+        "run_if": "ALL_SUCCESS",
+        "task_key": "deps-file-smoke"
+      }
+    ]
+  }
+}

--- a/acceptance/experimental/air/run-submit-deps/run-file.yaml
+++ b/acceptance/experimental/air/run-submit-deps/run-file.yaml
@@ -3,5 +3,7 @@ command: python train.py
 compute:
   accelerator_type: GPU_1xH100
   num_accelerators: 1
+  provisioned_capacity_id: capacity-123
 environment:
   dependencies: ./reqs.yaml
+mlflow_artifact_location: /Volumes/main/default/air-artifacts

--- a/acceptance/experimental/air/run-submit-deps/script
+++ b/acceptance/experimental/air/run-submit-deps/script
@@ -7,5 +7,11 @@ trace print_requests.py //api/2.0/workspace-files/import-file --oneline --sort -
 title "declared deps ride on environments[].spec.dependencies"
 trace print_requests.py //api/2.2/jobs/runs/submit
 
-title "a requirements.yaml file path is rejected; deps must be inline"
-musterr trace $CLI experimental air run -f run-file.yaml
+title "submit with file-backed dependencies"
+trace $CLI experimental air run -f run-file.yaml
+
+title "requirements.yaml is uploaded beside the launch config"
+trace print_requests.py //api/2.0/workspace-files/import-file --oneline --sort --unique --keep
+
+title "file deps, artifact location, and capacity id reach the submit payload"
+trace print_requests.py //api/2.2/jobs/runs/submit

--- a/acceptance/experimental/air/run-submit-deps/test.toml
+++ b/acceptance/experimental/air/run-submit-deps/test.toml
@@ -21,3 +21,7 @@ Response.Body = '''
 [[Repls]]
 Old = 'deps-smoke_[0-9a-f]{16}'
 New = 'deps-smoke_[RUN_ID]'
+
+[[Repls]]
+Old = 'deps-file-smoke_[0-9a-f]{16}'
+New = 'deps-file-smoke_[RUN_ID]'

--- a/experimental/air/cmd/compute.go
+++ b/experimental/air/cmd/compute.go
@@ -1,6 +1,7 @@
 package aircmd
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 )
@@ -54,12 +55,13 @@ func gpusPerNode(g gpuType) (int, error) {
 // computeConfig is the `compute` block of the run YAML: which accelerators to
 // use and how many.
 type computeConfig struct {
-	NumAccelerators int    `yaml:"num_accelerators" help:"Total number of GPUs to allocate. Must be a positive multiple of the accelerator type's per-node GPU count. See https://docs.databricks.com/aws/en/machine-learning/ai-runtime/cli/yaml-config#reference for supported GPU types."`
-	AcceleratorType string `yaml:"accelerator_type" help:"Which accelerator to run on, e.g. GPU_1xA10. See https://docs.databricks.com/aws/en/machine-learning/ai-runtime/cli/yaml-config#reference for the current list of supported GPU types. Matched case-sensitively."`
+	NumAccelerators       int     `yaml:"num_accelerators" help:"Total number of GPUs to allocate. Must be a positive multiple of the accelerator type's per-node GPU count. See https://docs.databricks.com/aws/en/machine-learning/ai-runtime/cli/yaml-config#reference for supported GPU types."`
+	AcceleratorType       string  `yaml:"accelerator_type" help:"Which accelerator to run on, e.g. GPU_1xA10. See https://docs.databricks.com/aws/en/machine-learning/ai-runtime/cli/yaml-config#reference for the current list of supported GPU types. Matched case-sensitively."`
+	ProvisionedCapacityID *string `yaml:"provisioned_capacity_id" help:"Pre-provisioned AIR capacity reservation id. Must be 1-255 characters."`
 }
 
 // validate checks the compute block against the backend's constraints.
-func (c computeConfig) validate() error {
+func (c *computeConfig) validate() error {
 	g, err := parseGPUType(c.AcceleratorType)
 	if err != nil {
 		return fmt.Errorf("compute.accelerator_type: %w", err)
@@ -75,6 +77,17 @@ func (c computeConfig) validate() error {
 	}
 	if c.NumAccelerators%perNode != 0 {
 		return fmt.Errorf("compute.num_accelerators for %s must be a multiple of %d, got %d", c.AcceleratorType, perNode, c.NumAccelerators)
+	}
+
+	if c.ProvisionedCapacityID != nil {
+		v := strings.TrimSpace(*c.ProvisionedCapacityID)
+		if v == "" {
+			return errors.New("compute.provisioned_capacity_id cannot be empty")
+		}
+		if len(v) > 255 {
+			return fmt.Errorf("compute.provisioned_capacity_id must be 255 characters or less, got %d", len(v))
+		}
+		*c.ProvisionedCapacityID = v
 	}
 
 	return nil

--- a/experimental/air/cmd/compute_test.go
+++ b/experimental/air/cmd/compute_test.go
@@ -1,6 +1,7 @@
 package aircmd
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -67,6 +68,9 @@ func TestComputeConfigValidate(t *testing.T) {
 		{"single node", computeConfig{NumAccelerators: 8, AcceleratorType: "GPU_8xH100"}, ""},
 		{"multiple nodes", computeConfig{NumAccelerators: 16, AcceleratorType: "GPU_8xH100"}, ""},
 		{"single-gpu partitions", computeConfig{NumAccelerators: 3, AcceleratorType: "GPU_1xH100"}, ""},
+		{"capacity id", computeConfig{NumAccelerators: 1, AcceleratorType: "GPU_1xH100", ProvisionedCapacityID: new(" capacity ")}, ""},
+		{"empty capacity id", computeConfig{NumAccelerators: 1, AcceleratorType: "GPU_1xH100", ProvisionedCapacityID: new(" ")}, "cannot be empty"},
+		{"long capacity id", computeConfig{NumAccelerators: 1, AcceleratorType: "GPU_1xH100", ProvisionedCapacityID: new(strings.Repeat("a", 256))}, "255 characters or less"},
 		{"unknown type", computeConfig{NumAccelerators: 8, AcceleratorType: "b200"}, "accelerator_type"},
 		{"legacy type rejected", computeConfig{NumAccelerators: 8, AcceleratorType: "h100_80gb"}, "accelerator_type"},
 		{"non-positive count", computeConfig{NumAccelerators: 0, AcceleratorType: "GPU_1xH100"}, "must be positive"},

--- a/experimental/air/cmd/convert_to_dabs.go
+++ b/experimental/air/cmd/convert_to_dabs.go
@@ -329,8 +329,8 @@ func buildBundleValue(ctx context.Context, cfg *runConfig, configPath, codeSourc
 // bundleEnvironmentDeps resolves the runtime version and the inline dependency
 // list to emit in the bundle's environments[] spec. The aicode mutator synthesizes
 // requirements.yaml from that spec at deploy, so the whole set must be here.
-// Dependencies are inline-only (a requirements-file path is rejected at config
-// load), so an unset list yields no dependencies.
+// File-backed dependencies are resolved during config load, so an unset list
+// yields no dependencies here.
 func bundleEnvironmentDeps(ctx context.Context, cfg *runConfig) (version string, deps []string) {
 	cfgVersion, _ := cfg.runtimeVersion()
 	version = dlRuntimeImage(ctx, cfgVersion)

--- a/experimental/air/cmd/format.go
+++ b/experimental/air/cmd/format.go
@@ -102,6 +102,43 @@ func runStatus(state *jobs.RunState) string {
 	return statusWord(string(state.LifeCycleState), string(state.ResultState))
 }
 
+func displayRunStatus(run *jobs.Run) string {
+	status := runStatus(run.State)
+	if status != string(jobs.RunLifeCycleStateRunning) || len(run.Tasks) == 0 || run.Tasks[0].State == nil {
+		return status
+	}
+	switch run.Tasks[0].State.LifeCycleState {
+	case jobs.RunLifeCycleStatePending, jobs.RunLifeCycleStateQueued,
+		jobs.RunLifeCycleStateWaitingForRetry, jobs.RunLifeCycleStateBlocked:
+		return "PENDING"
+	default:
+		return status
+	}
+}
+
+func terminationReason(run *jobs.Run) *string {
+	status := runStatus(run.State)
+	if status != "FAILED" && status != "TIMEDOUT" && status != "INTERNAL_ERROR" {
+		return nil
+	}
+	if run.Status != nil && run.Status.TerminationDetails != nil {
+		if message := strings.TrimSpace(run.Status.TerminationDetails.Message); message != "" {
+			return &message
+		}
+	}
+	if run.State != nil {
+		if message := strings.TrimSpace(run.State.StateMessage); message != "" {
+			return &message
+		}
+	}
+	if len(run.Tasks) > 0 && run.Tasks[0].State != nil {
+		if message := strings.TrimSpace(run.Tasks[0].State.StateMessage); message != "" {
+			return &message
+		}
+	}
+	return nil
+}
+
 // statusWord picks the status word to show from a run's lifecycle and result
 // states: the result state is the more meaningful one, so it wins when set.
 func statusWord(lifeCycle, result string) string {

--- a/experimental/air/cmd/format_test.go
+++ b/experimental/air/cmd/format_test.go
@@ -235,3 +235,48 @@ func TestStatusWord(t *testing.T) {
 	assert.Equal(t, "RUNNING", statusWord("RUNNING", ""))           // falls back to lifecycle
 	assert.Equal(t, "UNKNOWN", statusWord("", ""))
 }
+
+func TestDisplayRunStatus(t *testing.T) {
+	pendingStates := []jobs.RunLifeCycleState{
+		jobs.RunLifeCycleStatePending,
+		jobs.RunLifeCycleStateQueued,
+		jobs.RunLifeCycleStateWaitingForRetry,
+		jobs.RunLifeCycleStateBlocked,
+	}
+	for _, state := range pendingStates {
+		run := &jobs.Run{
+			State: &jobs.RunState{LifeCycleState: jobs.RunLifeCycleStateRunning},
+			Tasks: []jobs.RunTask{{State: &jobs.RunState{LifeCycleState: state}}},
+		}
+		assert.Equal(t, "PENDING", displayRunStatus(run))
+	}
+
+	assert.Equal(t, "RUNNING", displayRunStatus(&jobs.Run{
+		State: &jobs.RunState{LifeCycleState: jobs.RunLifeCycleStateRunning},
+		Tasks: []jobs.RunTask{{State: &jobs.RunState{LifeCycleState: jobs.RunLifeCycleStateRunning}}},
+	}))
+	assert.Equal(t, "RUNNING", displayRunStatus(&jobs.Run{State: &jobs.RunState{LifeCycleState: jobs.RunLifeCycleStateRunning}}))
+	assert.Equal(t, "FAILED", displayRunStatus(&jobs.Run{
+		State: &jobs.RunState{LifeCycleState: jobs.RunLifeCycleStateTerminated, ResultState: jobs.RunResultStateFailed},
+		Tasks: []jobs.RunTask{{State: &jobs.RunState{LifeCycleState: jobs.RunLifeCycleStatePending}}},
+	}))
+}
+
+func TestTerminationReason(t *testing.T) {
+	reason := terminationReason(&jobs.Run{
+		State:  &jobs.RunState{ResultState: jobs.RunResultStateFailed, StateMessage: "parent reason"},
+		Status: &jobs.RunStatus{TerminationDetails: &jobs.TerminationDetails{Message: " detailed reason "}},
+	})
+	require.NotNil(t, reason)
+	assert.Equal(t, "detailed reason", *reason)
+
+	reason = terminationReason(&jobs.Run{
+		State: &jobs.RunState{ResultState: jobs.RunResultStateTimedout},
+		Tasks: []jobs.RunTask{{State: &jobs.RunState{StateMessage: "task timed out"}}},
+	})
+	require.NotNil(t, reason)
+	assert.Equal(t, "task timed out", *reason)
+
+	assert.Nil(t, terminationReason(&jobs.Run{State: &jobs.RunState{ResultState: jobs.RunResultStateSuccess, StateMessage: "done"}}))
+	assert.Nil(t, terminationReason(&jobs.Run{State: &jobs.RunState{ResultState: jobs.RunResultStateCanceled, StateMessage: "cancelled"}}))
+}

--- a/experimental/air/cmd/get.go
+++ b/experimental/air/cmd/get.go
@@ -21,14 +21,15 @@ import (
 // the machine-readable output; fields tagged `json:"-"` are shown only in the
 // human-readable text view.
 type getData struct {
-	RunID           string  `json:"run_id"`
-	Status          string  `json:"status"`
-	StartedAt       *string `json:"started_at"`
-	DurationSeconds *int64  `json:"duration_seconds"`
-	AttemptNumber   int     `json:"attempt_number"`
-	ExperimentName  *string `json:"experiment_name"`
-	DashboardURL    string  `json:"dashboard_url"`
-	MLflowURL       *string `json:"mlflow_url"`
+	RunID             string  `json:"run_id"`
+	Status            string  `json:"status"`
+	StartedAt         *string `json:"started_at"`
+	DurationSeconds   *int64  `json:"duration_seconds"`
+	AttemptNumber     int     `json:"attempt_number"`
+	ExperimentName    *string `json:"experiment_name"`
+	DashboardURL      string  `json:"dashboard_url"`
+	MLflowURL         *string `json:"mlflow_url"`
+	TerminationReason *string `json:"termination_reason,omitempty"`
 	// ESTRemainingSeconds and ESTPercentComplete are a best-effort progress
 	// estimate for a running run, or null when one can't be made (see
 	// estimateTrainingETA).
@@ -50,6 +51,7 @@ type getData struct {
 	// ProgressDisplay is the pre-rendered "Progress" cell ("45% · ~2h 15m left"),
 	// set only for a running run with an estimable remaining time.
 	ProgressDisplay string `json:"-"`
+	DisplayStatus   string `json:"-"`
 	// TrainingConfigPath is the run's config file, downloaded for the config box.
 	TrainingConfigPath string `json:"-"`
 	// Sweep replaces the single-run view for foreach runs.
@@ -61,7 +63,7 @@ type getData struct {
 // used only when .Data.Sweep is set. It reads from the JSON envelope, so every
 // field is reached through ".Data".
 const getTemplate = `Sweep Run ID: {{.Data.RunID}}
-Status:       {{.Data.Status}}
+Status:       {{if .Data.DisplayStatus}}{{.Data.DisplayStatus}}{{else}}{{.Data.Status}}{{end}}
 Total:        {{.Data.Sweep.Total}}
 Completed:    {{.Data.Sweep.Completed}}
 Succeeded:    {{.Data.Sweep.Succeeded}}
@@ -237,12 +239,14 @@ func aiRuntimeTaskOf(run *jobs.Run) *jobs.AiRuntimeTask {
 // hyperlinks and colors once the dashboard and MLflow identifiers are known.
 func buildGetData(run *jobs.Run) getData {
 	data := getData{
-		RunID:           strconv.FormatInt(run.RunId, 10),
-		Status:          runStatus(run.State),
-		StartedAt:       startedAt(run),
-		DurationSeconds: durationSeconds(run),
-		AttemptNumber:   latestAttemptNumber(run),
-		ExperimentName:  experimentName(run),
+		RunID:             strconv.FormatInt(run.RunId, 10),
+		Status:            runStatus(run.State),
+		DisplayStatus:     displayRunStatus(run),
+		TerminationReason: terminationReason(run),
+		StartedAt:         startedAt(run),
+		DurationSeconds:   durationSeconds(run),
+		AttemptNumber:     latestAttemptNumber(run),
+		ExperimentName:    experimentName(run),
 	}
 	data.SubmittedDisplay = submittedDisplay(run)
 	data.DurationDisplay = na

--- a/experimental/air/cmd/get_test.go
+++ b/experimental/air/cmd/get_test.go
@@ -220,6 +220,38 @@ func TestBuildGetData(t *testing.T) {
 	assert.Equal(t, int64(12), *d.DurationSeconds)
 }
 
+func TestBuildGetDataTerminationReasonJSON(t *testing.T) {
+	failed := buildGetData(&jobs.Run{
+		RunId: 5,
+		State: &jobs.RunState{ResultState: jobs.RunResultStateFailed},
+		Status: &jobs.RunStatus{TerminationDetails: &jobs.TerminationDetails{
+			Message: "out of memory",
+		}},
+	})
+	body, err := json.Marshal(failed)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{
+		"run_id":"5","status":"FAILED","started_at":null,"duration_seconds":null,
+		"attempt_number":0,"experiment_name":null,"dashboard_url":"","mlflow_url":null,
+		"termination_reason":"out of memory","est_remaining_seconds":null,"est_percent_complete":null
+	}`, string(body))
+
+	canceled := buildGetData(&jobs.Run{RunId: 6, State: &jobs.RunState{ResultState: jobs.RunResultStateCanceled, StateMessage: "user canceled"}})
+	body, err = json.Marshal(canceled)
+	require.NoError(t, err)
+	assert.NotContains(t, string(body), "termination_reason")
+}
+
+func TestGetTemplateUsesDisplayStatus(t *testing.T) {
+	out := renderGet(t, getData{
+		RunID:         "456",
+		Status:        "RUNNING",
+		DisplayStatus: "PENDING",
+		Sweep:         &sweepInfo{Total: 1, Active: 1},
+	})
+	assert.Contains(t, out, "Status:       PENDING")
+}
+
 func TestEnrichFromAiRuntimeTask(t *testing.T) {
 	t.Run("fills config path, experiment, and accelerators", func(t *testing.T) {
 		run := &jobs.Run{RunId: 5, Tasks: []jobs.RunTask{{

--- a/experimental/air/cmd/list.go
+++ b/experimental/air/cmd/list.go
@@ -37,12 +37,13 @@ type listData struct {
 // machine-readable output; fields tagged `json:"-"` are shown only in the
 // human-readable table.
 type listRow struct {
-	RunID     string  `json:"run_id"`
-	RunName   string  `json:"run_name"`
-	User      string  `json:"user"`
-	Status    string  `json:"status"`
-	StartedAt *string `json:"started_at"`
-	IsSweep   bool    `json:"is_sweep"`
+	RunID         string  `json:"run_id"`
+	RunName       string  `json:"run_name"`
+	User          string  `json:"user"`
+	Status        string  `json:"status"`
+	DisplayStatus string  `json:"-"`
+	StartedAt     *string `json:"started_at"`
+	IsSweep       bool    `json:"is_sweep"`
 
 	// Experiment, Duration, Progress, MLflowURL and Accelerators are table-only
 	// columns, omitted from JSON to match `air list --json`.

--- a/experimental/air/cmd/list_format.go
+++ b/experimental/air/cmd/list_format.go
@@ -34,17 +34,18 @@ func buildListRow(run *jobs.Run, host string, workspaceID int64) listRow {
 	}
 
 	return listRow{
-		RunID:        strconv.FormatInt(run.RunId, 10),
-		RunName:      run.RunName,
-		User:         run.CreatorUserName,
-		Status:       runStatus(run.State),
-		StartedAt:    startedAt,
-		IsSweep:      isSweep(run),
-		Experiment:   experiment,
-		Duration:     duration,
-		MLflowURL:    "-",
-		MLflowLabel:  "-",
-		RunURL:       dashboardURL(host, run.RunId, workspaceID),
-		Accelerators: accel,
+		RunID:         strconv.FormatInt(run.RunId, 10),
+		RunName:       run.RunName,
+		User:          run.CreatorUserName,
+		Status:        runStatus(run.State),
+		DisplayStatus: displayRunStatus(run),
+		StartedAt:     startedAt,
+		IsSweep:       isSweep(run),
+		Experiment:    experiment,
+		Duration:      duration,
+		MLflowURL:     "-",
+		MLflowLabel:   "-",
+		RunURL:        dashboardURL(host, run.RunId, workspaceID),
+		Accelerators:  accel,
 	}
 }

--- a/experimental/air/cmd/list_tui_render.go
+++ b/experimental/air/cmd/list_tui_render.go
@@ -58,7 +58,7 @@ func computeListCols(rows []listRow) listCols {
 	for _, r := range rows {
 		c.runID = max(c.runID, lipgloss.Width(r.RunID))
 		c.experiment = min(columnCap, max(c.experiment, lipgloss.Width(r.Experiment)))
-		c.status = max(c.status, lipgloss.Width("● "+r.Status))
+		c.status = max(c.status, lipgloss.Width("● "+listRowStatus(r)))
 		c.started = max(c.started, lipgloss.Width(startedDisplay(r)))
 		c.duration = max(c.duration, lipgloss.Width(r.Duration))
 		c.progress = max(c.progress, lipgloss.Width(progressDisplay(r)))
@@ -123,7 +123,7 @@ func (s listStyles) renderRow(cols listCols, r listRow, selected, links bool) st
 		s.cell(base, gutter, 1, fg(colN7), false, false, ""),
 		s.cell(base, r.RunID, cols.runID, fg(colRunID), false, runIDLink != "", runIDLink),
 		s.cell(base, r.Experiment, cols.experiment, fg(colN11), false, experimentLink != "", experimentLink),
-		s.cell(base, "● "+r.Status, cols.status, fg(statusColor(r.Status)), false, false, ""),
+		s.cell(base, "● "+listRowStatus(r), cols.status, fg(statusColor(listRowStatus(r))), false, false, ""),
 		s.cell(base, startedDisplay(r), cols.started, fg(colN9), false, false, ""),
 		s.cell(base, r.Duration, cols.duration, fg(colN9), true, false, ""),
 		s.cell(base, progressDisplay(r), cols.progress, fg(colAmber), true, false, ""),
@@ -133,6 +133,13 @@ func (s listStyles) renderRow(cols listCols, r listRow, selected, links bool) st
 	}
 	// Trim the final column's trailing pad so rows carry no trailing whitespace.
 	return strings.TrimRight(strings.Join(cells, base.Render("  ")), " ")
+}
+
+func listRowStatus(r listRow) string {
+	if r.DisplayStatus != "" {
+		return r.DisplayStatus
+	}
+	return r.Status
 }
 
 // cell renders one padded, colored cell. The text is truncated to width, then

--- a/experimental/air/cmd/logdownload.go
+++ b/experimental/air/cmd/logdownload.go
@@ -80,7 +80,11 @@ func downloadLogs(ctx context.Context, w *databricks.WorkspaceClient, out io.Wri
 
 	// A run with no logs is reported the same way as on the streaming path, so
 	// the message and exit code agree between them.
-	ids := mlflowIDs(ctx, w, run)
+	attempt, taskRunID, err := resolveLogAttempt(run, req.attempt)
+	if err != nil {
+		return false, err
+	}
+	ids := mlflowIDsForTask(ctx, w, taskRunID)
 	if ids == nil || ids.RunID == "" {
 		emitNoLogs(out, req, status)
 		return status.downloadOutcome(), nil
@@ -96,7 +100,7 @@ func downloadLogs(ctx context.Context, w *databricks.WorkspaceClient, out io.Wri
 		return false, fmt.Errorf("failed to create %s: %w", dir, err)
 	}
 
-	nodeLogs, failures, err := downloadAllNodeLogs(ctx, w, ids.RunID, dir, nodes, req.attempt)
+	nodeLogs, failures, err := downloadAllNodeLogs(ctx, w, ids.RunID, dir, nodes, attempt)
 	if err != nil {
 		return false, err
 	}

--- a/experimental/air/cmd/logmlflow.go
+++ b/experimental/air/cmd/logmlflow.go
@@ -3,6 +3,7 @@ package aircmd
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -12,15 +13,46 @@ import (
 	"regexp"
 	"slices"
 	"strconv"
+	"strings"
+	"sync"
 	"time"
 
+	"github.com/databricks/cli/libs/filer"
 	"github.com/databricks/cli/libs/log"
 	"github.com/databricks/databricks-sdk-go"
+	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/databricks-sdk-go/client"
 	"github.com/databricks/databricks-sdk-go/listing"
 	"github.com/databricks/databricks-sdk-go/service/jobs"
 	"github.com/databricks/databricks-sdk-go/service/ml"
 )
+
+var mlflowArtifactRoots sync.Map
+
+func mlflowArtifactRoot(ctx context.Context, w *databricks.WorkspaceClient, mlflowRunID string) (string, error) {
+	key := strings.TrimRight(w.Config.Host, "/") + "\x00" + mlflowRunID
+	if cached, ok := mlflowArtifactRoots.Load(key); ok {
+		return cached.(string), nil
+	}
+	response, err := w.Experiments.GetRun(ctx, ml.GetRunRequest{RunId: mlflowRunID})
+	if err != nil {
+		log.Debugf(ctx, "air logs: could not resolve MLflow artifact URI for %s: %v", mlflowRunID, err)
+		return "", nil
+	}
+	if response.Run == nil || response.Run.Info == nil {
+		return "", nil
+	}
+	root := strings.TrimRight(response.Run.Info.ArtifactUri, "/")
+	mlflowArtifactRoots.Store(key, root)
+	return root, nil
+}
+
+func volumeArtifactRoot(root string) (string, bool) {
+	if strings.HasPrefix(root, "dbfs:/Volumes/") {
+		return strings.TrimPrefix(root, "dbfs:"), true
+	}
+	return "", false
+}
 
 // chunkFilePattern matches a log chunk file (logs-<index>.chunk.txt); group 1 is
 // the chunk index. The sidecar splits stdout into 4MB chunks, index ascending.
@@ -53,6 +85,13 @@ func mlflowLogFallback(ctx context.Context, w *databricks.WorkspaceClient, out i
 		log.Debugf(ctx, "air logs: --minutes is not supported on the MLflow fallback path; showing the default tail")
 	}
 
+	if !status.terminal() && !req.staticView {
+		return streamMLflowLogs(ctx, w, out, req, status)
+	}
+	return fetchMLflowLogTail(ctx, w, out, req, status)
+}
+
+func fetchMLflowLogTail(ctx context.Context, w *databricks.WorkspaceClient, out io.Writer, req logRequest, status logRunStatus) (bool, error) {
 	mlflowRunID, logDir, err := resolveMLflowLogPath(ctx, w, req)
 	if err != nil {
 		return false, err
@@ -94,19 +133,113 @@ func mlflowLogFallback(ctx context.Context, w *databricks.WorkspaceClient, out i
 	return status.downloadOutcome(), nil
 }
 
+func mlflowLogsExist(ctx context.Context, w *databricks.WorkspaceClient, req logRequest) bool {
+	mlflowRunID, logDir, err := resolveMLflowLogPath(ctx, w, req)
+	if err != nil || mlflowRunID == "" || logDir == "" {
+		if err != nil {
+			log.Debugf(ctx, "air logs: MLflow log-existence probe failed for run %d: %v", req.runID, err)
+		}
+		return false
+	}
+	chunks, err := listLogChunks(ctx, w, mlflowRunID, logDir)
+	if err != nil {
+		log.Debugf(ctx, "air logs: MLflow log-existence probe failed for run %d: %v", req.runID, err)
+		return false
+	}
+	return len(chunks) > 0
+}
+
+func streamMLflowLogs(ctx context.Context, w *databricks.WorkspaceClient, out io.Writer, req logRequest, status logRunStatus) (bool, error) {
+	lineOffsets := make(map[string]int)
+	currentRunID := ""
+	printed := false
+	previousState := ""
+
+	for {
+		if req.onStatusChange != nil {
+			current := status.displayState()
+			if current != previousState {
+				req.onStatusChange(current, previousState)
+				previousState = current
+			}
+		}
+
+		mlflowRunID, logDir, err := resolveMLflowLogPath(ctx, w, req)
+		if err != nil {
+			if status.terminal() {
+				return false, err
+			}
+			log.Debugf(ctx, "air logs: failed to resolve MLflow log path: %v", err)
+		} else if mlflowRunID != "" && logDir != "" {
+			if currentRunID != mlflowRunID {
+				currentRunID = mlflowRunID
+				lineOffsets = make(map[string]int)
+			}
+			chunks, listErr := listLogChunks(ctx, w, mlflowRunID, logDir)
+			if listErr != nil {
+				if status.terminal() {
+					return false, listErr
+				}
+				log.Debugf(ctx, "air logs: failed to list MLflow log chunks: %v", listErr)
+			} else {
+				for _, chunk := range chunks {
+					lines, downloadErr := downloadChunkLines(ctx, w, mlflowRunID, chunk.path)
+					if downloadErr != nil {
+						if status.terminal() {
+							return false, downloadErr
+						}
+						log.Debugf(ctx, "air logs: failed to read MLflow log chunk %s: %v", chunk.path, downloadErr)
+						continue
+					}
+					offset := lineOffsets[chunk.path]
+					if offset > len(lines) {
+						offset = 0
+					}
+					for _, line := range lines[offset:] {
+						emitLogLine(out, req, line)
+						printed = true
+					}
+					lineOffsets[chunk.path] = len(lines)
+				}
+			}
+		}
+
+		if status.terminal() {
+			if !printed {
+				emitNoLogs(out, req, status)
+			}
+			return status.succeeded(), nil
+		}
+		if err := sleepOrCancel(ctx, retryCheckInterval); err != nil {
+			return false, err
+		}
+		refreshed, err := resolveRunStatus(ctx, w, req.runID)
+		if err != nil {
+			if errors.Is(err, apierr.ErrResourceDoesNotExist) || ctx.Err() != nil {
+				return false, err
+			}
+			log.Debugf(ctx, "air logs: failed to refresh run status on MLflow fallback: %v", err)
+			continue
+		}
+		status = refreshed
+	}
+}
+
 // resolveMLflowLogPath returns the run's MLflow run id and per-node log directory.
 func resolveMLflowLogPath(ctx context.Context, w *databricks.WorkspaceClient, req logRequest) (string, string, error) {
 	run, err := w.Jobs.GetRun(ctx, jobs.GetRunRequest{RunId: req.runID})
 	if err != nil {
 		return "", "", err
 	}
-	ids := mlflowIDs(ctx, w, run)
+	attempt, taskRunID, err := resolveLogAttempt(run, req.attempt)
+	if err != nil {
+		return "", "", err
+	}
+	ids := mlflowIDsForTask(ctx, w, taskRunID)
 	if ids == nil || ids.RunID == "" {
 		return "", "", nil
 	}
 
-	// -1 (latest) maps to attempt 0's directory.
-	attempt := max(req.attempt, 0)
 	withAttempt, err := discoverAttemptPrefix(ctx, w, ids.RunID, attempt)
 	if err != nil {
 		return "", "", err
@@ -224,8 +357,35 @@ func downloadChunkLines(ctx context.Context, w *databricks.WorkspaceClient, mlfl
 }
 
 // listArtifacts lists a run's artifacts under a path.
-func listArtifacts(ctx context.Context, w *databricks.WorkspaceClient, mlflowRunID, path string) ([]ml.FileInfo, error) {
-	it := w.Experiments.ListArtifacts(ctx, ml.ListArtifactsRequest{RunId: mlflowRunID, Path: path})
+func listArtifacts(ctx context.Context, w *databricks.WorkspaceClient, mlflowRunID, artifactPath string) ([]ml.FileInfo, error) {
+	root, err := mlflowArtifactRoot(ctx, w, mlflowRunID)
+	if err != nil {
+		return nil, err
+	}
+	if volumeRoot, ok := volumeArtifactRoot(root); ok {
+		fc, err := filer.NewWorkspaceFilesClient(w, volumeRoot)
+		if err != nil {
+			return nil, err
+		}
+		entries, err := fc.ReadDir(ctx, artifactPath)
+		if err != nil {
+			return nil, err
+		}
+		files := make([]ml.FileInfo, 0, len(entries))
+		for _, entry := range entries {
+			info := ml.FileInfo{Path: path.Join(artifactPath, entry.Name()), IsDir: entry.IsDir()}
+			if !entry.IsDir() {
+				stat, err := entry.Info()
+				if err != nil {
+					return nil, err
+				}
+				info.FileSize = stat.Size()
+			}
+			files = append(files, info)
+		}
+		return files, nil
+	}
+	it := w.Experiments.ListArtifacts(ctx, ml.ListArtifactsRequest{RunId: mlflowRunID, Path: artifactPath})
 	return listing.ToSlice(ctx, it)
 }
 
@@ -247,6 +407,35 @@ type credentialsForReadResponse struct {
 // path. credentials-for-read returns a pre-signed URL, which we stream to disk;
 // that endpoint is not modeled by the SDK, so it is called via a raw client.Do.
 func downloadArtifact(ctx context.Context, w *databricks.WorkspaceClient, mlflowRunID, artifactPath string) (string, error) {
+	root, err := mlflowArtifactRoot(ctx, w, mlflowRunID)
+	if err != nil {
+		return "", err
+	}
+	if volumeRoot, ok := volumeArtifactRoot(root); ok {
+		fc, err := filer.NewWorkspaceFilesClient(w, volumeRoot)
+		if err != nil {
+			return "", err
+		}
+		reader, err := fc.Read(ctx, artifactPath)
+		if err != nil {
+			return "", err
+		}
+		defer reader.Close()
+		tmp, err := os.CreateTemp("", "air-log-chunk-*")
+		if err != nil {
+			return "", err
+		}
+		if _, err := io.Copy(tmp, reader); err != nil {
+			tmp.Close()
+			os.Remove(tmp.Name())
+			return "", err
+		}
+		if err := tmp.Close(); err != nil {
+			os.Remove(tmp.Name())
+			return "", err
+		}
+		return tmp.Name(), nil
+	}
 	apiClient, err := client.New(w.Config)
 	if err != nil {
 		return "", fmt.Errorf("failed to create API client: %w", err)

--- a/experimental/air/cmd/logmlflow_test.go
+++ b/experimental/air/cmd/logmlflow_test.go
@@ -2,14 +2,45 @@ package aircmd
 
 import (
 	"bytes"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
+	"github.com/databricks/cli/libs/filer"
+	"github.com/databricks/cli/libs/testserver"
+	"github.com/databricks/databricks-sdk-go"
+	"github.com/databricks/databricks-sdk-go/service/jobs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestResolveLogAttempt(t *testing.T) {
+	run := &jobs.Run{RunId: 5, Tasks: []jobs.RunTask{
+		{RunId: 100, AttemptNumber: 0},
+		{RunId: 101, AttemptNumber: 1},
+		{RunId: 102, AttemptNumber: 2},
+	}}
+
+	attempt, taskRunID, err := resolveLogAttempt(run, -1)
+	require.NoError(t, err)
+	assert.Equal(t, 2, attempt)
+	assert.Equal(t, int64(102), taskRunID)
+
+	attempt, taskRunID, err = resolveLogAttempt(run, 1)
+	require.NoError(t, err)
+	assert.Equal(t, 1, attempt)
+	assert.Equal(t, int64(101), taskRunID)
+
+	_, _, err = resolveLogAttempt(run, 3)
+	require.ErrorContains(t, err, "available retries are 0 to 2")
+	_, _, err = resolveLogAttempt(run, -2)
+	require.ErrorContains(t, err, "must be -1 or greater")
+}
 
 func TestConstructLogPath(t *testing.T) {
 	assert.Equal(t, "logs/node_0", constructLogPath(0, 0, false))
@@ -112,6 +143,111 @@ func TestMLflowFallbackNoLogsReflectsRunOutcome(t *testing.T) {
 		logRequest{runID: 5}, logRunStatus{lifeCycleState: "TERMINATED", resultState: "FAILED"})
 	require.NoError(t, err)
 	assert.False(t, success)
+}
+
+func TestStreamMLflowLogsFollowsWithoutDuplicates(t *testing.T) {
+	oldInterval := retryCheckInterval
+	retryCheckInterval = time.Millisecond
+	t.Cleanup(func() { retryCheckInterval = oldInterval })
+
+	var getRunCalls atomic.Int32
+	var artifactReads atomic.Int32
+	var base string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/2.2/jobs/runs/get":
+			state := `{"life_cycle_state":"RUNNING"}`
+			if getRunCalls.Add(1) >= 4 {
+				state = `{"life_cycle_state":"TERMINATED","result_state":"SUCCESS"}`
+			}
+			_, _ = fmt.Fprintf(w, `{"run_id":5,"state":%s,"tasks":[{"run_id":101,"attempt_number":1}]}`, state)
+		case "/api/2.2/jobs/runs/get-output":
+			_, _ = w.Write([]byte(`{"ai_runtime_task_output":{"mlflow_experiment_id":"exp","mlflow_run_id":"mlrun"}}`))
+		case "/api/2.0/mlflow/runs/get":
+			_, _ = w.Write([]byte(`{}`))
+		case "/api/2.0/mlflow/artifacts/list":
+			if r.URL.Query().Get("path") == "logs" {
+				_, _ = w.Write([]byte(`{"files":[{"path":"logs/attempt_1","is_dir":true}]}`))
+			} else {
+				_, _ = w.Write([]byte(`{"files":[{"path":"logs/attempt_1/node_0/logs-0.chunk.txt"}]}`))
+			}
+		case "/api/2.0/mlflow/artifacts/credentials-for-read":
+			_, _ = fmt.Fprintf(w, `{"credential_infos":[{"signed_uri":%q}]}`, base+"/artifact")
+		case "/artifact":
+			if artifactReads.Add(1) == 1 {
+				_, _ = w.Write([]byte("one\n"))
+			} else {
+				_, _ = w.Write([]byte("one\ntwo\n"))
+			}
+		default:
+			_, _ = w.Write([]byte(`{}`))
+		}
+	}))
+	base = srv.URL
+	t.Cleanup(srv.Close)
+
+	var out bytes.Buffer
+	success, err := streamMLflowLogs(t.Context(), newTestWorkspaceClient(t, srv.URL), &out,
+		logRequest{runID: 5, attempt: -1, tailLines: -1}, logRunStatus{lifeCycleState: "RUNNING", latestAttempt: 1})
+	require.NoError(t, err)
+	assert.True(t, success)
+	assert.Equal(t, 1, strings.Count(out.String(), "one"))
+	assert.Equal(t, 1, strings.Count(out.String(), "two"))
+}
+
+func TestVolumeArtifactListAndDownload(t *testing.T) {
+	server := testserver.New(t)
+	t.Cleanup(server.Close)
+	server.Handle("GET", "/api/2.0/mlflow/runs/get", func(req testserver.Request) any {
+		return map[string]any{"run": map[string]any{"info": map[string]any{
+			"run_id": "volume-run", "artifact_uri": "dbfs:/Volumes/main/default/logs/root",
+		}}}
+	})
+	testserver.AddDefaultHandlers(server)
+
+	w, err := databricks.NewWorkspaceClient(&databricks.Config{Host: server.URL, Token: "token"})
+	require.NoError(t, err)
+	fc, err := filer.NewWorkspaceFilesClient(w, "/Volumes/main/default/logs/root")
+	require.NoError(t, err)
+	require.NoError(t, fc.Write(t.Context(), "logs/node_0/logs-0.chunk.txt", strings.NewReader("volume line\n"), filer.CreateParentDirectories))
+
+	chunks, err := listLogChunks(t.Context(), w, "volume-run", "logs/node_0")
+	require.NoError(t, err)
+	require.Len(t, chunks, 1)
+	assert.Equal(t, "logs/node_0/logs-0.chunk.txt", chunks[0].path)
+
+	lines, err := downloadChunkLines(t.Context(), w, "volume-run", chunks[0].path)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"volume line"}, lines)
+}
+
+func TestMLflowArtifactRootCachesSuccessButNotFailure(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/2.0/mlflow/runs/get" {
+			_, _ = w.Write([]byte(`{}`))
+			return
+		}
+		if calls.Add(1) == 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"error_code":"INTERNAL_ERROR","message":"retry"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"run":{"info":{"run_id":"cache-run","artifact_uri":"dbfs:/Volumes/main/default/v"}}}`))
+	}))
+	t.Cleanup(srv.Close)
+	w := newTestWorkspaceClient(t, srv.URL)
+
+	root, err := mlflowArtifactRoot(t.Context(), w, "cache-run")
+	require.NoError(t, err)
+	assert.Empty(t, root)
+	root, err = mlflowArtifactRoot(t.Context(), w, "cache-run")
+	require.NoError(t, err)
+	assert.Equal(t, "dbfs:/Volumes/main/default/v", root)
+	root, err = mlflowArtifactRoot(t.Context(), w, "cache-run")
+	require.NoError(t, err)
+	assert.Equal(t, "dbfs:/Volumes/main/default/v", root)
+	assert.Equal(t, int32(2), calls.Load())
 }
 
 func TestDownloadArtifactSendsUnbracketedPath(t *testing.T) {

--- a/experimental/air/cmd/logs.go
+++ b/experimental/air/cmd/logs.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"slices"
 	"strconv"
 
 	"github.com/databricks/cli/cmd/root"
@@ -13,6 +14,7 @@ import (
 	"github.com/databricks/databricks-sdk-go"
 	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/databricks-sdk-go/service/iam"
+	"github.com/databricks/databricks-sdk-go/service/jobs"
 	"github.com/spf13/cobra"
 )
 
@@ -84,6 +86,10 @@ func newLogsCommand() *cobra.Command {
 		if node < 0 {
 			return renderError(ctx, cmd, "INVALID_ARGS", "PERMANENT", false,
 				fmt.Errorf("invalid --node %d: must not be negative", node))
+		}
+		if retry < -1 {
+			return renderError(ctx, cmd, "INVALID_ARGS", "PERMANENT", false,
+				fmt.Errorf("invalid --retry %d: must be -1 or greater", retry))
 		}
 
 		runID, err := strconv.ParseInt(args[0], 10, 64)
@@ -179,6 +185,29 @@ func runLogs(ctx context.Context, cmd *cobra.Command, req logRequest) error {
 		return root.ErrAlreadyPrinted
 	}
 	return nil
+}
+
+func resolveLogAttempt(run *jobs.Run, requested int) (int, int64, error) {
+	if requested < -1 {
+		return 0, 0, fmt.Errorf("invalid retry %d: must be -1 or greater", requested)
+	}
+	if len(run.Tasks) == 0 {
+		return 0, 0, nil
+	}
+	latest := latestAttemptNumber(run)
+	attempt := requested
+	if attempt < 0 {
+		attempt = latest
+	}
+	if attempt > latest {
+		return 0, 0, fmt.Errorf("invalid retry %d: available retries are 0 to %d", requested, latest)
+	}
+	for _, v := range slices.Backward(run.Tasks) {
+		if v.AttemptNumber == attempt {
+			return attempt, v.RunId, nil
+		}
+	}
+	return 0, 0, fmt.Errorf("run %d has no task for retry %d", run.RunId, attempt)
 }
 
 // fetchLogs serves logs from Bricklens, falling back to MLflow when Bricklens

--- a/experimental/air/cmd/logstream.go
+++ b/experimental/air/cmd/logstream.go
@@ -30,6 +30,9 @@ const (
 	// statusMessageRefreshEveryNPolls throttles the status_message fetch so the
 	// waiting spinner doesn't issue a get-output on every poll tick.
 	statusMessageRefreshEveryNPolls = 5
+	// bricklensEmptyMLflowProbeEveryNPolls throttles the active-run MLflow
+	// existence probe while Bricklens has returned no records.
+	bricklensEmptyMLflowProbeEveryNPolls = 10
 )
 
 // statusMessageType tags a client-facing message packed into
@@ -114,7 +117,7 @@ type logRunStatus struct {
 // set (result states only appear on terminal runs).
 var (
 	terminalLifeCycleStates = map[string]bool{"TERMINATED": true, "SKIPPED": true, "INTERNAL_ERROR": true}
-	terminalResultStates    = map[string]bool{"SUCCESS": true, "FAILED": true, "CANCELED": true}
+	terminalResultStates    = map[string]bool{"SUCCESS": true, "FAILED": true, "TIMEDOUT": true, "CANCELED": true}
 )
 
 func (s logRunStatus) terminal() bool {
@@ -324,6 +327,7 @@ func (st *bricklensStreamer) run() (bool, error) {
 	// server status_message fetch to every Nth poll, and lastSpinnerText avoids
 	// redundant spinner updates.
 	statusRefreshCounter := 0
+	emptyStreamPolls := 0
 	lastSpinnerText := ""
 	for {
 		if !firstIteration {
@@ -387,6 +391,13 @@ func (st *bricklensStreamer) run() (bool, error) {
 			}
 			log.Infof(st.ctx, "air logs: run %d finished in state %s", st.req.runID, st.status.displayState())
 			return st.status.succeeded(), nil
+		}
+		if !st.firstLogSeen {
+			emptyStreamPolls++
+			if emptyStreamPolls%bricklensEmptyMLflowProbeEveryNPolls == 0 && mlflowLogsExist(st.ctx, st.w, st.req) {
+				log.Debugf(st.ctx, "air logs: MLflow artifacts exist for run %d; falling back to MLflow log stream", st.req.runID)
+				return false, errBricklensFeatureDisabled
+			}
 		}
 
 		firstIteration = false

--- a/experimental/air/cmd/logstream_test.go
+++ b/experimental/air/cmd/logstream_test.go
@@ -112,6 +112,7 @@ func TestLogRunStatusTerminal(t *testing.T) {
 		{"terminated lifecycle", "TERMINATED", "", true},
 		{"internal error lifecycle", "INTERNAL_ERROR", "", true},
 		{"failed result", "TERMINATING", "FAILED", true},
+		{"timed out result", "RUNNING", "TIMEDOUT", true},
 		{"canceled result", "RUNNING", "CANCELED", true},
 	}
 	for _, tt := range tests {
@@ -496,6 +497,41 @@ func TestStreamBricklensTerminalWithRecordsDoesNotFallBack(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, ok)
 	assert.Contains(t, buf.String(), `"line":"hello"`)
+}
+
+func TestStreamBricklensActiveEmptyProbesMLflow(t *testing.T) {
+	oldInterval := retryCheckInterval
+	retryCheckInterval = time.Millisecond
+	t.Cleanup(func() { retryCheckInterval = oldInterval })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/logs"):
+			_, _ = w.Write([]byte(`{"log_records":[]}`))
+		case r.URL.Path == "/api/2.2/jobs/runs/get":
+			_, _ = w.Write([]byte(`{"run_id":123,"state":{"life_cycle_state":"RUNNING"},"tasks":[{"run_id":456,"attempt_number":0}]}`))
+		case r.URL.Path == "/api/2.2/jobs/runs/get-output":
+			_, _ = w.Write([]byte(`{"ai_runtime_task_output":{"mlflow_experiment_id":"E1","mlflow_run_id":"R1"}}`))
+		case r.URL.Path == "/api/2.0/mlflow/runs/get":
+			_, _ = w.Write([]byte(`{}`))
+		case r.URL.Path == "/api/2.0/mlflow/artifacts/list":
+			if r.URL.Query().Get("path") == "logs" {
+				_, _ = w.Write([]byte(`{"files":[{"path":"logs/node_0","is_dir":true}]}`))
+			} else {
+				_, _ = w.Write([]byte(`{"files":[{"path":"logs/node_0/logs-0.chunk.txt"}]}`))
+			}
+		default:
+			_, _ = w.Write([]byte(`{}`))
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	var out bytes.Buffer
+	_, err := streamBricklensLogs(t.Context(), newTestWorkspaceClient(t, srv.URL), &out,
+		logRequest{runID: 123, attempt: -1, tailLines: -1, jsonOutput: true},
+		logRunStatus{lifeCycleState: "RUNNING"})
+	require.ErrorIs(t, err, errBricklensFeatureDisabled)
+	assert.Empty(t, out.String())
 }
 
 func TestFetchLogsFallsBackToMLflowWhenBricklensEmpty(t *testing.T) {

--- a/experimental/air/cmd/render.go
+++ b/experimental/air/cmd/render.go
@@ -118,6 +118,9 @@ func renderRunText(ctx context.Context, out io.Writer, w *databricks.WorkspaceCl
 		accelerators: data.AcceleratorsDisplay,
 		environment:  data.EnvironmentDisplay,
 	}
+	if data.DisplayStatus != "" {
+		view.status = data.DisplayStatus
+	}
 
 	if ids != nil {
 		view.mlflowLabel = mlflowRunLabel(fetchMLflowRunName(ctx, w, ids.RunID), ids.RunID)
@@ -129,6 +132,9 @@ func renderRunText(ctx context.Context, out io.Writer, w *databricks.WorkspaceCl
 		sections = append(sections, renderBox(p, configBoxTitle, body))
 	}
 	sections = append(sections, renderBox(p, metadataBoxTitle, renderFields(p, colorOn, view)))
+	if data.TerminationReason != nil {
+		sections = append(sections, p.red.Render("Failure reason: ")+p.n12.Render(*data.TerminationReason))
+	}
 
 	// A single write: a blank line before the first box and after the last, and
 	// one between each box.

--- a/experimental/air/cmd/runconfig.go
+++ b/experimental/air/cmd/runconfig.go
@@ -56,6 +56,7 @@ type runConfig struct {
 	Parameters                map[string]any `yaml:"parameters" help:"Free-form values passed through to the workload. Any nested structure is allowed."`
 	MLflowRunName             *string        `yaml:"mlflow_run_name" help:"Name for the MLflow run. Max 100 characters, alphanumerics, hyphens, and underscores only."`
 	MLflowExperimentDirectory *string        `yaml:"mlflow_experiment_directory" help:"Workspace directory holding the MLflow experiment. Must start with /Workspace."`
+	MLflowArtifactLocation    *string        `yaml:"mlflow_artifact_location" help:"DBFS location where MLflow artifacts are written. A /Volumes path is normalized to dbfs:/Volumes/... ."`
 	Permissions               []permission   `yaml:"permissions" help:"Who may view or manage the run, as a list of principal plus level grants."`
 	UsagePolicyName           *string        `yaml:"usage_policy_name" help:"Usage policy to bill the run to, by name. Max 127 characters. Mutually exclusive with usage_policy_id."`
 	UsagePolicyID             *string        `yaml:"usage_policy_id" help:"Usage policy to bill the run to, by id. Mutually exclusive with usage_policy_name."`
@@ -150,6 +151,20 @@ func (c *runConfig) validate() error {
 		}
 	}
 
+	if c.MLflowArtifactLocation != nil {
+		v := strings.TrimSpace(*c.MLflowArtifactLocation)
+		if v == "" {
+			return errors.New("mlflow_artifact_location cannot be empty")
+		}
+		if strings.HasPrefix(v, "/Volumes/") {
+			v = "dbfs:" + v
+		}
+		if !strings.HasPrefix(v, "dbfs:/") {
+			return fmt.Errorf("mlflow_artifact_location must be a dbfs: URI, got: %s", v)
+		}
+		*c.MLflowArtifactLocation = v
+	}
+
 	for i := range c.Permissions {
 		if err := c.Permissions[i].validate(); err != nil {
 			return err
@@ -229,7 +244,7 @@ func validateSecretRefs(secrets map[string]string) error {
 // environmentConfig is the `environment` block: dependencies and/or a custom
 // docker image.
 type environmentConfig struct {
-	Dependencies dependencies       `yaml:"dependencies" help:"Inline list of packages to install. Not allowed alongside docker_image."`
+	Dependencies dependencies       `yaml:"dependencies" help:"Inline package list or path to a requirements YAML file. Not allowed alongside docker_image."`
 	Version      stringOrInt        `yaml:"version" help:"Client image version to pin. Only valid alongside inline dependencies."`
 	DockerImage  *dockerImageConfig `yaml:"docker_image" help:"Custom image supplying the whole runtime. Not allowed alongside dependencies or version."`
 }
@@ -256,24 +271,43 @@ func (e *environmentConfig) validate() error {
 	if e.Version.set && !e.Dependencies.set {
 		return errors.New("'environment.version' requires inline 'dependencies' (a list of packages)")
 	}
+	if e.Version.set {
+		version, err := validateRuntimeVersion(e.Version.raw, "environment.version")
+		if err != nil {
+			return err
+		}
+		e.Version.raw = version
+	}
 
 	return nil
 }
 
-// dependencies is environment.dependencies: an inline list of packages. A scalar
-// (e.g. a path to a requirements file) is rejected — the list may itself reference
-// a requirements.txt, but dependencies must be given as a list.
+// dependencies is environment.dependencies: either an inline list of packages or
+// a path to a requirements YAML file resolved relative to the run config.
 type dependencies struct {
-	set  bool
-	list []string
+	set          bool
+	list         []string
+	path         string
+	resolvedPath string
+	version      string
 }
 
 func (d *dependencies) UnmarshalYAML(node *yaml.Node) error {
-	if node.Kind != yaml.SequenceNode {
-		return errors.New("environment.dependencies must be a list of packages or reference a requirements.txt (see https://docs.databricks.com/aws/en/machine-learning/ai-runtime/cli/yaml-config#reference). A direct file reference is not supported")
-	}
 	d.set = true
-	return node.Decode(&d.list)
+	switch node.Kind {
+	case yaml.SequenceNode:
+		return node.Decode(&d.list)
+	case yaml.ScalarNode:
+		if err := node.Decode(&d.path); err != nil {
+			return err
+		}
+		if strings.TrimSpace(d.path) == "" {
+			return errors.New("environment.dependencies requirements YAML path cannot be empty")
+		}
+		return nil
+	default:
+		return errors.New("environment.dependencies must be a list of packages or a requirements YAML path")
+	}
 }
 
 // stringOrInt holds a scalar that may be a string or an integer in YAML

--- a/experimental/air/cmd/runconfig_launch.go
+++ b/experimental/air/cmd/runconfig_launch.go
@@ -26,9 +26,6 @@ func (c *runConfig) maxRetries() int {
 }
 
 // dockerImageURL returns the custom docker image URL, or "" when none is set.
-//
-// TODO: not wired into submission yet — the native ai_runtime_task carries no
-// docker field, and full support needs image registration (pending the DCS work).
 func (c *runConfig) dockerImageURL() string {
 	if c.Environment != nil && c.Environment.DockerImage != nil {
 		return c.Environment.DockerImage.URL
@@ -53,10 +50,23 @@ func (c *runConfig) inlineDependencies() ([]string, bool) {
 	return c.Environment.Dependencies.list, true
 }
 
+func (c *runConfig) requirementsPath() string {
+	if c.Environment == nil {
+		return ""
+	}
+	return c.Environment.Dependencies.resolvedPath
+}
+
 // runtimeVersion returns the client image version from environment.version when
 // set.
 func (c *runConfig) runtimeVersion() (string, bool) {
-	if c.Environment == nil || !c.Environment.Version.set {
+	if c.Environment == nil {
+		return "", false
+	}
+	if c.Environment.Dependencies.version != "" {
+		return c.Environment.Dependencies.version, true
+	}
+	if !c.Environment.Version.set {
 		return "", false
 	}
 	return c.Environment.Version.raw, true

--- a/experimental/air/cmd/runconfig_load.go
+++ b/experimental/air/cmd/runconfig_load.go
@@ -182,7 +182,6 @@ func resolveRequirementsFile(cfg *runConfig, configPath string) error {
 	}
 	defer f.Close()
 	dec := yaml.NewDecoder(f)
-	dec.KnownFields(true)
 	var req requirementsConfig
 	if err := dec.Decode(&req); err != nil {
 		return fmt.Errorf("failed to parse requirements YAML %q: %w", resolved, err)

--- a/experimental/air/cmd/runconfig_load.go
+++ b/experimental/air/cmd/runconfig_load.go
@@ -7,6 +7,10 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
 
 	"go.yaml.in/yaml/v3"
 )
@@ -55,6 +59,9 @@ func loadRunConfig(path string) (*runConfig, error) {
 		return nil, err
 	}
 	if err := validateRunConfig(cfg); err != nil {
+		return nil, err
+	}
+	if err := resolveRequirementsFile(cfg, path); err != nil {
 		return nil, err
 	}
 	return cfg, nil
@@ -107,5 +114,95 @@ func loadRunConfigWithOverrides(ctx context.Context, path string, overrides []st
 	if err := validateRunConfig(cfg); err != nil {
 		return nil, err
 	}
+	if err := resolveRequirementsFile(cfg, path); err != nil {
+		return nil, err
+	}
 	return cfg, nil
+}
+
+var runtimeVersionRe = regexp.MustCompile(`^[0-9]+$`)
+
+const databricksAIPrefix = "databricks_ai_v"
+
+func validateRuntimeVersion(version, source string) (string, error) {
+	normalized := strings.ToLower(version)
+	numeric := normalized
+	usesDatabricksAI := strings.HasPrefix(normalized, databricksAIPrefix)
+	if usesDatabricksAI {
+		numeric = strings.TrimPrefix(normalized, databricksAIPrefix)
+	}
+	if !runtimeVersionRe.MatchString(numeric) {
+		return "", fmt.Errorf("unsupported client image version %q in %s: version must be an integer, optionally prefixed with databricks_ai_v", version, source)
+	}
+	if !usesDatabricksAI {
+		return numeric, nil
+	}
+	major, err := strconv.Atoi(numeric)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse client image version %q in %s: %w", version, source, err)
+	}
+	if major < 5 {
+		return "", fmt.Errorf("databricks_ai_v in %s requires AI Runtime version 5 or higher, got %q", source, version)
+	}
+	return databricksAIPrefix + numeric, nil
+}
+
+type requirementsConfig struct {
+	Version      stringOrInt `yaml:"version"`
+	Dependencies []string    `yaml:"dependencies"`
+}
+
+func resolveRequirementsFile(cfg *runConfig, configPath string) error {
+	if cfg.Environment == nil || cfg.Environment.Dependencies.path == "" {
+		return nil
+	}
+	if cfg.Environment.Version.set {
+		return errors.New("'environment.version' is only supported with inline 'dependencies'")
+	}
+
+	dep := &cfg.Environment.Dependencies
+	resolved := dep.path
+	if !filepath.IsAbs(resolved) {
+		resolved = filepath.Join(filepath.Dir(configPath), resolved)
+	}
+	info, err := os.Stat(resolved)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("environment.dependencies: requirements YAML not found at %q", resolved)
+		}
+		return fmt.Errorf("failed to inspect requirements YAML %q: %w", resolved, err)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("environment.dependencies: requirements YAML %q is not a file", resolved)
+	}
+
+	f, err := os.Open(resolved)
+	if err != nil {
+		return fmt.Errorf("failed to open requirements YAML %q: %w", resolved, err)
+	}
+	defer f.Close()
+	dec := yaml.NewDecoder(f)
+	dec.KnownFields(true)
+	var req requirementsConfig
+	if err := dec.Decode(&req); err != nil {
+		return fmt.Errorf("failed to parse requirements YAML %q: %w", resolved, err)
+	}
+	version := "4"
+	if req.Version.set {
+		version = req.Version.raw
+	}
+	version, err = validateRuntimeVersion(version, fmt.Sprintf("requirements YAML %q", resolved))
+	if err != nil {
+		return err
+	}
+	for _, item := range req.Dependencies {
+		fields := strings.Fields(item)
+		if len(fields) > 0 && (fields[0] == "-r" || fields[0] == "--requirement") {
+			return fmt.Errorf("requirements YAML dependency %q uses unsupported -r/--requirement include", item)
+		}
+	}
+	dep.resolvedPath = resolved
+	dep.version = version
+	dep.list = req.Dependencies
+	return nil
 }

--- a/experimental/air/cmd/runconfig_test.go
+++ b/experimental/air/cmd/runconfig_test.go
@@ -126,6 +126,16 @@ environment:
 		assert.Equal(t, "databricks_ai_v5", version)
 	})
 
+	t.Run("requirements permits worker-side fields", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "requirements.yaml"), []byte("version: 5\ndependencies:\n  - torch\npip_options:\n  index_url: https://packages.example/simple\n"), 0o600))
+		configPath := filepath.Join(dir, "run.yaml")
+		require.NoError(t, os.WriteFile(configPath, []byte(minimalConfig+"environment:\n  dependencies: requirements.yaml\n"), 0o600))
+		cfg, err := loadRunConfig(configPath)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"torch"}, cfg.Environment.Dependencies.list)
+	})
+
 	t.Run("requirements rejects old databricks ai version", func(t *testing.T) {
 		dir := t.TempDir()
 		require.NoError(t, os.WriteFile(filepath.Join(dir, "requirements.yaml"), []byte("version: databricks_ai_v4\n"), 0o600))

--- a/experimental/air/cmd/runconfig_test.go
+++ b/experimental/air/cmd/runconfig_test.go
@@ -95,16 +95,53 @@ permissions:
 }
 
 // TestLoadRunConfig_PolymorphicFields exercises the str|int and bool|str unions
-// decoded by custom UnmarshalYAML, plus the rejection of the removed
-// dependencies string form.
+// decoded by custom UnmarshalYAML, including file-backed dependencies.
 func TestLoadRunConfig_PolymorphicFields(t *testing.T) {
-	t.Run("dependencies as string path is rejected", func(t *testing.T) {
-		_, err := loadRunConfig(writeConfig(t, minimalConfig+`
+	t.Run("dependencies as string path is resolved", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "requirements.yaml"), []byte("version: 5\ndependencies:\n  - torch\n"), 0o600))
+		configPath := filepath.Join(dir, "run.yaml")
+		require.NoError(t, os.WriteFile(configPath, []byte(minimalConfig+`
 environment:
   dependencies: requirements.yaml
-`))
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "must be a list of packages")
+`), 0o600))
+		cfg, err := loadRunConfig(configPath)
+		require.NoError(t, err)
+		assert.Equal(t, filepath.Join(dir, "requirements.yaml"), cfg.requirementsPath())
+		assert.Equal(t, []string{"torch"}, cfg.Environment.Dependencies.list)
+		version, ok := cfg.runtimeVersion()
+		assert.True(t, ok)
+		assert.Equal(t, "5", version)
+	})
+
+	t.Run("requirements defaults version and normalizes prefix", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "requirements.yaml"), []byte("version: DATABRICKS_AI_V5\ndependencies:\n  - torch\n"), 0o600))
+		configPath := filepath.Join(dir, "run.yaml")
+		require.NoError(t, os.WriteFile(configPath, []byte(minimalConfig+"environment:\n  dependencies: requirements.yaml\n"), 0o600))
+		cfg, err := loadRunConfig(configPath)
+		require.NoError(t, err)
+		version, ok := cfg.runtimeVersion()
+		assert.True(t, ok)
+		assert.Equal(t, "databricks_ai_v5", version)
+	})
+
+	t.Run("requirements rejects old databricks ai version", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "requirements.yaml"), []byte("version: databricks_ai_v4\n"), 0o600))
+		configPath := filepath.Join(dir, "run.yaml")
+		require.NoError(t, os.WriteFile(configPath, []byte(minimalConfig+"environment:\n  dependencies: requirements.yaml\n"), 0o600))
+		_, err := loadRunConfig(configPath)
+		require.ErrorContains(t, err, "requires AI Runtime version 5 or higher")
+	})
+
+	t.Run("requirements rejects includes", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "requirements.yaml"), []byte("dependencies:\n  - -r other.txt\n"), 0o600))
+		configPath := filepath.Join(dir, "run.yaml")
+		require.NoError(t, os.WriteFile(configPath, []byte(minimalConfig+"environment:\n  dependencies: requirements.yaml\n"), 0o600))
+		_, err := loadRunConfig(configPath)
+		require.ErrorContains(t, err, "unsupported -r/--requirement include")
 	})
 
 	t.Run("git remote as bool true is rejected", func(t *testing.T) {
@@ -229,6 +266,9 @@ func TestRunConfigValidate_FieldRules(t *testing.T) {
 		{"long idempotency", func(c *runConfig) { c.IdempotencyToken = str(string(make([]byte, 65))) }, "64 characters or less"},
 		{"bad mlflow_run_name", func(c *runConfig) { c.MLflowRunName = str("bad name") }, "invalid mlflow_run_name"},
 		{"bad experiment dir", func(c *runConfig) { c.MLflowExperimentDirectory = str("/Users/me") }, "must start with '/Workspace'"},
+		{"artifact volume path normalizes", func(c *runConfig) { c.MLflowArtifactLocation = str(" /Volumes/main/default/artifacts ") }, ""},
+		{"empty artifact location", func(c *runConfig) { c.MLflowArtifactLocation = str(" ") }, "mlflow_artifact_location cannot be empty"},
+		{"non-dbfs artifact location", func(c *runConfig) { c.MLflowArtifactLocation = str("s3://bucket/path") }, "must be a dbfs: URI"},
 		{"empty usage policy", func(c *runConfig) { c.UsagePolicyName = str(" ") }, "usage_policy_name must not be empty"},
 		{"bad secret ref", func(c *runConfig) { c.Secrets = map[string]string{"T": "noslash"} }, "expected format 'scope/key'"},
 		{"empty secret scope", func(c *runConfig) { c.Secrets = map[string]string{"T": "/key"} }, "scope and key cannot be empty"},
@@ -254,6 +294,9 @@ func TestRunConfigValidate_FieldRules(t *testing.T) {
 			err := c.validate()
 			if tt.errFrag == "" {
 				assert.NoError(t, err)
+				if tt.name == "artifact volume path normalizes" {
+					assert.Equal(t, "dbfs:/Volumes/main/default/artifacts", *c.MLflowArtifactLocation)
+				}
 				return
 			}
 			require.Error(t, err)
@@ -299,12 +342,31 @@ func TestEnvironmentConfigValidate(t *testing.T) {
 			},
 			"",
 		},
+		{
+			"version prefix normalizes",
+			environmentConfig{
+				Version:      stringOrInt{set: true, raw: "DATABRICKS_AI_V5"},
+				Dependencies: dependencies{set: true, list: []string{"torch"}},
+			},
+			"",
+		},
+		{
+			"old databricks ai version rejected",
+			environmentConfig{
+				Version:      stringOrInt{set: true, raw: "databricks_ai_v4"},
+				Dependencies: dependencies{set: true, list: []string{"torch"}},
+			},
+			"requires AI Runtime version 5 or higher",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := tt.env.validate()
 			if tt.errFrag == "" {
 				assert.NoError(t, err)
+				if tt.name == "version prefix normalizes" {
+					assert.Equal(t, "databricks_ai_v5", tt.env.Version.raw)
+				}
 				return
 			}
 			require.Error(t, err)
@@ -474,7 +536,7 @@ func TestResolveConfigField_Containers(t *testing.T) {
 	compute, err := resolveConfigField("config.compute")
 	require.NoError(t, err)
 	assert.Equal(t, "object", compute.typeName)
-	require.Len(t, compute.children, 2)
+	require.Len(t, compute.children, 3)
 }
 
 func TestResolveConfigField_Errors(t *testing.T) {

--- a/experimental/air/cmd/runlaunch.go
+++ b/experimental/air/cmd/runlaunch.go
@@ -7,6 +7,7 @@ import (
 	"path"
 	"strings"
 
+	"github.com/databricks/cli/libs/databrickscfg"
 	"github.com/databricks/cli/libs/env"
 	"github.com/databricks/databricks-sdk-go"
 	"github.com/databricks/databricks-sdk-go/apierr"
@@ -31,6 +32,13 @@ func currentUserEmail(ctx context.Context, w *databricks.WorkspaceClient) (strin
 // userWorkspaceDir returns the user's workspace home, honoring the env override.
 func userWorkspaceDir(ctx context.Context, w *databricks.WorkspaceClient) (string, error) {
 	if override := env.Get(ctx, userWorkspaceDirEnv); override != "" {
+		return override, nil
+	}
+	override, err := databrickscfg.ProfileValue(w.Config, "databricks_internal_user_workspace_dir")
+	if err != nil {
+		return "", fmt.Errorf("failed to read selected profile: %w", err)
+	}
+	if override != "" {
 		return override, nil
 	}
 	email, err := currentUserEmail(ctx, w)

--- a/experimental/air/cmd/runlaunch_test.go
+++ b/experimental/air/cmd/runlaunch_test.go
@@ -1,6 +1,8 @@
 package aircmd
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -31,6 +33,7 @@ func newFakeWorkspaceClient(t *testing.T) *databricks.WorkspaceClient {
 
 func TestUserWorkspaceDir(t *testing.T) {
 	w := newFakeWorkspaceClient(t)
+	t.Setenv(userWorkspaceDirEnv, "")
 	dir, err := userWorkspaceDir(t.Context(), w)
 	require.NoError(t, err)
 	assert.True(t, strings.HasPrefix(dir, "/Workspace/Users/"), dir)
@@ -40,6 +43,52 @@ func TestUserWorkspaceDir(t *testing.T) {
 	dir, err = userWorkspaceDir(t.Context(), w)
 	require.NoError(t, err)
 	assert.Equal(t, "/Workspace/custom", dir)
+}
+
+func TestUserWorkspaceDirProfilePrecedence(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), ".databrickscfg")
+	require.NoError(t, os.WriteFile(configPath, []byte(`
+[__settings__]
+default_profile = second
+
+[first]
+host = https://first.test
+databricks_internal_user_workspace_dir = /Workspace/first
+
+[second]
+host = https://second.test
+databricks_internal_user_workspace_dir = /Workspace/second
+`), 0o600))
+
+	t.Run("explicit profile", func(t *testing.T) {
+		w := newFakeWorkspaceClient(t)
+		w.Config.ConfigFile = configPath
+		w.Config.Profile = "first"
+		t.Setenv(userWorkspaceDirEnv, "")
+		dir, err := userWorkspaceDir(t.Context(), w)
+		require.NoError(t, err)
+		assert.Equal(t, "/Workspace/first", dir)
+	})
+
+	t.Run("default profile", func(t *testing.T) {
+		w := newFakeWorkspaceClient(t)
+		w.Config.ConfigFile = configPath
+		w.Config.Profile = ""
+		t.Setenv(userWorkspaceDirEnv, "")
+		dir, err := userWorkspaceDir(t.Context(), w)
+		require.NoError(t, err)
+		assert.Equal(t, "/Workspace/second", dir)
+	})
+
+	t.Run("environment wins", func(t *testing.T) {
+		w := newFakeWorkspaceClient(t)
+		w.Config.ConfigFile = configPath
+		w.Config.Profile = "first"
+		t.Setenv(userWorkspaceDirEnv, "/Workspace/env")
+		dir, err := userWorkspaceDir(t.Context(), w)
+		require.NoError(t, err)
+		assert.Equal(t, "/Workspace/env", dir)
+	})
 }
 
 func TestEnsureExperimentDirectory(t *testing.T) {

--- a/experimental/air/cmd/runsubmit.go
+++ b/experimental/air/cmd/runsubmit.go
@@ -1,6 +1,7 @@
 package aircmd
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -127,7 +128,9 @@ func submitRun(ctx context.Context, w *databricks.WorkspaceClient, payload jobs.
 		return 0, fmt.Errorf("failed to marshal AIR submit payload: %w", err)
 	}
 	var body map[string]any
-	if err := json.Unmarshal(raw, &body); err != nil {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	if err := decoder.Decode(&body); err != nil {
 		return 0, fmt.Errorf("failed to decode AIR submit payload: %w", err)
 	}
 	if err := injectProvisionedCapacityID(body, provisionedCapacityID); err != nil {

--- a/experimental/air/cmd/runsubmit.go
+++ b/experimental/air/cmd/runsubmit.go
@@ -2,15 +2,20 @@ package aircmd
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
+	"net/http"
 	"path"
 	"strconv"
 	"strings"
 
+	"github.com/databricks/cli/libs/auth"
 	"github.com/databricks/cli/libs/cmdio"
 	"github.com/databricks/cli/libs/env"
 	"github.com/databricks/cli/libs/filer"
 	"github.com/databricks/databricks-sdk-go"
+	"github.com/databricks/databricks-sdk-go/client"
 	"github.com/databricks/databricks-sdk-go/service/compute"
 	"github.com/databricks/databricks-sdk-go/service/jobs"
 	"github.com/google/uuid"
@@ -67,6 +72,10 @@ func buildSubmitPayload(cfg *runConfig, commandPath, dlImage, usagePolicyID stri
 	if cfg.MLflowExperimentDirectory != nil {
 		task.MlflowExperimentDirectory = *cfg.MLflowExperimentDirectory
 	}
+	if cfg.MLflowArtifactLocation != nil {
+		task.MlflowArtifactLocation = *cfg.MLflowArtifactLocation
+	}
+	task.DockerImageUrl = cfg.dockerImageURL()
 
 	maxRetries := cfg.maxRetries()
 	st := jobs.SubmitTask{
@@ -102,6 +111,68 @@ func buildSubmitPayload(cfg *runConfig, commandPath, dlImage, usagePolicyID stri
 			Spec:           envSpec,
 		}},
 	}
+}
+
+func submitRun(ctx context.Context, w *databricks.WorkspaceClient, payload jobs.SubmitRun, provisionedCapacityID string) (int64, error) {
+	if provisionedCapacityID == "" {
+		wait, err := w.Jobs.Submit(ctx, payload)
+		if err != nil {
+			return 0, err
+		}
+		return wait.RunId, nil
+	}
+
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return 0, fmt.Errorf("failed to marshal AIR submit payload: %w", err)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(raw, &body); err != nil {
+		return 0, fmt.Errorf("failed to decode AIR submit payload: %w", err)
+	}
+	if err := injectProvisionedCapacityID(body, provisionedCapacityID); err != nil {
+		return 0, err
+	}
+
+	apiClient, err := client.New(w.Config)
+	if err != nil {
+		return 0, fmt.Errorf("failed to create API client: %w", err)
+	}
+	var response jobs.SubmitRunResponse
+	err = apiClient.Do(ctx, http.MethodPost, "/api/2.2/jobs/runs/submit", auth.WorkspaceIDHeaders(w.Config), nil, body, &response)
+	if err != nil {
+		return 0, err
+	}
+	return response.RunId, nil
+}
+
+func injectProvisionedCapacityID(body map[string]any, provisionedCapacityID string) error {
+	tasks, ok := body["tasks"].([]any)
+	if !ok || len(tasks) != 1 {
+		return errors.New("AIR submit payload must contain exactly one task")
+	}
+	task, ok := tasks[0].(map[string]any)
+	if !ok {
+		return errors.New("AIR submit payload task has an invalid shape")
+	}
+	aiRuntimeTask, ok := task["ai_runtime_task"].(map[string]any)
+	if !ok {
+		return errors.New("AIR submit payload is missing ai_runtime_task")
+	}
+	deployments, ok := aiRuntimeTask["deployments"].([]any)
+	if !ok || len(deployments) != 1 {
+		return errors.New("AIR submit payload must contain exactly one deployment")
+	}
+	deployment, ok := deployments[0].(map[string]any)
+	if !ok {
+		return errors.New("AIR submit payload deployment has an invalid shape")
+	}
+	computeSpec, ok := deployment["compute"].(map[string]any)
+	if !ok {
+		return errors.New("AIR submit payload is missing deployment compute")
+	}
+	computeSpec["provisioned_capacity_id"] = provisionedCapacityID
+	return nil
 }
 
 // submitToken resolves the idempotency token: the --idempotency-key flag wins,
@@ -235,12 +306,15 @@ func submitWorkload(ctx context.Context, w *databricks.WorkspaceClient, cfg *run
 	payload := buildSubmitPayload(cfg, commandPath, dlRuntimeImage(ctx, runtimeVersion), usagePolicyID, snap, deps)
 	payload.IdempotencyToken = token
 
+	provisionedCapacityID := ""
+	if cfg.Compute.ProvisionedCapacityID != nil {
+		provisionedCapacityID = *cfg.Compute.ProvisionedCapacityID
+	}
 	// Submit returns as soon as the run is created; we don't wait for it to finish.
-	wait, err := w.Jobs.Submit(ctx, payload)
+	runID, err := submitRun(ctx, w, payload, provisionedCapacityID)
 	if err != nil {
 		return 0, "", err
 	}
-	runID := wait.RunId
 
 	dashboardURL := strings.TrimRight(w.Config.Host, "/") + "/jobs/runs/" + strconv.FormatInt(runID, 10)
 	return runID, dashboardURL, nil

--- a/experimental/air/cmd/runsubmit_test.go
+++ b/experimental/air/cmd/runsubmit_test.go
@@ -47,6 +47,10 @@ func TestBuildSubmitPayload(t *testing.T) {
 		TimeoutMinutes:            new(30),
 		MLflowRunName:             new("run-v2"),
 		MLflowExperimentDirectory: new("/Workspace/Users/me/exp"),
+		MLflowArtifactLocation:    new("dbfs:/Volumes/main/default/artifacts"),
+		Environment: &environmentConfig{DockerImage: &dockerImageConfig{
+			URL: "registry.example.com/team/image:tag",
+		}},
 	}
 
 	p := buildSubmitPayload(cfg, "/d/command.sh", "5", "", snapshotResult{}, nil)
@@ -73,9 +77,41 @@ func TestBuildSubmitPayload(t *testing.T) {
 	assert.Equal(t, "exp", at.Experiment)
 	assert.Equal(t, "run-v2", at.MlflowRun)
 	assert.Equal(t, "/Workspace/Users/me/exp", at.MlflowExperimentDirectory)
+	assert.Equal(t, "dbfs:/Volumes/main/default/artifacts", at.MlflowArtifactLocation)
+	assert.Equal(t, "registry.example.com/team/image:tag", at.DockerImageUrl)
 	require.Len(t, at.Deployments, 1)
 	assert.Equal(t, "/d/command.sh", at.Deployments[0].CommandPath)
 	assert.Equal(t, jobs.ComputeSpec{AcceleratorType: jobs.ComputeSpecAcceleratorTypeGpu8xH100, AcceleratorCount: 16}, at.Deployments[0].Compute)
+}
+
+func TestSubmitRunInjectsProvisionedCapacityID(t *testing.T) {
+	server := testserver.New(t)
+	t.Cleanup(server.Close)
+	server.Handle("POST", "/api/2.2/jobs/runs/submit", func(req testserver.Request) any {
+		assert.Equal(t, "123", req.Headers.Get("X-Databricks-Workspace-Id"))
+		var body map[string]any
+		require.NoError(t, json.Unmarshal(req.Body, &body))
+		tasks := body["tasks"].([]any)
+		task := tasks[0].(map[string]any)
+		airTask := task["ai_runtime_task"].(map[string]any)
+		deployments := airTask["deployments"].([]any)
+		deployment := deployments[0].(map[string]any)
+		compute := deployment["compute"].(map[string]any)
+		assert.Equal(t, "capacity-1", compute["provisioned_capacity_id"])
+		return jobs.SubmitRunResponse{RunId: 42}
+	})
+
+	w, err := databricks.NewWorkspaceClient(&databricks.Config{Host: server.URL, Token: "token", WorkspaceID: "123"})
+	require.NoError(t, err)
+	payload := buildSubmitPayload(&runConfig{
+		ExperimentName: "exp",
+		Command:        new("x"),
+		Compute:        &computeConfig{AcceleratorType: "GPU_1xH100", NumAccelerators: 1},
+	}, "/command.sh", "4", "", snapshotResult{}, nil)
+
+	runID, err := submitRun(t.Context(), w, payload, "capacity-1")
+	require.NoError(t, err)
+	assert.Equal(t, int64(42), runID)
 }
 
 func TestBuildSubmitPayloadDefaultRetries(t *testing.T) {

--- a/experimental/air/cmd/runupload.go
+++ b/experimental/air/cmd/runupload.go
@@ -24,6 +24,7 @@ const (
 	hyperparametersName = "hyperparameters.yaml"
 	envVarsName         = "env_vars.json"
 	secretEnvVarsName   = "secret_env_vars.json"
+	requirementsName    = "requirements.yaml"
 )
 
 // maxConfigYAMLBytes caps training_config.yaml. It is referenced by the Jobs
@@ -72,6 +73,14 @@ func buildArtifacts(cfg *runConfig, configPath string) ([]uploadItem, error) {
 			return nil, fmt.Errorf("failed to serialize parameters: %w", err)
 		}
 		items = append(items, uploadItem{hyperparametersName, data})
+	}
+
+	if requirementsPath := cfg.requirementsPath(); requirementsPath != "" {
+		data, err := os.ReadFile(requirementsPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read requirements YAML %s: %w", requirementsPath, err)
+		}
+		items = append(items, uploadItem{requirementsName, data})
 	}
 
 	// The ai_runtime_task proto carries no inline env vars or secrets; stage them

--- a/experimental/air/cmd/runupload_test.go
+++ b/experimental/air/cmd/runupload_test.go
@@ -74,6 +74,25 @@ func TestBuildArtifacts_ParametersButNoRequirements(t *testing.T) {
 	assert.Equal(t, []string{trainingConfigName, commandScriptName, hyperparametersName}, itemNames(items))
 }
 
+func TestBuildArtifacts_FileRequirements(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "run.yaml")
+	requirementsPath := filepath.Join(dir, "deps.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte("x: y\n"), 0o600))
+	require.NoError(t, os.WriteFile(requirementsPath, []byte("version: 5\ndependencies:\n  - torch\n"), 0o600))
+	cfg := &runConfig{
+		Command: new("echo hi"),
+		Environment: &environmentConfig{Dependencies: dependencies{
+			set: true, resolvedPath: requirementsPath,
+		}},
+	}
+
+	items, err := buildArtifacts(cfg, configPath)
+	require.NoError(t, err)
+	assert.Equal(t, []string{trainingConfigName, commandScriptName, requirementsName}, itemNames(items))
+	assert.Equal(t, "version: 5\ndependencies:\n  - torch\n", string(items[2].data))
+}
+
 func TestBuildArtifacts_EnvVarsAndSecrets(t *testing.T) {
 	path := writeConfigFile(t, "run.yaml", "x: y\n")
 	cfg := &runConfig{

--- a/experimental/air/cmd/snapshot_package.go
+++ b/experimental/air/cmd/snapshot_package.go
@@ -57,45 +57,21 @@ func createPlainTarball(ctx context.Context, repoPath, outputTarball string, inc
 	}
 	outName := filepath.Base(outputTarball)
 
-	args := []string{"-czf", outName}
-
-	// Exclude macOS AppleDouble files: they sort before the real top-level dir and
-	// hijack a remote `head -1` parse. No-op on Linux.
-	args = append(args, "--exclude=._*")
-
-	// Never ship .git — provenance flows via the git_state.json sidecar.
-	args = append(args, "--exclude=.git")
-
-	// Honor .gitignore if present.
-	gitignorePath := filepath.Join(repoPath, ".gitignore")
-	if patterns, err := parseGitignore(gitignorePath); err == nil {
-		for _, p := range patterns {
-			if strings.Contains(p, "/") {
-				// Anchor path-relative patterns to the archive root so they don't
-				// match identically-named paths in subdirectories.
-				args = append(args, "--exclude="+dirName+"/"+strings.TrimPrefix(p, "/"))
-			} else {
-				args = append(args, "--exclude="+p)
-			}
-		}
+	files, err := snapshotFiles(ctx, repoPath, includePaths)
+	if err != nil {
+		return err
 	}
-
-	// Archive from the parent so the directory name is preserved; with include_paths,
-	// prefix each so entries nest under it (matching git archive --prefix). -C only
-	// affects the file operands that follow it, not the -f archive path (which
-	// resolves against tar's working dir, set to outDirAbs below).
-	args = append(args, "-C", parent)
-	if len(includePaths) > 0 {
-		for _, p := range includePaths {
-			args = append(args, dirName+"/"+p)
-		}
-	} else {
-		args = append(args, dirName)
-	}
+	args := []string{"-czf", outName, "-C", parent, "--null", "--no-recursion", "-T", "-"}
 
 	cmd := exec.CommandContext(ctx, "tar", args...)
 	// Run tar in the output directory so the bare -f basename lands there.
 	cmd.Dir = outDirAbs
+	var stdin bytes.Buffer
+	for _, file := range files {
+		stdin.WriteString(filepath.ToSlash(filepath.Join(dirName, file)))
+		stdin.WriteByte(0)
+	}
+	cmd.Stdin = &stdin
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
@@ -107,43 +83,41 @@ func createPlainTarball(ctx context.Context, repoPath, outputTarball string, inc
 	return nil
 }
 
-// parseGitignore reads a .gitignore and returns tar --exclude patterns. It mirrors
-// the Python CLI's lossy normalization so plain-tar snapshots exclude the same set:
-//
-//   - comments (#…) and blank lines are skipped;
-//   - negation patterns (!…) are unsupported by tar --exclude and skipped;
-//   - a trailing "/" (directory marker) is stripped;
-//   - "**" is not a path-separator-agnostic wildcard in tar, so "**/foo" → "foo"
-//     and "foo/**" → "foo"; a mid-path "**" has no tar equivalent and is skipped.
-//
-// A missing file returns (nil, error); callers treat any error as "no patterns".
-func parseGitignore(path string) ([]string, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return nil, err
+func snapshotFiles(ctx context.Context, repoPath string, includePaths []string) ([]string, error) {
+	args := []string{"-C", repoPath, "ls-files", "-z", "--cached", "--others", "--exclude-standard"}
+	if !newGitRepo(repoPath).isRepository(ctx) {
+		gitDir, err := os.MkdirTemp("", "air-snapshot-git-")
+		if err != nil {
+			return nil, fmt.Errorf("failed to create temporary git metadata: %w", err)
+		}
+		defer os.RemoveAll(gitDir)
+		cmd := exec.CommandContext(ctx, "git", "--git-dir", gitDir, "--work-tree", repoPath, "init", "--quiet")
+		if output, err := cmd.CombinedOutput(); err != nil {
+			return nil, fmt.Errorf("failed to initialize temporary git metadata: %w: %s", err, strings.TrimSpace(string(output)))
+		}
+		args = []string{"--git-dir", gitDir, "--work-tree", repoPath, "ls-files", "-z", "--cached", "--others", "--exclude-standard"}
 	}
 
-	var patterns []string
-	for raw := range strings.SplitSeq(string(data), "\n") {
-		line := strings.TrimRight(raw, " \t\r")
-		if line == "" || strings.HasPrefix(line, "#") {
-			continue
-		}
-		if strings.HasPrefix(line, "!") {
-			continue
-		}
-		line = strings.TrimRight(line, "/")
-		if strings.Contains(line, "**") {
-			switch {
-			case strings.HasPrefix(line, "**/"):
-				line = line[len("**/"):]
-			case strings.HasSuffix(line, "/**"):
-				line = line[:len(line)-len("/**")]
-			default:
-				continue
-			}
-		}
-		patterns = append(patterns, line)
+	if len(includePaths) > 0 {
+		args = append(args, "--")
+		args = append(args, includePaths...)
 	}
-	return patterns, nil
+	output, err := exec.CommandContext(ctx, "git", args...).Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to evaluate git ignore rules: %w", err)
+	}
+
+	var files []string
+	for raw := range bytes.SplitSeq(output, []byte{0}) {
+		if len(raw) == 0 {
+			continue
+		}
+		name := filepath.ToSlash(string(raw))
+		base := filepath.Base(name)
+		if name == ".git" || strings.HasPrefix(name, ".git/") || strings.HasPrefix(base, "._") {
+			continue
+		}
+		files = append(files, filepath.FromSlash(name))
+	}
+	return files, nil
 }

--- a/experimental/air/cmd/snapshot_package.go
+++ b/experimental/air/cmd/snapshot_package.go
@@ -3,6 +3,7 @@ package aircmd
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -116,6 +117,13 @@ func snapshotFiles(ctx context.Context, repoPath string, includePaths []string) 
 		base := filepath.Base(name)
 		if name == ".git" || strings.HasPrefix(name, ".git/") || strings.HasPrefix(base, "._") {
 			continue
+		}
+		_, err := os.Lstat(filepath.Join(repoPath, filepath.FromSlash(name)))
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return nil, fmt.Errorf("failed to inspect snapshot path %q: %w", name, err)
 		}
 		files = append(files, filepath.FromSlash(name))
 	}

--- a/experimental/air/cmd/snapshot_package_test.go
+++ b/experimental/air/cmd/snapshot_package_test.go
@@ -153,3 +153,19 @@ func TestCreatePlainTarball_HonorsNestedGitignoreAndNegation(t *testing.T) {
 	assert.NotContains(t, entries, dirName+"/nested/drop.tmp")
 	assert.Contains(t, entries, dirName+"/nested/keep.tmp")
 }
+
+func TestCreatePlainTarball_SkipsDeletedTrackedFiles(t *testing.T) {
+	repo := newTestRepo(t)
+	writeRepoFile(t, repo, "keep.txt", "keep")
+	writeRepoFile(t, repo, "deleted.txt", "deleted")
+	commitAll(t, repo, "init")
+	require.NoError(t, os.Remove(filepath.Join(repo, "deleted.txt")))
+
+	out := filepath.Join(t.TempDir(), "snap.tar.gz")
+	require.NoError(t, createPlainTarball(t.Context(), repo, out, nil))
+
+	dirName := filepath.Base(repo)
+	entries := tarballEntries(t, out)
+	assert.Contains(t, entries, dirName+"/keep.txt")
+	assert.NotContains(t, entries, dirName+"/deleted.txt")
+}

--- a/experimental/air/cmd/snapshot_package_test.go
+++ b/experimental/air/cmd/snapshot_package_test.go
@@ -130,32 +130,26 @@ func TestCreatePlainTarball_IncludePaths(t *testing.T) {
 	assert.NotContains(t, entries, dirName+"/a.txt")
 }
 
-func TestParseGitignore(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, ".gitignore")
-	content := "# comment\n" +
-		"\n" +
-		"*.log\n" +
-		"!keep.log\n" + // negation: skipped
-		"build/\n" + // trailing slash stripped
-		"**/node_modules\n" + // **/foo -> foo
-		"dist/**\n" + // foo/** -> foo
-		"a/**/b\n" + // mid ** : skipped
-		"src/config\n" // path-relative kept as-is
-	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+func TestCreatePlainTarball_HonorsNestedGitignoreAndNegation(t *testing.T) {
+	repo := t.TempDir()
+	writeRepoFile(t, repo, ".gitignore", "*.log\n!keep.log\n/root-only.txt\n")
+	writeRepoFile(t, repo, "drop.log", "drop")
+	writeRepoFile(t, repo, "keep.log", "keep")
+	writeRepoFile(t, repo, "root-only.txt", "drop")
+	writeRepoFile(t, repo, "nested/root-only.txt", "keep")
+	writeRepoFile(t, repo, "nested/.gitignore", "*.tmp\n!keep.tmp\n")
+	writeRepoFile(t, repo, "nested/drop.tmp", "drop")
+	writeRepoFile(t, repo, "nested/keep.tmp", "keep")
 
-	patterns, err := parseGitignore(path)
-	require.NoError(t, err)
-	assert.Equal(t, []string{
-		"*.log",
-		"build",
-		"node_modules",
-		"dist",
-		"src/config",
-	}, patterns)
-}
+	out := filepath.Join(t.TempDir(), "snap.tar.gz")
+	require.NoError(t, createPlainTarball(t.Context(), repo, out, nil))
 
-func TestParseGitignore_Missing(t *testing.T) {
-	_, err := parseGitignore(filepath.Join(t.TempDir(), "nope"))
-	require.Error(t, err)
+	dirName := filepath.Base(repo)
+	entries := tarballEntries(t, out)
+	assert.NotContains(t, entries, dirName+"/drop.log")
+	assert.Contains(t, entries, dirName+"/keep.log")
+	assert.NotContains(t, entries, dirName+"/root-only.txt")
+	assert.Contains(t, entries, dirName+"/nested/root-only.txt")
+	assert.NotContains(t, entries, dirName+"/nested/drop.tmp")
+	assert.Contains(t, entries, dirName+"/nested/keep.tmp")
 }

--- a/experimental/air/cmd/validateconfig.go
+++ b/experimental/air/cmd/validateconfig.go
@@ -66,6 +66,7 @@ func validateConfigRequest(cfg *runConfig, commandPath string) map[string]any {
 	if cfg.Compute != nil {
 		compute["accelerator_type"] = cfg.Compute.AcceleratorType
 		compute["accelerator_count"] = cfg.Compute.NumAccelerators
+		putOpt(compute, "provisioned_capacity_id", cfg.Compute.ProvisionedCapacityID)
 	}
 	task := map[string]any{
 		"experiment":  cfg.ExperimentName,
@@ -73,6 +74,10 @@ func validateConfigRequest(cfg *runConfig, commandPath string) map[string]any {
 	}
 	putOpt(task, "mlflow_run", cfg.MLflowRunName)
 	putOpt(task, "mlflow_experiment_directory", cfg.MLflowExperimentDirectory)
+	putOpt(task, "mlflow_artifact_location", cfg.MLflowArtifactLocation)
+	if dockerImageURL := cfg.dockerImageURL(); dockerImageURL != "" {
+		task["docker_image_url"] = dockerImageURL
+	}
 
 	req := map[string]any{"task": task}
 	if runOptions := validateConfigRunOptions(cfg); len(runOptions) > 0 {

--- a/libs/databrickscfg/profile_value.go
+++ b/libs/databrickscfg/profile_value.go
@@ -1,0 +1,36 @@
+package databrickscfg
+
+import (
+	"errors"
+	"io/fs"
+
+	"github.com/databricks/databricks-sdk-go/config"
+)
+
+// ProfileValue returns a property from the selected configuration profile. An
+// empty profile name uses the configured default-profile resolution order.
+func ProfileValue(cfg *config.Config, key string) (string, error) {
+	file, err := config.LoadFile(cfg.ConfigFile)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return "", nil
+		}
+		return "", err
+	}
+	profile := cfg.Profile
+	if profile == "" {
+		profile = GetDefaultProfileFrom(file)
+	}
+	if profile == "" {
+		return "", nil
+	}
+	section, err := file.GetSection(profile)
+	if err != nil {
+		return "", nil
+	}
+	value, err := section.GetKey(key)
+	if err != nil {
+		return "", nil
+	}
+	return value.Value(), nil
+}

--- a/libs/databrickscfg/profile_value_test.go
+++ b/libs/databrickscfg/profile_value_test.go
@@ -1,0 +1,52 @@
+package databrickscfg
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/databricks/databricks-sdk-go/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProfileValue(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".databrickscfg")
+	require.NoError(t, os.WriteFile(path, []byte(`
+[__settings__]
+default_profile = second
+
+[first]
+host = https://first.test
+databricks_internal_user_workspace_dir = /Workspace/first
+
+[second]
+host = https://second.test
+databricks_internal_user_workspace_dir = /Workspace/second
+`), 0o600))
+
+	value, err := ProfileValue(&config.Config{ConfigFile: path, Profile: "first"}, "databricks_internal_user_workspace_dir")
+	require.NoError(t, err)
+	assert.Equal(t, "/Workspace/first", value)
+
+	value, err = ProfileValue(&config.Config{ConfigFile: path}, "databricks_internal_user_workspace_dir")
+	require.NoError(t, err)
+	assert.Equal(t, "/Workspace/second", value)
+
+	value, err = ProfileValue(&config.Config{ConfigFile: path, Profile: "missing"}, "databricks_internal_user_workspace_dir")
+	require.NoError(t, err)
+	assert.Empty(t, value)
+}
+
+func TestProfileValueSingleProfileDefault(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".databrickscfg")
+	require.NoError(t, os.WriteFile(path, []byte(`
+[only]
+host = https://only.test
+databricks_internal_user_workspace_dir = /Workspace/only
+`), 0o600))
+
+	value, err := ProfileValue(&config.Config{ConfigFile: path}, "databricks_internal_user_workspace_dir")
+	require.NoError(t, err)
+	assert.Equal(t, "/Workspace/only", value)
+}


### PR DESCRIPTION
## Changes
Brings the experimental `air` Go CLI to parity with the Python CLI across four areas:

**Run submission**
- Restore file-backed `environment.dependencies`: a scalar path to a requirements YAML is resolved relative to the run config, its `version`/`dependencies` are read, `-r`/`--requirement` includes are rejected, and the file is uploaded beside the launch config.
- Add `mlflow_artifact_location` (a `/Volumes/...` path is normalized to `dbfs:/Volumes/...`).
- Add `compute.provisioned_capacity_id`; because the SDK's `ComputeSpec` has no such field, a submission that sets it is sent via a raw `/api/2.2/jobs/runs/submit` call with the id injected into the deployment's compute block.
- Wire `docker_image` into the submit payload (`ai_runtime_task.docker_image_url`).

**Status / list / get**
- Add a `Failure reason` derived from termination details / state message for FAILED, TIMEDOUT, and INTERNAL_ERROR runs (`termination_reason` in JSON, `omitempty`).
- Show `PENDING` as the display status when the overall run is RUNNING but its task is still pending/queued/waiting-for-retry/blocked.
- Treat TIMEDOUT as a terminal result state.

**Logs**
- Follow (stream) MLflow-fallback logs for non-terminal runs instead of only tailing.
- While Bricklens returns no records for an active run, periodically probe MLflow and fall back to it when artifacts exist.
- Resolve the correct attempt/task-run for `--retry` (including `-1` = latest) and validate the flag.
- Read log artifacts from Unity Catalog volumes via the workspace-files filer when the MLflow artifact root is a `dbfs:/Volumes/...` URI (root cached per host+run, failures not cached).

**Snapshots**
- Package the working tree via `git ls-files ... --exclude-standard` so nested `.gitignore` files and negation patterns are honored (replacing the lossy manual `.gitignore` parser). Non-git directories are handled through a temporary git metadata dir.

**Config**
- Add `libs/databrickscfg.ProfileValue` and use it so `air` honors a `databricks_internal_user_workspace_dir` override from the selected profile (env var still wins).

## Why
The Go implementation of `air` was missing behaviors the Python CLI already supported — file-backed dependencies, artifact-location/capacity/docker submission fields, failure reasons, volume-backed logs, and gitignore-accurate snapshots — creating migration gaps for users moving off the Python CLI. This closes them.

## Tests
- Unit tests alongside each changed command (`compute`, `format`, `get`, `logmlflow`, `logstream`, `runconfig`, `runlaunch`, `runsubmit`, `runupload`, `snapshot_package`, `profile_value`).
- Acceptance tests under `acceptance/experimental/air/`: `config-help` documents the new fields; `run-submit-deps` now exercises a file-backed requirements submission end-to-end, asserting the uploaded artifacts and the `/api/2.2/jobs/runs/submit` payload.
- Changelog fragments under `.nextchanges/cli/`.