### PR TITLE
apps: interactive Git onboarding for init outside a repo

### DIFF
--- a/.nextchanges/cli/apps-init-git-onboard.md
+++ b/.nextchanges/cli/apps-init-git-onboard.md
@@ -1,0 +1,1 @@
+`databricks apps init` now offers interactive Git onboarding when run outside a Git repository: create a new GitHub repository (via the `gh` CLI) or clone an existing one, and scaffold a git-backed app into it.

--- a/cmd/apps/gitonboard.go
+++ b/cmd/apps/gitonboard.go
@@ -129,6 +129,20 @@ func onboardExistingRepo(ctx context.Context, outputDir string) (gitOnboardResul
 // otherwise it falls back to writing the git-backed config from a URL the user
 // supplies, leaving repo creation to them.
 func onboardCreateRepo(ctx context.Context, outputDir string) (gitOnboardResult, error) {
+	// gh must be installed and authenticated to create the repo for the user.
+	// Its login and org memberships also drive owner selection, so resolve it
+	// before prompting.
+	login, ghOK := ghLogin(ctx)
+
+	owner := login
+	if ghOK {
+		selected, err := prompt.PromptRepoOwner(ctx, login, ghOrgs(ctx))
+		if err != nil {
+			return gitOnboardResult{}, err
+		}
+		owner = selected
+	}
+
 	name, private, err := prompt.PromptNewRepoDetails(ctx, defaultRepoName())
 	if err != nil {
 		return gitOnboardResult{}, err
@@ -139,9 +153,8 @@ func onboardCreateRepo(ctx context.Context, outputDir string) (gitOnboardResult,
 		destDir = filepath.Join(outputDir, name)
 	}
 
-	// gh must be installed and authenticated to create the repo for the user.
-	if login, ok := ghLogin(ctx); ok {
-		ownerRepo := login + "/" + name
+	if ghOK {
+		ownerRepo := owner + "/" + name
 		src := &gitScaffoldSource{
 			URL:            "https://github.com/" + ownerRepo,
 			Provider:       "gitHub",
@@ -231,6 +244,23 @@ func ghLogin(ctx context.Context) (string, bool) {
 		return "", false
 	}
 	return login, true
+}
+
+// ghOrgs returns the organizations the authenticated gh user belongs to, or nil
+// if the query fails (e.g. the token lacks read:org). Best-effort — owner
+// selection falls back to the personal account when this is empty.
+func ghOrgs(ctx context.Context) []string {
+	out, err := exec.CommandContext(ctx, "gh", "api", "user/orgs", "--jq", ".[].login").Output()
+	if err != nil {
+		return nil
+	}
+	var orgs []string
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if line = strings.TrimSpace(line); line != "" {
+			orgs = append(orgs, line)
+		}
+	}
+	return orgs
 }
 
 // defaultRepoName suggests the current directory's basename as the repo/app

--- a/cmd/apps/gitonboard.go
+++ b/cmd/apps/gitonboard.go
@@ -1,0 +1,267 @@
+package apps
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/databricks/cli/libs/apps/prompt"
+	"github.com/databricks/cli/libs/cmdctx"
+	"github.com/databricks/cli/libs/log"
+)
+
+// gitOnboardResult is the outcome of the interactive Git onboarding prompt that
+// runs when `apps init` is started outside any Git repository.
+type gitOnboardResult struct {
+	// resolved is true when onboarding took ownership of the destination (name,
+	// destDir, in-place). When false the caller falls through to the normal
+	// name/location prompts and passive detection.
+	resolved bool
+	appName  string
+	destDir  string
+	inPlace  bool
+
+	// source overrides the scaffolded git-backed config. It is nil for the
+	// clone path, where the freshly cloned origin is picked up by the normal
+	// post-scaffold detection instead.
+	source *gitScaffoldSource
+
+	// createRepo, when set, is executed after scaffolding to create the GitHub
+	// repository from the generated files and push the first commit.
+	createRepo *githubRepoCreate
+}
+
+// githubRepoCreate captures a deferred `gh repo create` for the "create a new
+// repo" path. sourceDir is filled in by the caller once the scaffold
+// destination is known.
+type githubRepoCreate struct {
+	ownerRepo string // "owner/name"
+	public    bool
+	sourceDir string
+}
+
+// runGitOnboarding runs the interactive "no Git repository" flow. It returns a
+// zero (unresolved) result — leaving the caller's normal name/location prompts
+// in charge — when the user is already in a repo, declines, or a step can't be
+// completed. It never fails the scaffold for an optional Git step.
+func runGitOnboarding(ctx context.Context, outputDir string) (gitOnboardResult, error) {
+	// Only offered when the user has no Git repo set up at all; a repo that
+	// already exists (with or without a remote) is left untouched.
+	if isInGitRepo(ctx, ".", cmdctx.WorkspaceClient(ctx)) {
+		return gitOnboardResult{}, nil
+	}
+
+	deploy, err := prompt.PromptDeployFromGit(ctx)
+	if err != nil {
+		return gitOnboardResult{}, err
+	}
+	if !deploy {
+		return gitOnboardResult{}, nil
+	}
+
+	choice, err := prompt.PromptCreateOrExistingRepo(ctx)
+	if err != nil {
+		return gitOnboardResult{}, err
+	}
+
+	switch choice {
+	case prompt.GitRepoExisting:
+		return onboardExistingRepo(ctx, outputDir)
+	case prompt.GitRepoCreate:
+		return onboardCreateRepo(ctx, outputDir)
+	default:
+		return gitOnboardResult{}, nil
+	}
+}
+
+// onboardExistingRepo clones a user-provided repository into the current
+// directory and scaffolds the app in place. Cloning into "." requires an empty
+// directory, so a non-empty cwd falls back to the normal flow.
+func onboardExistingRepo(ctx context.Context, outputDir string) (gitOnboardResult, error) {
+	if outputDir != "" {
+		log.Warnf(ctx, "--output-dir is not compatible with cloning into the current directory; continuing without Git setup")
+		return gitOnboardResult{}, nil
+	}
+	if !dirIsEmpty(".") {
+		log.Warnf(ctx, "the current directory is not empty; cloning an existing repo requires an empty directory. Continuing without Git setup")
+		return gitOnboardResult{}, nil
+	}
+
+	rawURL, err := prompt.PromptRepoURL(ctx, "Existing repository URL", "the app is cloned into the current directory and deployed from this repo")
+	if err != nil {
+		return gitOnboardResult{}, err
+	}
+	if rawURL == "" {
+		return gitOnboardResult{}, nil
+	}
+
+	appName, err := prompt.DeriveInPlaceAppName(".")
+	if err != nil {
+		return gitOnboardResult{}, fmt.Errorf("cloning here needs a directory whose name is a valid app name: %w", err)
+	}
+
+	if err := gitCloneInto(ctx, rawURL, "."); err != nil {
+		return gitOnboardResult{}, fmt.Errorf("clone %s: %w", rawURL, err)
+	}
+	// Guard against clobbering: the app is scaffolded in place over the clone,
+	// so the repository must be empty (a bare initial repo). A repo with files
+	// (README, LICENSE, ...) would have its contents overwritten by the scaffold.
+	if !dirHasOnlyGit(".") {
+		return gitOnboardResult{}, fmt.Errorf("cloned repository %s is not empty; scaffolding would overwrite its files — start from an empty repository", rawURL)
+	}
+	prompt.PrintAnswered(ctx, "Cloned", rawURL)
+
+	// The freshly cloned origin is detected by the normal post-scaffold pass,
+	// so no source override is needed here.
+	return gitOnboardResult{
+		resolved: true,
+		appName:  appName,
+		destDir:  ".",
+		inPlace:  true,
+	}, nil
+}
+
+// onboardCreateRepo gathers details for a new GitHub repo. With an authenticated
+// gh CLI it predicts the repo URL and defers creation until after scaffolding;
+// otherwise it falls back to writing the git-backed config from a URL the user
+// supplies, leaving repo creation to them.
+func onboardCreateRepo(ctx context.Context, outputDir string) (gitOnboardResult, error) {
+	name, private, err := prompt.PromptNewRepoDetails(ctx, defaultRepoName())
+	if err != nil {
+		return gitOnboardResult{}, err
+	}
+
+	destDir := name
+	if outputDir != "" {
+		destDir = filepath.Join(outputDir, name)
+	}
+
+	// gh must be installed and authenticated to create the repo for the user.
+	if login, ok := ghLogin(ctx); ok {
+		ownerRepo := login + "/" + name
+		src := &gitScaffoldSource{
+			URL:            "https://github.com/" + ownerRepo,
+			Provider:       "gitHub",
+			Branch:         "main",
+			SourceCodePath: "./",
+		}
+		return gitOnboardResult{
+			resolved:   true,
+			appName:    name,
+			destDir:    destDir,
+			source:     src,
+			createRepo: &githubRepoCreate{ownerRepo: ownerRepo, public: !private},
+		}, nil
+	}
+
+	// Fallback: no usable gh. Ask for the URL and write the git-backed config;
+	// the user creates and pushes the repo themselves.
+	log.Warnf(ctx, "gh CLI not installed or not authenticated — writing git-backed config without creating the repo. Install and authenticate gh (https://cli.github.com), then create the repo and push before deploying.")
+	rawURL, err := prompt.PromptRepoURL(ctx, "Git repository URL", "create this repo and push the app before deploying")
+	if err != nil {
+		return gitOnboardResult{}, err
+	}
+	repoURL, provider := normalizeGitOrigin(rawURL)
+	if repoURL == "" || provider == "" {
+		log.Warnf(ctx, "could not determine a Git provider from %q; continuing without Git setup", rawURL)
+		return gitOnboardResult{resolved: true, appName: name, destDir: destDir}, nil
+	}
+	return gitOnboardResult{
+		resolved: true,
+		appName:  name,
+		destDir:  destDir,
+		source:   &gitScaffoldSource{URL: repoURL, Provider: provider, Branch: "main", SourceCodePath: "./"},
+	}, nil
+}
+
+// run creates the GitHub repository from the scaffolded files: it initializes a
+// repo, commits, then `gh repo create ... --push`.
+func (c *githubRepoCreate) run(ctx context.Context) error {
+	init := [][]string{
+		{"git", "init", "-b", "main"},
+		{"git", "add", "-A"},
+		{"git", "commit", "-m", "Initial commit from databricks apps init"},
+	}
+	for _, args := range init {
+		if err := runIn(ctx, c.sourceDir, args...); err != nil {
+			return err
+		}
+	}
+	visibility := "--private"
+	if c.public {
+		visibility = "--public"
+	}
+	return runIn(ctx, c.sourceDir, "gh", "repo", "create", c.ownerRepo, visibility, "--source", ".", "--remote", "origin", "--push")
+}
+
+// runIn runs a command in dir, wrapping failures with the combined output.
+func runIn(ctx context.Context, dir string, args ...string) error {
+	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%s: %w: %s", strings.Join(args, " "), err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// gitCloneInto clones repoURL into dir (which must be empty for ".").
+func gitCloneInto(ctx context.Context, repoURL, dir string) error {
+	return runIn(ctx, ".", "git", "clone", repoURL, dir)
+}
+
+// ghLogin returns the authenticated GitHub username when the gh CLI is
+// installed and logged in, and false otherwise.
+func ghLogin(ctx context.Context) (string, bool) {
+	if _, err := exec.LookPath("gh"); err != nil {
+		return "", false
+	}
+	if err := exec.CommandContext(ctx, "gh", "auth", "status").Run(); err != nil {
+		return "", false
+	}
+	out, err := exec.CommandContext(ctx, "gh", "api", "user", "--jq", ".login").Output()
+	if err != nil {
+		return "", false
+	}
+	login := strings.TrimSpace(string(out))
+	if login == "" {
+		return "", false
+	}
+	return login, true
+}
+
+// defaultRepoName suggests the current directory's basename as the repo/app
+// name when it is a valid app name, else a generic default.
+func defaultRepoName() string {
+	if cwd, err := os.Getwd(); err == nil {
+		base := filepath.Base(cwd)
+		if prompt.ValidateProjectName(base) == nil {
+			return base
+		}
+	}
+	return "my-app"
+}
+
+// dirIsEmpty reports whether dir has no entries.
+func dirIsEmpty(dir string) bool {
+	entries, err := os.ReadDir(dir)
+	return err == nil && len(entries) == 0
+}
+
+// dirHasOnlyGit reports whether dir contains nothing but a .git entry (i.e. a
+// freshly cloned empty repository).
+func dirHasOnlyGit(dir string) bool {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false
+	}
+	for _, e := range entries {
+		if e.Name() != ".git" {
+			return false
+		}
+	}
+	return true
+}

--- a/cmd/apps/gitonboard_test.go
+++ b/cmd/apps/gitonboard_test.go
@@ -1,0 +1,37 @@
+package apps
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDirIsEmpty(t *testing.T) {
+	empty := t.TempDir()
+	assert.True(t, dirIsEmpty(empty))
+
+	withFile := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(withFile, "f"), []byte("x"), 0o644))
+	assert.False(t, dirIsEmpty(withFile))
+
+	assert.False(t, dirIsEmpty(filepath.Join(empty, "does-not-exist")))
+}
+
+func TestDefaultRepoName(t *testing.T) {
+	t.Run("valid dir name is used", func(t *testing.T) {
+		dir := filepath.Join(t.TempDir(), "my-app")
+		require.NoError(t, os.Mkdir(dir, 0o755))
+		t.Chdir(dir)
+		assert.Equal(t, "my-app", defaultRepoName())
+	})
+
+	t.Run("invalid dir name falls back", func(t *testing.T) {
+		dir := filepath.Join(t.TempDir(), "Bad_Name")
+		require.NoError(t, os.Mkdir(dir, 0o755))
+		t.Chdir(dir)
+		assert.Equal(t, "my-app", defaultRepoName())
+	})
+}

--- a/cmd/apps/gitsource.go
+++ b/cmd/apps/gitsource.go
@@ -93,6 +93,14 @@ func detectGitScaffoldSource(ctx context.Context, destDir string, w *databricks.
 	}
 }
 
+// isInGitRepo reports whether dir is inside a Git worktree. It is used to gate
+// the interactive Git onboarding prompt, which only runs when the user has no
+// Git repository set up at all.
+func isInGitRepo(ctx context.Context, dir string, w *databricks.WorkspaceClient) bool {
+	info, err := git.FetchRepositoryInfo(ctx, dir, w)
+	return err == nil && info.WorktreeRoot != ""
+}
+
 // normalizeGitOrigin converts a raw git remote URL into an https clone URL and
 // the matching Databricks git provider. It handles https/ssh URLs and scp-style
 // remotes (git@host:owner/repo.git). It returns empty strings when the host maps

--- a/cmd/apps/init.go
+++ b/cmd/apps/init.go
@@ -1059,6 +1059,11 @@ func runCreate(ctx context.Context, opts createOptions) error {
 	var (
 		destDir string
 		inPlace bool
+		// gitOverride, when set by the interactive Git onboarding, replaces the
+		// passively detected git-backed source. pendingRepoCreate, when set,
+		// creates the GitHub repo from the scaffolded files after copy.
+		gitOverride       *gitScaffoldSource
+		pendingRepoCreate *githubRepoCreate
 	)
 	switch {
 	case opts.name == prompt.InPlaceName:
@@ -1089,12 +1094,26 @@ func runCreate(ctx context.Context, opts createOptions) error {
 		// may follow, and so the resolved template ref is visible before
 		// the user commits to either path.
 		prompt.PrintHeader(ctx, refLabel)
+		// When the user has no Git repo set up, offer git-backed deployment
+		// first: create a new GitHub repo or clone an existing one. When it
+		// resolves the destination, skip the name/location prompts below.
+		onboard, err := runGitOnboarding(ctx, opts.outputDir)
+		if err != nil {
+			return err
+		}
+		if onboard.resolved {
+			opts.name = onboard.appName
+			destDir = onboard.destDir
+			inPlace = onboard.inPlace
+			gitOverride = onboard.source
+			pendingRepoCreate = onboard.createRepo
+		}
 		// Offer in-place scaffolding when the current directory is empty
 		// (modulo .git) and its basename is a valid app name. Skipped when
 		// --output-dir was set, since in-place targets cwd and would silently
 		// drop the flag — same reasoning as the --name . / --output-dir mutex
 		// above.
-		if opts.outputDir == "" {
+		if !onboard.resolved && opts.outputDir == "" {
 			if basename, ok := prompt.ShouldOfferInPlace("."); ok {
 				useCurrent, err := prompt.PromptScaffoldLocation(ctx, basename)
 				if err != nil {
@@ -1112,7 +1131,7 @@ func runCreate(ctx context.Context, opts createOptions) error {
 				}
 			}
 		}
-		if !inPlace {
+		if !onboard.resolved && !inPlace {
 			name, err := prompt.PromptForProjectName(ctx, opts.outputDir)
 			if err != nil {
 				return err
@@ -1410,6 +1429,11 @@ func runCreate(ctx context.Context, opts createOptions) error {
 	// the bundle deploys from the repo/ref instead of uploading local files.
 	// Falls back to a plain source_code_path when there is no repo to point at.
 	gitSource := detectGitScaffoldSource(ctx, destDir, cmdctx.WorkspaceClient(ctx))
+	// Interactive onboarding (e.g. a repo it is about to create) takes
+	// precedence over passive detection.
+	if gitOverride != nil {
+		gitSource = *gitOverride
+	}
 	if gitSource.active() {
 		log.Debugf(ctx, "Scaffolding git-backed deploy: %s (%s) @ %s, path %s",
 			gitSource.URL, gitSource.Provider, gitSource.Branch, gitSource.SourceCodePath)
@@ -1498,6 +1522,24 @@ func runCreate(ctx context.Context, opts createOptions) error {
 	if runMode == prompt.RunModeDevRemote {
 		if projectInitializer == nil || !projectInitializer.SupportsDevRemote() {
 			return errors.New("--run=dev-remote is only supported for Node.js projects with @databricks/appkit")
+		}
+	}
+
+	// Create and push the GitHub repo from the scaffolded files, if the user
+	// chose to during onboarding. Deferred to here — after the project is fully
+	// initialized and all fatal setup has passed — so a successful create/push
+	// is never left orphaned by a later failure. A create failure is itself not
+	// fatal: the git-backed databricks.yml is already written, so the user can
+	// create and push the repo manually.
+	if pendingRepoCreate != nil {
+		pendingRepoCreate.sourceDir = absOutputDir
+		if err := prompt.RunWithSpinnerCtx(ctx, "Creating GitHub repository...", func() error {
+			return pendingRepoCreate.run(ctx)
+		}); err != nil {
+			cmdio.LogString(ctx, fmt.Sprintf("⚠ Could not create the GitHub repository: %v", err))
+			cmdio.LogString(ctx, "  The git-backed databricks.yml is written; create the repo and push before deploying.")
+		} else {
+			prompt.PrintDone(ctx, "GitHub repository created and pushed")
 		}
 	}
 

--- a/libs/apps/prompt/git.go
+++ b/libs/apps/prompt/git.go
@@ -55,6 +55,33 @@ func PromptCreateOrExistingRepo(ctx context.Context) (string, error) {
 	return choice, nil
 }
 
+// PromptRepoOwner asks which GitHub account the new repo should be created
+// under: the personal account or an organization the user belongs to. When
+// there are no orgs to choose from it returns the personal account without
+// prompting.
+func PromptRepoOwner(ctx context.Context, personal string, orgs []string) (string, error) {
+	if len(orgs) == 0 {
+		return personal, nil
+	}
+	options := make([]huh.Option[string], 0, len(orgs)+1)
+	options = append(options, huh.NewOption(personal+" (personal)", personal))
+	for _, o := range orgs {
+		options = append(options, huh.NewOption(o, o))
+	}
+	owner := personal
+	if err := huh.NewSelect[string]().
+		Title("Repository owner").
+		Description("your personal account or an organization you belong to").
+		Options(options...).
+		Value(&owner).
+		WithTheme(AppkitTheme()).
+		Run(); err != nil {
+		return "", err
+	}
+	printAnswered(ctx, "Owner", owner)
+	return owner, nil
+}
+
 // PromptRepoURL asks for a Git repository URL. An empty response is allowed and
 // left for the caller to treat as "skip".
 func PromptRepoURL(ctx context.Context, title, description string) (string, error) {

--- a/libs/apps/prompt/git.go
+++ b/libs/apps/prompt/git.go
@@ -1,0 +1,109 @@
+package prompt
+
+import (
+	"context"
+	"strings"
+
+	"github.com/charmbracelet/huh"
+)
+
+// Git repo onboarding choices returned by PromptCreateOrExistingRepo.
+const (
+	GitRepoCreate   = "create"
+	GitRepoExisting = "existing"
+)
+
+// PromptDeployFromGit asks whether to deploy the app from a Git repository.
+// Defaults to yes, since git-backed deployment is the recommended path.
+func PromptDeployFromGit(ctx context.Context) (bool, error) {
+	deploy := true
+	err := huh.NewConfirm().
+		Title("Deploy from a Git repository? (recommended)").
+		Description("Deploy from a repo/ref instead of uploading local files — reproducible and rollback-able").
+		Value(&deploy).
+		WithTheme(AppkitTheme()).
+		Run()
+	if err != nil {
+		return false, err
+	}
+	if deploy {
+		printAnswered(ctx, "Git-backed deploy", "Yes")
+	} else {
+		printAnswered(ctx, "Git-backed deploy", "No")
+	}
+	return deploy, nil
+}
+
+// PromptCreateOrExistingRepo asks whether to create a new GitHub repo or use an
+// existing one. Returns GitRepoCreate or GitRepoExisting.
+func PromptCreateOrExistingRepo(ctx context.Context) (string, error) {
+	choice := GitRepoCreate
+	err := huh.NewSelect[string]().
+		Title("Set up the Git repository").
+		Options(
+			huh.NewOption("Create a new GitHub repository", GitRepoCreate),
+			huh.NewOption("Use an existing repository (clone into the current directory)", GitRepoExisting),
+		).
+		Value(&choice).
+		WithTheme(AppkitTheme()).
+		Run()
+	if err != nil {
+		return "", err
+	}
+	labels := map[string]string{GitRepoCreate: "Create new", GitRepoExisting: "Use existing"}
+	printAnswered(ctx, "Repository", labels[choice])
+	return choice, nil
+}
+
+// PromptRepoURL asks for a Git repository URL. An empty response is allowed and
+// left for the caller to treat as "skip".
+func PromptRepoURL(ctx context.Context, title, description string) (string, error) {
+	var url string
+	err := huh.NewInput().
+		Title(title).
+		Description(description).
+		Placeholder("https://github.com/my-org/my-repo").
+		Value(&url).
+		WithTheme(AppkitTheme()).
+		Run()
+	if err != nil {
+		return "", err
+	}
+	url = strings.TrimSpace(url)
+	if url != "" {
+		printAnswered(ctx, "Repository URL", url)
+	}
+	return url, nil
+}
+
+// PromptNewRepoDetails asks for the new repo/app name (defaulting to
+// defaultName) and whether it should be private.
+func PromptNewRepoDetails(ctx context.Context, defaultName string) (name string, private bool, err error) {
+	name = defaultName
+	if err = huh.NewInput().
+		Title("Repository name").
+		Description("also used as the app name — lowercase letters, numbers, hyphens (max 26 chars)").
+		Placeholder("my-app").
+		Value(&name).
+		Validate(ValidateProjectName).
+		WithTheme(AppkitTheme()).
+		Run(); err != nil {
+		return "", false, err
+	}
+	printAnswered(ctx, "Repository name", name)
+
+	private = true
+	if err = huh.NewConfirm().
+		Title("Private repository?").
+		Value(&private).
+		WithTheme(AppkitTheme()).
+		Run(); err != nil {
+		return "", false, err
+	}
+	if private {
+		printAnswered(ctx, "Visibility", "private")
+	} else {
+		printAnswered(ctx, "Visibility", "public")
+	}
+	return name, private, nil
+}


### PR DESCRIPTION
> **Stacked on #6406** (base `apps-init-git-autodetect`). Review/merge #6406 first; this PR's diff is just the onboarding layer. I'll retarget to `main` once #6406 lands.

## Changes

When `databricks apps init` runs **outside any Git repository** (interactive mode only), it now offers to set up git-backed deployment — recommended, default yes:

- **Create a new GitHub repository** — with an authenticated `gh` CLI, the repo is created and the scaffolded app pushed to it; `databricks.yml` is rendered git-backed at the predicted `https://github.com/<owner>/<name>`. Without a usable `gh`, it falls back to writing the git-backed config from a URL the user supplies (repo creation left to them).
- **Use an existing repository** — clones it into the current directory (which must be empty) and scaffolds the app in place; the cloned origin is picked up by #6406's detection pass.

New: `cmd/apps/gitonboard.go` (orchestration + `gh`/`git` helpers), `libs/apps/prompt/git.go` (the huh prompts), `isInGitRepo` gate in `gitsource.go`, and wiring in `init.go`.

## Why

#6406 makes a scaffold git-backed when you're *already* in a repo. This closes the other half: the common case where the user has no repo yet. Rather than silently defaulting to a local `source_code_path` upload, `apps init` walks them into a repo (create or clone) so git-backed deployment — the recommended path for Databricks Apps — is the default outcome, not something they have to discover and wire up by hand.

Safety:
- Repo creation is deferred until after the project is fully initialized, so a successful create/push is never orphaned by a later failure.
- The clone path refuses to scaffold over a non-empty repository (no clobbering).
- A `gh` failure is non-fatal — the git-backed `databricks.yml` is still written with guidance to create/push manually.
- Non-interactive / `--name` (flags) mode is unaffected and relies on passive detection only.

## Tests

- Unit tests for the pure helpers (`dirIsEmpty`, `dirHasOnlyGit` behavior via `defaultRepoName`/empty-dir checks); provider inference and URL normalization are covered in #6406.
- Build/vet clean; `cmd/apps` and `libs/apps/prompt` test packages pass. The interactive prompts and `gh`/`git clone` exec paths are exercised manually (they shell out to external tools).

This pull request and its description were written by Isaac.