### PR TITLE
Improve AIR run log guidance

### DIFF
--- a/acceptance/experimental/air/run-submit-deps/output.txt
+++ b/acceptance/experimental/air/run-submit-deps/output.txt
@@ -5,10 +5,9 @@ Submitting experiment: deps-smoke
 Submitted workload with Job Run ID: 555
 View job run at: [DATABRICKS_URL]/jobs/runs/555
 
-Stream real-time logs using:
+Tip: use --watch when submitting a run to stream logs to your terminal.
+Stream logs after submission using:
   databricks experimental air logs 555
-
-Tip: use --watch when submitting a run to stream logs in real time.
 
 === only config + command are uploaded; no requirements.yaml
 >>> print_requests.py //api/2.0/workspace-files/import-file --oneline --sort --unique --keep

--- a/acceptance/experimental/air/run-submit-deps/output.txt
+++ b/acceptance/experimental/air/run-submit-deps/output.txt
@@ -5,10 +5,10 @@ Submitting experiment: deps-smoke
 Submitted workload with Job Run ID: 555
 View job run at: [DATABRICKS_URL]/jobs/runs/555
 
-Stream logs in real time using:
+Stream real-time logs using:
   databricks experimental air logs 555
 
-Tip: use --watch when submitting a run to monitor the job and stream logs in real time.
+Tip: use --watch when submitting a run to stream logs in real time.
 
 === only config + command are uploaded; no requirements.yaml
 >>> print_requests.py //api/2.0/workspace-files/import-file --oneline --sort --unique --keep

--- a/acceptance/experimental/air/run-submit-deps/output.txt
+++ b/acceptance/experimental/air/run-submit-deps/output.txt
@@ -5,7 +5,10 @@ Submitting experiment: deps-smoke
 Submitted workload with Job Run ID: 555
 View job run at: [DATABRICKS_URL]/jobs/runs/555
 
-Tip: use --watch to stream logs until the run completes.
+Stream logs in real time using:
+  databricks experimental air logs 555
+
+Tip: use --watch when submitting a run to monitor the job and stream logs in real time.
 
 === only config + command are uploaded; no requirements.yaml
 >>> print_requests.py //api/2.0/workspace-files/import-file --oneline --sort --unique --keep

--- a/acceptance/experimental/air/run-submit/output.txt
+++ b/acceptance/experimental/air/run-submit/output.txt
@@ -6,10 +6,9 @@ Uploading [SNAPSHOT_TARBALL]...
 Submitted workload with Job Run ID: 555
 View job run at: [DATABRICKS_URL]/jobs/runs/555
 
-Stream real-time logs using:
+Tip: use --watch when submitting a run to stream logs to your terminal.
+Stream logs after submission using:
   databricks experimental air logs 555
-
-Tip: use --watch when submitting a run to stream logs in real time.
 
 === the ai_runtime_task carries the code_source_path
 >>> print_requests.py //api/2.2/jobs/runs/submit

--- a/acceptance/experimental/air/run-submit/output.txt
+++ b/acceptance/experimental/air/run-submit/output.txt
@@ -6,10 +6,10 @@ Uploading [SNAPSHOT_TARBALL]...
 Submitted workload with Job Run ID: 555
 View job run at: [DATABRICKS_URL]/jobs/runs/555
 
-Stream logs in real time using:
+Stream real-time logs using:
   databricks experimental air logs 555
 
-Tip: use --watch when submitting a run to monitor the job and stream logs in real time.
+Tip: use --watch when submitting a run to stream logs in real time.
 
 === the ai_runtime_task carries the code_source_path
 >>> print_requests.py //api/2.2/jobs/runs/submit

--- a/acceptance/experimental/air/run-submit/output.txt
+++ b/acceptance/experimental/air/run-submit/output.txt
@@ -6,7 +6,10 @@ Uploading [SNAPSHOT_TARBALL]...
 Submitted workload with Job Run ID: 555
 View job run at: [DATABRICKS_URL]/jobs/runs/555
 
-Tip: use --watch to stream logs until the run completes.
+Stream logs in real time using:
+  databricks experimental air logs 555
+
+Tip: use --watch when submitting a run to monitor the job and stream logs in real time.
 
 === the ai_runtime_task carries the code_source_path
 >>> print_requests.py //api/2.2/jobs/runs/submit

--- a/experimental/air/cmd/format.go
+++ b/experimental/air/cmd/format.go
@@ -104,16 +104,39 @@ func runStatus(state *jobs.RunState) string {
 
 func displayRunStatus(run *jobs.Run) string {
 	status := runStatus(run.State)
-	if status != string(jobs.RunLifeCycleStateRunning) || len(run.Tasks) == 0 || run.Tasks[0].State == nil {
-		return status
+	if runWaitingForCompute(run) {
+		return "PENDING"
+	}
+	return status
+}
+
+func runWaitingForCompute(run *jobs.Run) bool {
+	if run.State == nil || run.State.ResultState != "" {
+		return false
+	}
+	if run.State.LifeCycleState == jobs.RunLifeCycleStatePending {
+		return true
+	}
+	if run.State.LifeCycleState != jobs.RunLifeCycleStateRunning || len(run.Tasks) == 0 || run.Tasks[0].State == nil {
+		return false
 	}
 	switch run.Tasks[0].State.LifeCycleState {
 	case jobs.RunLifeCycleStatePending, jobs.RunLifeCycleStateQueued,
 		jobs.RunLifeCycleStateWaitingForRetry, jobs.RunLifeCycleStateBlocked:
-		return "PENDING"
+		return true
 	default:
-		return status
+		return false
 	}
+}
+
+func detailedDisplayRunStatus(run *jobs.Run, statusMessage string) string {
+	if run.State != nil && run.State.ResultState == "" && statusMessage != "" {
+		return statusMessage
+	}
+	if runWaitingForCompute(run) {
+		return waitingForComputeStatus
+	}
+	return displayRunStatus(run)
 }
 
 func terminationReason(run *jobs.Run) *string {

--- a/experimental/air/cmd/format_test.go
+++ b/experimental/air/cmd/format_test.go
@@ -262,6 +262,27 @@ func TestDisplayRunStatus(t *testing.T) {
 	}))
 }
 
+func TestDetailedDisplayRunStatus(t *testing.T) {
+	waiting := &jobs.Run{
+		State: &jobs.RunState{LifeCycleState: jobs.RunLifeCycleStateRunning},
+		Tasks: []jobs.RunTask{{State: &jobs.RunState{LifeCycleState: jobs.RunLifeCycleStateQueued}}},
+	}
+	assert.Equal(t, "Waiting for GPU capacity...", detailedDisplayRunStatus(waiting, "Waiting for GPU capacity..."))
+	assert.Equal(t, waitingForComputeStatus, detailedDisplayRunStatus(waiting, ""))
+
+	started := &jobs.Run{
+		State: &jobs.RunState{LifeCycleState: jobs.RunLifeCycleStateRunning},
+		Tasks: []jobs.RunTask{{State: &jobs.RunState{LifeCycleState: jobs.RunLifeCycleStateRunning}}},
+	}
+	assert.Equal(t, "RUNNING", detailedDisplayRunStatus(started, ""))
+
+	failed := &jobs.Run{
+		State: &jobs.RunState{LifeCycleState: jobs.RunLifeCycleStateTerminated, ResultState: jobs.RunResultStateFailed},
+		Tasks: []jobs.RunTask{{State: &jobs.RunState{LifeCycleState: jobs.RunLifeCycleStatePending}}},
+	}
+	assert.Equal(t, "FAILED", detailedDisplayRunStatus(failed, "stale status..."))
+}
+
 func TestTerminationReason(t *testing.T) {
 	reason := terminationReason(&jobs.Run{
 		State:  &jobs.RunState{ResultState: jobs.RunResultStateFailed, StateMessage: "parent reason"},

--- a/experimental/air/cmd/get.go
+++ b/experimental/air/cmd/get.go
@@ -161,7 +161,8 @@ func newGetCommand() *cobra.Command {
 
 		data := buildGetData(run)
 		data.DashboardURL = dashboardURL(w.Config.Host, runID, workspaceID)
-		ids := mlflowIDs(ctx, w, run)
+		taskOutput := aiRuntimeTaskOutput(ctx, w, run)
+		ids := mlflowIDsFromOutput(taskOutput)
 		if ids != nil {
 			url := mlflowLogsURL(w.Config.Host, ids)
 			data.MLflowURL = &url
@@ -194,6 +195,11 @@ func newGetCommand() *cobra.Command {
 			fmt.Fprintf(out, "Job Link: %s\n\n", hyperlink(ctx, out, data.DashboardURL, data.DashboardURL))
 			return renderEnvelope(ctx, data)
 		}
+		statusMessage := ""
+		if taskOutput != nil {
+			statusMessage = normalizeStatusMessage(taskOutput.StatusMessage)
+		}
+		data.DisplayStatus = detailedDisplayRunStatus(run, statusMessage)
 
 		renderRunText(ctx, out, w, run, &data, ids)
 		return nil

--- a/experimental/air/cmd/logs.go
+++ b/experimental/air/cmd/logs.go
@@ -105,7 +105,7 @@ func newLogsCommand() *cobra.Command {
 			tailLines = lines
 		}
 
-		return runLogs(ctx, cmd, logRequest{
+		err = runLogs(ctx, cmd, logRequest{
 			runID:         runID,
 			node:          node,
 			nodeSet:       cmd.Flags().Changed("node"),
@@ -115,6 +115,10 @@ func newLogsCommand() *cobra.Command {
 			downloadTo:    downloadTo,
 			jsonOutput:    root.OutputType(cmd) == flags.OutputJSON,
 		})
+		if downloadTo != "" || root.OutputType(cmd) == flags.OutputJSON {
+			return err
+		}
+		return handleWatchResult(cmd.OutOrStdout(), cmdctx.WorkspaceClient(ctx).Config.Profile, args[0], err)
 	}
 
 	return cmd

--- a/experimental/air/cmd/logs.go
+++ b/experimental/air/cmd/logs.go
@@ -105,7 +105,17 @@ func newLogsCommand() *cobra.Command {
 			tailLines = lines
 		}
 
-		err = runLogs(ctx, cmd, logRequest{
+		// Only the streaming path prints resume guidance, so only it catches the
+		// interrupt: without this a Ctrl-C kills the process before
+		// handleWatchResult runs. Download and JSON keep the default handling.
+		streamCtx := ctx
+		if downloadTo == "" && root.OutputType(cmd) != flags.OutputJSON {
+			var stop context.CancelFunc
+			streamCtx, stop = notifyInterrupt(ctx)
+			defer stop()
+		}
+
+		err = runLogs(streamCtx, cmd, logRequest{
 			runID:         runID,
 			node:          node,
 			nodeSet:       cmd.Flags().Changed("node"),

--- a/experimental/air/cmd/logs_test.go
+++ b/experimental/air/cmd/logs_test.go
@@ -223,8 +223,8 @@ func TestLogsCommandPrintsGuidanceWhenStreamingIsInterrupted(t *testing.T) {
 	err := cmd.RunE(cmd, []string{"5"})
 	require.ErrorIs(t, err, root.ErrAlreadyPrinted)
 	assert.Contains(t, buf.String(), "Streaming logs interrupted.")
-	assert.Contains(t, buf.String(), `Use "databricks experimental air get 5 -p 'team profile'" to check status.`)
-	assert.Contains(t, buf.String(), `Use "databricks experimental air logs 5 -p 'team profile'" to resume streaming logs.`)
+	assert.Contains(t, buf.String(), "To check status:\ndatabricks experimental air get 5 -p 'team profile'")
+	assert.Contains(t, buf.String(), "To resume streaming logs:\ndatabricks experimental air logs 5 -p 'team profile'")
 }
 
 // activeRunPastRetryServer serves a still-RUNNING run with two attempts and a

--- a/experimental/air/cmd/logs_test.go
+++ b/experimental/air/cmd/logs_test.go
@@ -2,11 +2,13 @@ package aircmd
 
 import (
 	"bytes"
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"github.com/databricks/cli/cmd/root"
 	"github.com/databricks/cli/libs/cmdctx"
 	"github.com/databricks/cli/libs/cmdio"
 	"github.com/databricks/cli/libs/flags"
@@ -192,6 +194,37 @@ func TestLogsFallsBackToMLflow(t *testing.T) {
 	err := runLogs(ctx, cmd, logRequest{runID: 5, node: 0, attempt: -1, tailLines: -1})
 	require.NoError(t, err)
 	assert.Equal(t, "line one\nline two\n", buf.String())
+}
+
+func TestLogsCommandPrintsGuidanceWhenStreamingIsInterrupted(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/2.2/jobs/runs/get":
+			_, _ = w.Write([]byte(`{"run_id":5,"state":{"life_cycle_state":"RUNNING"},"tasks":[{"run_id":456}]}`))
+		case strings.HasSuffix(r.URL.Path, "/logs"):
+			cancel()
+			_, _ = w.Write([]byte(`{"log_records":[]}`))
+		default:
+			_, _ = w.Write([]byte(`{"userName":"u@example.com"}`))
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	var buf bytes.Buffer
+	client := newTestWorkspaceClient(t, srv.URL)
+	client.Config.Profile = "team profile"
+	ctx = cmdio.InContext(ctx, cmdio.NewIO(ctx, flags.OutputText, nil, &buf, &buf, "", ""))
+	ctx = cmdctx.SetWorkspaceClient(ctx, client)
+	cmd := withOutput(newLogsCommand(), flags.OutputText)
+	cmd.SetContext(ctx)
+	cmd.SetOut(&buf)
+
+	err := cmd.RunE(cmd, []string{"5"})
+	require.ErrorIs(t, err, root.ErrAlreadyPrinted)
+	assert.Contains(t, buf.String(), "Streaming logs interrupted.")
+	assert.Contains(t, buf.String(), `Use "databricks experimental air get 5 -p 'team profile'" to check status.`)
+	assert.Contains(t, buf.String(), `Use "databricks experimental air logs 5 -p 'team profile'" to resume streaming logs.`)
 }
 
 // activeRunPastRetryServer serves a still-RUNNING run with two attempts and a

--- a/experimental/air/cmd/logstream.go
+++ b/experimental/air/cmd/logstream.go
@@ -58,6 +58,9 @@ func normalizeStatusMessage(raw string) string {
 	if payload == "" {
 		return ""
 	}
+	if strings.EqualFold(payload, "Waiting for GPU compute capacity to become available") {
+		return waitingForComputeStatus
+	}
 	return payload + "..."
 }
 

--- a/experimental/air/cmd/logstream.go
+++ b/experimental/air/cmd/logstream.go
@@ -104,11 +104,12 @@ type logRequest struct {
 // logRunStatus is the subset of a run's state the log path needs, resolved once
 // and reused.
 type logRunStatus struct {
-	lifeCycleState string
-	resultState    string
-	stateMessage   string
-	startTimeMs    int64
-	endTimeMs      int64
+	lifeCycleState          string
+	firstTaskLifeCycleState string
+	resultState             string
+	stateMessage            string
+	startTimeMs             int64
+	endTimeMs               int64
 	// latestAttempt is the highest attempt_number across the run's tasks.
 	latestAttempt int
 }
@@ -126,6 +127,25 @@ func (s logRunStatus) terminal() bool {
 
 func (s logRunStatus) succeeded() bool {
 	return s.resultState == "SUCCESS"
+}
+
+func (s logRunStatus) waitingForCompute() bool {
+	if s.resultState != "" {
+		return false
+	}
+	if s.lifeCycleState == string(jobs.RunLifeCycleStatePending) {
+		return true
+	}
+	if s.lifeCycleState != string(jobs.RunLifeCycleStateRunning) {
+		return false
+	}
+	switch jobs.RunLifeCycleState(s.firstTaskLifeCycleState) {
+	case jobs.RunLifeCycleStatePending, jobs.RunLifeCycleStateQueued,
+		jobs.RunLifeCycleStateWaitingForRetry, jobs.RunLifeCycleStateBlocked:
+		return true
+	default:
+		return false
+	}
 }
 
 // downloadOutcome is the exit status for a one-shot fetch, which unlike streaming
@@ -156,6 +176,9 @@ func projectRunStatus(run *jobs.Run) logRunStatus {
 		s.lifeCycleState = string(run.State.LifeCycleState)
 		s.resultState = string(run.State.ResultState)
 		s.stateMessage = run.State.StateMessage
+	}
+	if len(run.Tasks) > 0 && run.Tasks[0].State != nil {
+		s.firstTaskLifeCycleState = string(run.Tasks[0].State.LifeCycleState)
 	}
 	for i := range run.Tasks {
 		s.latestAttempt = max(s.latestAttempt, run.Tasks[i].AttemptNumber)
@@ -260,7 +283,7 @@ func (st *bricklensStreamer) waitingSpinnerText() string {
 	if msg := st.serverStatusMessage(); msg != "" {
 		return msg
 	}
-	if st.status.lifeCycleState == "PENDING" {
+	if st.status.waitingForCompute() {
 		return waitingForComputeStatus
 	}
 	return fmt.Sprintf("Waiting for run to start (node %d)...", st.req.node)

--- a/experimental/air/cmd/logstream_test.go
+++ b/experimental/air/cmd/logstream_test.go
@@ -82,7 +82,7 @@ func TestProjectRunStatus(t *testing.T) {
 			StateMessage:   "done",
 		},
 		Tasks: []jobs.RunTask{
-			{AttemptNumber: 0},
+			{AttemptNumber: 0, State: &jobs.RunState{LifeCycleState: jobs.RunLifeCycleStateQueued}},
 			{AttemptNumber: 2},
 			{AttemptNumber: 1},
 		},
@@ -92,6 +92,7 @@ func TestProjectRunStatus(t *testing.T) {
 	assert.Equal(t, "TERMINATED", s.lifeCycleState)
 	assert.Equal(t, "SUCCESS", s.resultState)
 	assert.Equal(t, "done", s.stateMessage)
+	assert.Equal(t, "QUEUED", s.firstTaskLifeCycleState)
 	assert.Equal(t, int64(1000), s.startTimeMs)
 	assert.Equal(t, int64(2000), s.endTimeMs)
 	assert.Equal(t, 2, s.latestAttempt)
@@ -228,7 +229,7 @@ func TestNormalizeStatusMessage(t *testing.T) {
 
 func TestWaitingSpinnerText(t *testing.T) {
 	// A server that returns the run (with a task) and a STATUS-typed status_message.
-	newStreamer := func(t *testing.T, statusMessage, lifeCycle string) *bricklensStreamer {
+	newStreamer := func(t *testing.T, statusMessage, lifeCycle, firstTaskLifeCycle string) *bricklensStreamer {
 		t.Helper()
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			switch r.URL.Path {
@@ -245,21 +246,30 @@ func TestWaitingSpinnerText(t *testing.T) {
 			ctx:    t.Context(),
 			w:      newTestWorkspaceClient(t, srv.URL),
 			req:    logRequest{runID: 1, node: 0},
-			status: logRunStatus{lifeCycleState: lifeCycle},
+			status: logRunStatus{lifeCycleState: lifeCycle, firstTaskLifeCycleState: firstTaskLifeCycle},
 		}
 	}
 
 	// Server STATUS message wins.
 	assert.Equal(t, "Waiting for GPU capacity...",
-		newStreamer(t, "STATUS: Waiting for GPU capacity", "PENDING").waitingSpinnerText())
+		newStreamer(t, "STATUS: Waiting for GPU capacity", "PENDING", "").waitingSpinnerText())
 
 	// No status message + PENDING -> compute-capacity fallback.
 	assert.Equal(t, waitingForComputeStatus,
-		newStreamer(t, "", "PENDING").waitingSpinnerText())
+		newStreamer(t, "", "PENDING", "").waitingSpinnerText())
+
+	for _, state := range []string{"PENDING", "QUEUED", "WAITING_FOR_RETRY", "BLOCKED"} {
+		assert.Equal(t, waitingForComputeStatus,
+			newStreamer(t, "", "RUNNING", state).waitingSpinnerText(), state)
+	}
 
 	// No status message + non-PENDING -> default "waiting for run to start".
 	assert.Equal(t, "Waiting for run to start (node 0)...",
-		newStreamer(t, "", "RUNNING").waitingSpinnerText())
+		newStreamer(t, "", "RUNNING", "RUNNING").waitingSpinnerText())
+	assert.Equal(t, "Waiting for run to start (node 0)...",
+		newStreamer(t, "", "RUNNING", "").waitingSpinnerText())
+	assert.Equal(t, "Waiting for run to start (node 0)...",
+		newStreamer(t, "", "TERMINATED", "PENDING").waitingSpinnerText())
 }
 
 func TestEmitLogLineJSON(t *testing.T) {

--- a/experimental/air/cmd/logstream_test.go
+++ b/experimental/air/cmd/logstream_test.go
@@ -214,6 +214,7 @@ func TestNormalizeStatusMessage(t *testing.T) {
 	}{
 		{"STATUS: Waiting for GPU capacity.", "Waiting for GPU capacity..."},
 		{"STATUS:Waiting for GPU capacity", "Waiting for GPU capacity..."},
+		{"STATUS: Waiting for GPU compute capacity to become available", waitingForComputeStatus},
 		{"status: provisioning", "provisioning..."}, // type match is case-insensitive
 		{"STATUS: done...", "done..."},              // trailing dots collapse to one "..."
 		{"INFO: not a status", ""},                  // other type ignored

--- a/experimental/air/cmd/mlflow.go
+++ b/experimental/air/cmd/mlflow.go
@@ -30,11 +30,14 @@ type mlflowIdentifiers struct {
 // mlflowIDs fetches the MLflow IDs for a run via its latest task. Returns nil if
 // they can't be obtained.
 func mlflowIDs(ctx context.Context, w *databricks.WorkspaceClient, run *jobs.Run) *mlflowIdentifiers {
+	return mlflowIDsFromOutput(aiRuntimeTaskOutput(ctx, w, run))
+}
+
+func aiRuntimeTaskOutput(ctx context.Context, w *databricks.WorkspaceClient, run *jobs.Run) *jobs.AiRuntimeTaskOutput {
 	if len(run.Tasks) == 0 {
 		return nil
 	}
-	// The MLflow output is attached to the task run, not the parent job run.
-	return mlflowIDsForTask(ctx, w, run.Tasks[len(run.Tasks)-1].RunId)
+	return aiRuntimeTaskOutputForTask(ctx, w, run.Tasks[len(run.Tasks)-1].RunId)
 }
 
 // mlflowIDsForTask fetches a task run's MLflow experiment and run IDs from
@@ -42,6 +45,10 @@ func mlflowIDs(ctx context.Context, w *databricks.WorkspaceClient, run *jobs.Run
 // link, so any failure (endpoint error, run not yet started, no MLflow output)
 // is logged and treated as "no link" rather than failing the command.
 func mlflowIDsForTask(ctx context.Context, w *databricks.WorkspaceClient, taskRunID int64) *mlflowIdentifiers {
+	return mlflowIDsFromOutput(aiRuntimeTaskOutputForTask(ctx, w, taskRunID))
+}
+
+func aiRuntimeTaskOutputForTask(ctx context.Context, w *databricks.WorkspaceClient, taskRunID int64) *jobs.AiRuntimeTaskOutput {
 	if taskRunID == 0 {
 		return nil
 	}
@@ -52,10 +59,14 @@ func mlflowIDsForTask(ctx context.Context, w *databricks.WorkspaceClient, taskRu
 		return nil
 	}
 
-	if o := out.AiRuntimeTaskOutput; o != nil && o.MlflowExperimentId != "" && o.MlflowRunId != "" {
-		return &mlflowIdentifiers{ExperimentID: o.MlflowExperimentId, RunID: o.MlflowRunId}
+	return out.AiRuntimeTaskOutput
+}
+
+func mlflowIDsFromOutput(output *jobs.AiRuntimeTaskOutput) *mlflowIdentifiers {
+	if output == nil || output.MlflowExperimentId == "" || output.MlflowRunId == "" {
+		return nil
 	}
-	return nil
+	return &mlflowIdentifiers{ExperimentID: output.MlflowExperimentId, RunID: output.MlflowRunId}
 }
 
 // mlflowLogsURL is the deep link to a run's node-0 logs. It is the value of the

--- a/experimental/air/cmd/mlflow_test.go
+++ b/experimental/air/cmd/mlflow_test.go
@@ -78,6 +78,17 @@ func TestMLflowIDs(t *testing.T) {
 	})
 }
 
+func TestAiRuntimeTaskOutput(t *testing.T) {
+	var hit bool
+	srv := runOutputServer(t, `{"ai_runtime_task_output":{"status_message":"STATUS: Waiting for GPU capacity"}}`, &hit)
+	run := &jobs.Run{Tasks: []jobs.RunTask{{RunId: 99}}}
+
+	got := aiRuntimeTaskOutput(t.Context(), newTestWorkspaceClient(t, srv.URL), run)
+	require.NotNil(t, got)
+	assert.True(t, hit)
+	assert.Equal(t, "STATUS: Waiting for GPU capacity", got.StatusMessage)
+}
+
 func TestMLflowIDsForTask(t *testing.T) {
 	ctx := t.Context()
 

--- a/experimental/air/cmd/run.go
+++ b/experimental/air/cmd/run.go
@@ -191,6 +191,14 @@ func airLogsCommand(profile, runID string) string {
 	return strings.Join(args, " ")
 }
 
+func airGetCommand(profile, runID string) string {
+	args := []string{"databricks", "experimental", "air", "get", shellquote.BashArg(runID)}
+	if profile != "" {
+		args = append(args, "-p", shellquote.BashArg(profile))
+	}
+	return strings.Join(args, " ")
+}
+
 func printPostSubmitGuidance(out io.Writer, profile, runID string) {
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Tip: use --watch when submitting a run to stream logs to your terminal.")
@@ -204,9 +212,9 @@ func handleWatchResult(out io.Writer, profile, runID string, err error) error {
 	}
 
 	fmt.Fprintln(out)
-	fmt.Fprintln(out, "Stopped streaming logs. The workload was not canceled.")
-	fmt.Fprintln(out, "Resume real-time logs using:")
-	fmt.Fprintln(out, "  "+airLogsCommand(profile, runID))
+	fmt.Fprintln(out, "Streaming logs interrupted.")
+	fmt.Fprintf(out, "Use %q to check status.\n", airGetCommand(profile, runID))
+	fmt.Fprintf(out, "Use %q to resume streaming logs.\n", airLogsCommand(profile, runID))
 	return root.ErrAlreadyPrinted
 }
 

--- a/experimental/air/cmd/run.go
+++ b/experimental/air/cmd/run.go
@@ -213,8 +213,12 @@ func handleWatchResult(out io.Writer, profile, runID string, err error) error {
 
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Streaming logs interrupted.")
-	fmt.Fprintf(out, "Use %q to check status.\n", airGetCommand(profile, runID))
-	fmt.Fprintf(out, "Use %q to resume streaming logs.\n", airLogsCommand(profile, runID))
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "To check status:")
+	fmt.Fprintln(out, airGetCommand(profile, runID))
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "To resume streaming logs:")
+	fmt.Fprintln(out, airLogsCommand(profile, runID))
 	return root.ErrAlreadyPrinted
 }
 

--- a/experimental/air/cmd/run.go
+++ b/experimental/air/cmd/run.go
@@ -2,8 +2,11 @@ package aircmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
+	"os"
+	"os/signal"
 	"strconv"
 	"strings"
 	"unicode/utf8"
@@ -12,6 +15,7 @@ import (
 	"github.com/databricks/cli/libs/cmdctx"
 	"github.com/databricks/cli/libs/cmdio"
 	"github.com/databricks/cli/libs/flags"
+	"github.com/databricks/cli/libs/shellquote"
 	"github.com/databricks/databricks-sdk-go"
 	"github.com/spf13/cobra"
 )
@@ -126,7 +130,7 @@ The path must be a separate argument: cobra reserves -h as a boolean, so
 				if ids := resolveMLflowIDsForRun(ctx, w, runID); ids != nil {
 					printMLflowLinks(ctx, out, w.Config.Host, ids)
 				}
-				cmdio.LogString(ctx, "\nTip: use --watch to stream logs until the run completes.")
+				printPostSubmitGuidance(out, w.Config.Profile, runIDStr)
 				return nil
 			}
 			// PENDING is the submit status, distinct from the --watch JSONL
@@ -144,6 +148,9 @@ The path must be a separate argument: cobra reserves -h as a boolean, so
 			jsonOutput: jsonOut,
 		}
 
+		watchCtx, stop := signal.NotifyContext(ctx, os.Interrupt)
+		defer stop()
+
 		if !jsonOut {
 			out := cmd.OutOrStdout()
 			// The MLflow links stream in via the logs below, so don't poll here.
@@ -152,7 +159,7 @@ The path must be a separate argument: cobra reserves -h as a boolean, so
 			fmt.Fprintln(out)
 			fmt.Fprintln(out, "Monitoring run and streaming logs...")
 			printLogsDivider(ctx, out)
-			return runLogs(ctx, cmd, req)
+			return handleWatchResult(out, w.Config.Profile, runIDStr, runLogs(watchCtx, cmd, req))
 		}
 
 		// --json: emit SUBMITTED first (so a consumer sees the run id immediately),
@@ -163,7 +170,7 @@ The path must be a separate argument: cobra reserves -h as a boolean, so
 		req.onStatusChange = func(current, previous string) {
 			printStatusEvent(out, current, previous)
 		}
-		err = runLogs(ctx, cmd, req)
+		err = runLogs(watchCtx, cmd, req)
 
 		// Re-resolve the run for the closing envelope. STATUS events only fire on
 		// the Bricklens path, so the terminal status must come from the run's
@@ -174,6 +181,35 @@ The path must be a separate argument: cobra reserves -h as a boolean, so
 	}
 
 	return cmd
+}
+
+func airLogsCommand(profile, runID string) string {
+	args := []string{"databricks", "experimental", "air", "logs"}
+	if profile != "" {
+		args = append(args, "-p", shellquote.BashArg(profile))
+	}
+	args = append(args, shellquote.BashArg(runID))
+	return strings.Join(args, " ")
+}
+
+func printPostSubmitGuidance(out io.Writer, profile, runID string) {
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Stream logs in real time using:")
+	fmt.Fprintln(out, "  "+airLogsCommand(profile, runID))
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Tip: use --watch when submitting a run to monitor the job and stream logs in real time.")
+}
+
+func handleWatchResult(out io.Writer, profile, runID string, err error) error {
+	if !errors.Is(err, context.Canceled) {
+		return err
+	}
+
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Stopped streaming logs. The workload was not canceled.")
+	fmt.Fprintln(out, "Resume streaming logs using:")
+	fmt.Fprintln(out, "  "+airLogsCommand(profile, runID))
+	return root.ErrAlreadyPrinted
 }
 
 // printSubmitResult writes the green success line and Job Run link. These don't

--- a/experimental/air/cmd/run.go
+++ b/experimental/air/cmd/run.go
@@ -148,7 +148,7 @@ The path must be a separate argument: cobra reserves -h as a boolean, so
 			jsonOutput: jsonOut,
 		}
 
-		watchCtx, stop := signal.NotifyContext(ctx, os.Interrupt)
+		watchCtx, stop := notifyInterrupt(ctx)
 		defer stop()
 
 		if !jsonOut {
@@ -204,6 +204,34 @@ func printPostSubmitGuidance(out io.Writer, profile, runID string) {
 	fmt.Fprintln(out, "Tip: use --watch when submitting a run to stream logs to your terminal.")
 	fmt.Fprintln(out, "Stream logs after submission using:")
 	fmt.Fprintln(out, "  "+airLogsCommand(profile, runID))
+}
+
+// notifyInterrupt returns a context cancelled on the first interrupt (Ctrl-C),
+// which lets the log stream unwind and print resume guidance via
+// handleWatchResult; the CLI root installs no signal handler of its own. The
+// caller must defer the returned stop.
+//
+// signal.Notify disables the default SIGINT disposition process-wide for as long
+// as the channel stays registered, so a second Ctrl-C would merely be buffered
+// and dropped, leaving no way to abort a hung teardown. Calling signal.Stop
+// before cancel restores SIG_DFL first, so the cancellation is only observable
+// once a second signal is guaranteed to terminate the process.
+func notifyInterrupt(parent context.Context) (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(parent)
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt)
+	go func() {
+		// Selecting on ctx.Done() too lets the goroutine exit on the normal (no
+		// signal) path rather than parking on sigCh for the life of the process.
+		select {
+		case <-sigCh:
+			signal.Stop(sigCh)
+			cancel()
+		case <-ctx.Done():
+			signal.Stop(sigCh)
+		}
+	}()
+	return ctx, cancel
 }
 
 func handleWatchResult(out io.Writer, profile, runID string, err error) error {

--- a/experimental/air/cmd/run.go
+++ b/experimental/air/cmd/run.go
@@ -184,20 +184,18 @@ The path must be a separate argument: cobra reserves -h as a boolean, so
 }
 
 func airLogsCommand(profile, runID string) string {
-	args := []string{"databricks", "experimental", "air", "logs"}
+	args := []string{"databricks", "experimental", "air", "logs", shellquote.BashArg(runID)}
 	if profile != "" {
 		args = append(args, "-p", shellquote.BashArg(profile))
 	}
-	args = append(args, shellquote.BashArg(runID))
 	return strings.Join(args, " ")
 }
 
 func printPostSubmitGuidance(out io.Writer, profile, runID string) {
 	fmt.Fprintln(out)
-	fmt.Fprintln(out, "Stream real-time logs using:")
+	fmt.Fprintln(out, "Tip: use --watch when submitting a run to stream logs to your terminal.")
+	fmt.Fprintln(out, "Stream logs after submission using:")
 	fmt.Fprintln(out, "  "+airLogsCommand(profile, runID))
-	fmt.Fprintln(out)
-	fmt.Fprintln(out, "Tip: use --watch when submitting a run to stream logs in real time.")
 }
 
 func handleWatchResult(out io.Writer, profile, runID string, err error) error {

--- a/experimental/air/cmd/run.go
+++ b/experimental/air/cmd/run.go
@@ -194,10 +194,10 @@ func airLogsCommand(profile, runID string) string {
 
 func printPostSubmitGuidance(out io.Writer, profile, runID string) {
 	fmt.Fprintln(out)
-	fmt.Fprintln(out, "Stream logs in real time using:")
+	fmt.Fprintln(out, "Stream real-time logs using:")
 	fmt.Fprintln(out, "  "+airLogsCommand(profile, runID))
 	fmt.Fprintln(out)
-	fmt.Fprintln(out, "Tip: use --watch when submitting a run to monitor the job and stream logs in real time.")
+	fmt.Fprintln(out, "Tip: use --watch when submitting a run to stream logs in real time.")
 }
 
 func handleWatchResult(out io.Writer, profile, runID string, err error) error {
@@ -207,7 +207,7 @@ func handleWatchResult(out io.Writer, profile, runID string, err error) error {
 
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Stopped streaming logs. The workload was not canceled.")
-	fmt.Fprintln(out, "Resume streaming logs using:")
+	fmt.Fprintln(out, "Resume real-time logs using:")
 	fmt.Fprintln(out, "  "+airLogsCommand(profile, runID))
 	return root.ErrAlreadyPrinted
 }

--- a/experimental/air/cmd/run_signal_test.go
+++ b/experimental/air/cmd/run_signal_test.go
@@ -1,0 +1,101 @@
+//go:build unix
+
+// The second-signal escape hatch is a Unix signal-delivery behavior: the test
+// re-execs itself and sends SIGINT, which os/signal cannot deliver to self on
+// Windows (notifyInterrupt only watches os.Interrupt there anyway).
+package aircmd
+
+import (
+	"bufio"
+	"context"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// notifyInterrupt flips signal dispositions process-wide, so the second-signal
+// behavior can only be observed in a real child process where the test binary's
+// own handlers don't mask it. Go resets dispositions to SIG_DFL across exec.
+const signalChildEnv = "TEST_AIR_SIGNAL_CHILD"
+
+// TestMain runs notifyInterrupt under test when re-executed as the child.
+func TestMain(m *testing.M) {
+	if os.Getenv(signalChildEnv) == "" {
+		os.Exit(m.Run())
+	}
+
+	// TestMain has no *testing.T, so t.Context() is unavailable here.
+	//nolint:gocritic
+	ctx, stop := notifyInterrupt(context.Background())
+	defer stop()
+
+	// Stand in for a log stream still draining after the first Ctrl-C; the user
+	// needs the escape hatch during this window.
+	os.Stdout.WriteString("READY\n")
+	<-ctx.Done()
+	os.Stdout.WriteString("CANCELLED\n")
+	time.Sleep(30 * time.Second)
+	os.Stdout.WriteString("SURVIVED\n")
+	os.Exit(0)
+}
+
+// TestNotifyInterruptSecondSignalStillKills is the regression test for the
+// escape hatch: signal.NotifyContext disables the default SIGINT disposition
+// process-wide, so relaying only the first signal would leave the user unable to
+// abort. The first Ctrl-C must cancel the context (so handleWatchResult prints
+// resume guidance), and the second must terminate the process outright.
+func TestNotifyInterruptSecondSignalStillKills(t *testing.T) {
+	cmd := exec.Command(os.Args[0], "-test.run=TestNotifyInterruptSecondSignalStillKills")
+	cmd.Env = append(os.Environ(), signalChildEnv+"=1")
+	stdout, err := cmd.StdoutPipe()
+	require.NoError(t, err)
+	require.NoError(t, cmd.Start())
+	t.Cleanup(func() { _ = cmd.Process.Kill() })
+
+	lines := make(chan string, 8)
+	go func() {
+		sc := bufio.NewScanner(stdout)
+		for sc.Scan() {
+			lines <- sc.Text()
+		}
+		close(lines)
+	}()
+	await := func(want string) bool {
+		deadline := time.After(30 * time.Second)
+		for {
+			select {
+			case l, ok := <-lines:
+				if !ok {
+					return false
+				}
+				if strings.Contains(l, want) {
+					return true
+				}
+			case <-deadline:
+				return false
+			}
+		}
+	}
+
+	require.True(t, await("READY"), "child never started")
+	require.NoError(t, cmd.Process.Signal(os.Interrupt))
+	require.True(t, await("CANCELLED"), "first interrupt did not cancel the context")
+
+	// The second interrupt must reach the default disposition and kill the child
+	// rather than being buffered and dropped by the handler.
+	require.NoError(t, cmd.Process.Signal(os.Interrupt))
+	waitErr := make(chan error, 1)
+	go func() { waitErr <- cmd.Wait() }()
+	select {
+	case err := <-waitErr:
+		// Killed by the signal, so a non-nil (non-exit-zero) error.
+		assert.Error(t, err, "child should die by signal, not exit cleanly")
+	case <-time.After(15 * time.Second):
+		t.Fatal("second interrupt was swallowed: the user has no way to abort a hung stream")
+	}
+}

--- a/experimental/air/cmd/run_test.go
+++ b/experimental/air/cmd/run_test.go
@@ -48,13 +48,19 @@ func submitServer(t *testing.T, getOutput string) *httptest.Server {
 }
 
 func runSubmitCmd(t *testing.T, out flags.Output, buf *bytes.Buffer, srvURL string) error {
+	return runSubmitCmdWithProfile(t, out, buf, srvURL, "")
+}
+
+func runSubmitCmdWithProfile(t *testing.T, out flags.Output, buf *bytes.Buffer, srvURL, profile string) error {
 	t.Helper()
 	cfgPath := writeConfigFile(t, "run.yaml", minimalConfig)
 	cmd := withOutput(newRunCommand(), out)
 	require.NoError(t, cmd.Flags().Set("file", cfgPath))
 
 	ctx := cmdio.InContext(t.Context(), cmdio.NewIO(t.Context(), out, nil, buf, buf, "", ""))
-	ctx = cmdctx.SetWorkspaceClient(ctx, newTestWorkspaceClient(t, srvURL))
+	w := newTestWorkspaceClient(t, srvURL)
+	w.Config.Profile = profile
+	ctx = cmdctx.SetWorkspaceClient(ctx, w)
 	cmd.SetContext(ctx)
 	cmd.SetOut(buf)
 	return cmd.RunE(cmd, nil)
@@ -73,8 +79,25 @@ func TestRunSubmitTextOutput(t *testing.T) {
 	assert.Contains(t, out, "Submitted workload with Job Run ID: 555")
 	assert.Contains(t, out, "View job run at: ")
 	assert.Contains(t, out, "/jobs/runs/555")
-	assert.Contains(t, out, "Tip: use --watch")
+	assert.Contains(t, out, "Stream logs in real time using:")
+	assert.Contains(t, out, "databricks experimental air logs 555")
+	assert.Contains(t, out, "Tip: use --watch when submitting a run")
 	assert.NotContains(t, out, "View MLflow run at:")
+}
+
+func TestRunSubmitTextOutputIncludesProfileInLogsCommand(t *testing.T) {
+	fastMLflowPoll(t)
+	var buf bytes.Buffer
+	err := runSubmitCmdWithProfile(t, flags.OutputText, &buf, submitServer(t, `{}`).URL, "team profile")
+	require.NoError(t, err)
+
+	assert.Contains(t, buf.String(), "databricks experimental air logs -p 'team profile' 555")
+}
+
+func TestAirLogsCommand(t *testing.T) {
+	assert.Equal(t, "databricks experimental air logs 123", airLogsCommand("", "123"))
+	assert.Equal(t, "databricks experimental air logs -p profile-name 123", airLogsCommand("profile-name", "123"))
+	assert.Equal(t, "databricks experimental air logs -p 'team profile' 123", airLogsCommand("team profile", "123"))
 }
 
 func TestRunSubmitTextOutputWithMLflowLinks(t *testing.T) {

--- a/experimental/air/cmd/run_test.go
+++ b/experimental/air/cmd/run_test.go
@@ -79,9 +79,9 @@ func TestRunSubmitTextOutput(t *testing.T) {
 	assert.Contains(t, out, "Submitted workload with Job Run ID: 555")
 	assert.Contains(t, out, "View job run at: ")
 	assert.Contains(t, out, "/jobs/runs/555")
-	assert.Contains(t, out, "Stream real-time logs using:")
+	assert.Contains(t, out, "Tip: use --watch when submitting a run to stream logs to your terminal.")
+	assert.Contains(t, out, "Stream logs after submission using:")
 	assert.Contains(t, out, "databricks experimental air logs 555")
-	assert.Contains(t, out, "Tip: use --watch when submitting a run to stream logs in real time.")
 	assert.NotContains(t, out, "View MLflow run at:")
 }
 
@@ -91,13 +91,13 @@ func TestRunSubmitTextOutputIncludesProfileInLogsCommand(t *testing.T) {
 	err := runSubmitCmdWithProfile(t, flags.OutputText, &buf, submitServer(t, `{}`).URL, "team profile")
 	require.NoError(t, err)
 
-	assert.Contains(t, buf.String(), "databricks experimental air logs -p 'team profile' 555")
+	assert.Contains(t, buf.String(), "databricks experimental air logs 555 -p 'team profile'")
 }
 
 func TestAirLogsCommand(t *testing.T) {
 	assert.Equal(t, "databricks experimental air logs 123", airLogsCommand("", "123"))
-	assert.Equal(t, "databricks experimental air logs -p profile-name 123", airLogsCommand("profile-name", "123"))
-	assert.Equal(t, "databricks experimental air logs -p 'team profile' 123", airLogsCommand("team profile", "123"))
+	assert.Equal(t, "databricks experimental air logs 123 -p profile-name", airLogsCommand("profile-name", "123"))
+	assert.Equal(t, "databricks experimental air logs 123 -p 'team profile'", airLogsCommand("team profile", "123"))
 }
 
 func TestRunSubmitTextOutputWithMLflowLinks(t *testing.T) {

--- a/experimental/air/cmd/run_test.go
+++ b/experimental/air/cmd/run_test.go
@@ -100,6 +100,12 @@ func TestAirLogsCommand(t *testing.T) {
 	assert.Equal(t, "databricks experimental air logs 123 -p 'team profile'", airLogsCommand("team profile", "123"))
 }
 
+func TestAirGetCommand(t *testing.T) {
+	assert.Equal(t, "databricks experimental air get 123", airGetCommand("", "123"))
+	assert.Equal(t, "databricks experimental air get 123 -p profile-name", airGetCommand("profile-name", "123"))
+	assert.Equal(t, "databricks experimental air get 123 -p 'team profile'", airGetCommand("team profile", "123"))
+}
+
 func TestRunSubmitTextOutputWithMLflowLinks(t *testing.T) {
 	var buf bytes.Buffer
 	srvURL := submitServer(t, `{"ai_runtime_task_output": {"mlflow_experiment_id": "exp1", "mlflow_run_id": "run1"}}`).URL

--- a/experimental/air/cmd/run_test.go
+++ b/experimental/air/cmd/run_test.go
@@ -79,9 +79,9 @@ func TestRunSubmitTextOutput(t *testing.T) {
 	assert.Contains(t, out, "Submitted workload with Job Run ID: 555")
 	assert.Contains(t, out, "View job run at: ")
 	assert.Contains(t, out, "/jobs/runs/555")
-	assert.Contains(t, out, "Stream logs in real time using:")
+	assert.Contains(t, out, "Stream real-time logs using:")
 	assert.Contains(t, out, "databricks experimental air logs 555")
-	assert.Contains(t, out, "Tip: use --watch when submitting a run")
+	assert.Contains(t, out, "Tip: use --watch when submitting a run to stream logs in real time.")
 	assert.NotContains(t, out, "View MLflow run at:")
 }
 

--- a/experimental/air/cmd/run_watch_test.go
+++ b/experimental/air/cmd/run_watch_test.go
@@ -168,8 +168,8 @@ func TestHandleWatchResultPrintsProfileAwareResumeCommand(t *testing.T) {
 
 	out := buf.String()
 	assert.Contains(t, out, "Streaming logs interrupted.")
-	assert.Contains(t, out, `Use "databricks experimental air get 777 -p 'team profile'" to check status.`)
-	assert.Contains(t, out, `Use "databricks experimental air logs 777 -p 'team profile'" to resume streaming logs.`)
+	assert.Contains(t, out, "To check status:\ndatabricks experimental air get 777 -p 'team profile'")
+	assert.Contains(t, out, "To resume streaming logs:\ndatabricks experimental air logs 777 -p 'team profile'")
 	assert.NotContains(t, out, "The workload was not canceled")
 }
 

--- a/experimental/air/cmd/run_watch_test.go
+++ b/experimental/air/cmd/run_watch_test.go
@@ -167,9 +167,10 @@ func TestHandleWatchResultPrintsProfileAwareResumeCommand(t *testing.T) {
 	require.ErrorIs(t, err, root.ErrAlreadyPrinted)
 
 	out := buf.String()
-	assert.Contains(t, out, "Stopped streaming logs. The workload was not canceled.")
-	assert.Contains(t, out, "Resume real-time logs using:")
-	assert.Contains(t, out, "databricks experimental air logs 777 -p 'team profile'")
+	assert.Contains(t, out, "Streaming logs interrupted.")
+	assert.Contains(t, out, `Use "databricks experimental air get 777 -p 'team profile'" to check status.`)
+	assert.Contains(t, out, `Use "databricks experimental air logs 777 -p 'team profile'" to resume streaming logs.`)
+	assert.NotContains(t, out, "The workload was not canceled")
 }
 
 func TestHandleWatchResultPassesThroughOtherErrors(t *testing.T) {

--- a/experimental/air/cmd/run_watch_test.go
+++ b/experimental/air/cmd/run_watch_test.go
@@ -2,6 +2,9 @@ package aircmd
 
 import (
 	"bytes"
+	"context"
+	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -156,6 +159,25 @@ func TestRunWatchFailedRunExitsNonZero(t *testing.T) {
 	err := runWatchCmd(t, flags.OutputText, &buf, watchServer(t, "FAILED").URL)
 	require.ErrorIs(t, err, root.ErrAlreadyPrinted)
 	assert.Contains(t, buf.String(), "step 1\nstep 2")
+}
+
+func TestHandleWatchResultPrintsProfileAwareResumeCommand(t *testing.T) {
+	var buf bytes.Buffer
+	err := handleWatchResult(&buf, "team profile", "777", fmt.Errorf("stream logs: %w", context.Canceled))
+	require.ErrorIs(t, err, root.ErrAlreadyPrinted)
+
+	out := buf.String()
+	assert.Contains(t, out, "Stopped streaming logs. The workload was not canceled.")
+	assert.Contains(t, out, "Resume streaming logs using:")
+	assert.Contains(t, out, "databricks experimental air logs -p 'team profile' 777")
+}
+
+func TestHandleWatchResultPassesThroughOtherErrors(t *testing.T) {
+	want := errors.New("stream failed")
+	var buf bytes.Buffer
+
+	assert.ErrorIs(t, handleWatchResult(&buf, "profile", "777", want), want)
+	assert.Empty(t, buf.String())
 }
 
 func TestRunWatchDryRunSkipsSubmit(t *testing.T) {

--- a/experimental/air/cmd/run_watch_test.go
+++ b/experimental/air/cmd/run_watch_test.go
@@ -168,7 +168,7 @@ func TestHandleWatchResultPrintsProfileAwareResumeCommand(t *testing.T) {
 
 	out := buf.String()
 	assert.Contains(t, out, "Stopped streaming logs. The workload was not canceled.")
-	assert.Contains(t, out, "Resume streaming logs using:")
+	assert.Contains(t, out, "Resume real-time logs using:")
 	assert.Contains(t, out, "databricks experimental air logs -p 'team profile' 777")
 }
 

--- a/experimental/air/cmd/run_watch_test.go
+++ b/experimental/air/cmd/run_watch_test.go
@@ -169,7 +169,7 @@ func TestHandleWatchResultPrintsProfileAwareResumeCommand(t *testing.T) {
 	out := buf.String()
 	assert.Contains(t, out, "Stopped streaming logs. The workload was not canceled.")
 	assert.Contains(t, out, "Resume real-time logs using:")
-	assert.Contains(t, out, "databricks experimental air logs -p 'team profile' 777")
+	assert.Contains(t, out, "databricks experimental air logs 777 -p 'team profile'")
 }
 
 func TestHandleWatchResultPassesThroughOtherErrors(t *testing.T) {


### PR DESCRIPTION
## Changes
- Print a copyable `air logs` command after submission.
- Preserve the selected profile in generated commands.
- Print a resumable logs command when `air run --watch` is interrupted.

## Why
Make it obvious how to start or resume log streaming without making `--watch` the default.

## Tests
- `go test ./experimental/air/cmd -run 'Test(RunSubmit|AirLogsCommand|HandleWatchResult|RunWatch)'`
- `go test ./acceptance -run 'TestAccept/experimental/air/(run-submit|run-submit-deps)$' -timeout=10m`
- Focused `golangci-lint` for `./experimental/air/cmd`

_This PR was written with Codex._
