### PR TITLE
Bump dbt-sql to DBR 16.4 LTS for classic compute

### DIFF
--- a/.nextchanges/bundles/dbt-sql-classic-dbr-16-4.md
+++ b/.nextchanges/bundles/dbt-sql-classic-dbr-16-4.md
@@ -1,0 +1,1 @@
+The `dbt-sql` bundle template now uses Databricks Runtime 16.4 LTS (up from 15.4 LTS) for classic (non-serverless) compute.

--- a/acceptance/bundle/templates/dbt-sql-classic/input.json
+++ b/acceptance/bundle/templates/dbt-sql-classic/input.json
@@ -1,0 +1,7 @@
+{
+    "project_name": "my_dbt_sql",
+    "http_path": "/sql/2.0/warehouses/f00dcafe",
+    "default_catalog": "main",
+    "personal_schemas": "yes",
+    "serverless": "no"
+}

--- a/acceptance/bundle/templates/dbt-sql-classic/out.test.toml
+++ b/acceptance/bundle/templates/dbt-sql-classic/out.test.toml
@@ -1,0 +1,2 @@
+Cloud = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/templates/dbt-sql-classic/out.test.toml
+++ b/acceptance/bundle/templates/dbt-sql-classic/out.test.toml
@@ -1,2 +1,3 @@
 Cloud = false
+Phase = 1
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/templates/dbt-sql-classic/out.test.toml
+++ b/acceptance/bundle/templates/dbt-sql-classic/out.test.toml
@@ -1,3 +1,4 @@
 Cloud = false
 Phase = 1
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DMS = [""]

--- a/acceptance/bundle/templates/dbt-sql-classic/output.txt
+++ b/acceptance/bundle/templates/dbt-sql-classic/output.txt
@@ -1,0 +1,45 @@
+
+>>> [CLI] bundle init dbt-sql --config-file ./input.json --output-dir output
+
+Welcome to the dbt template for Declarative Automation Bundles!
+
+A workspace was selected based on your current profile. For information about how to change this, see https://docs.databricks.com/dev-tools/cli/profiles.html.
+workspace_host: [DATABRICKS_URL]
+
+📊 Your new project has been created in the 'my_dbt_sql' directory!
+If you already have dbt installed, just type 'cd my_dbt_sql; dbt init' to get started.
+Refer to the README.md file for full "getting started" guide and production setup instructions.
+
+
+>>> diff.py [TESTROOT]/bundle/templates/dbt-sql-classic/../dbt-sql/output/my_dbt_sql/resources/my_dbt_sql.job.yml output/my_dbt_sql/resources/my_dbt_sql.job.yml
+--- [TESTROOT]/bundle/templates/dbt-sql-classic/../dbt-sql/output/my_dbt_sql/resources/my_dbt_sql.job.yml
++++ output/my_dbt_sql/resources/my_dbt_sql.job.yml
+@@ -16,5 +16,4 @@
+       tasks:
+         - task_key: dbt
+-          environment_key: default
+           dbt_task:
+             project_directory: ../
+@@ -27,8 +26,16 @@
+               - 'dbt run --target=${bundle.target} --vars "{ dev_schema: ${workspace.current_user.short_name} }"'
+
+-      environments:
+-        - environment_key: default
+-          spec:
+-            environment_version: "5"
+-            dependencies:
+-              - dbt-databricks>=1.8.0,<2.0.0
++          libraries:
++            - pypi:
++                package: dbt-databricks>=1.8.0,<2.0.0
++
++          new_cluster:
++            spark_version: 16.4.x-scala2.12
++            node_type_id: [NODE_TYPE_ID]
++            data_security_mode: DATA_SECURITY_MODE_AUTO
++            num_workers: 0
++            spark_conf:
++              spark.master: "local[*, 4]"
++              spark.databricks.cluster.profile: singleNode
++            custom_tags:
++              ResourceClass: SingleNode

--- a/acceptance/bundle/templates/dbt-sql-classic/script
+++ b/acceptance/bundle/templates/dbt-sql-classic/script
@@ -1,0 +1,7 @@
+# With serverless: no, the dbt-sql job runs on a classic new_cluster instead of a
+# serverless environment. Only the job resource differs from the serverless dbt-sql
+# variant, so we diff just that file against the dbt-sql golden. This locks in the
+# new_cluster spark_version (latest_lts_dbr_version).
+trace $CLI bundle init dbt-sql --config-file ./input.json --output-dir output
+trace diff.py $TESTDIR/../dbt-sql/output/my_dbt_sql/resources/my_dbt_sql.job.yml output/my_dbt_sql/resources/my_dbt_sql.job.yml
+rm -fr output

--- a/acceptance/bundle/templates/dbt-sql-classic/test.toml
+++ b/acceptance/bundle/templates/dbt-sql-classic/test.toml
@@ -1,0 +1,3 @@
+# This test reads the sibling dbt-sql test's committed golden via $TESTDIR, so it
+# must run in phase 1 (after phase 0 regenerates that golden in update mode).
+Phase = 1

--- a/libs/template/templates/dbt-sql/library/versions.tmpl
+++ b/libs/template/templates/dbt-sql/library/versions.tmpl
@@ -1,10 +1,5 @@
 {{define "latest_lts_dbr_version" -}}
-  15.4.x-scala2.12
-{{- end}}
-
-{{/* TODO: unused — no dbt-sql template references this macro. Remove it. */}}
-{{define "latest_lts_db_connect_version_spec" -}}
-  >=16.4,<16.5
+  16.4.x-scala2.12
 {{- end}}
 
 {{/* The serverless environment version to use.


### PR DESCRIPTION
## Changes

Follow-up from #6378: bump the `dbt-sql` bundle template's classic (non-serverless) compute to Databricks Runtime 16.4 LTS.

- **dbt-sql**: bump `latest_lts_dbr_version` from `15.4.x-scala2.12` to `16.4.x-scala2.12`. This matches the `default` template (already pinned to 16.4) and aligns the cluster runtime's Python version (3.12) with serverless environment version 5.
- **dbt-sql**: remove the unused, TODO-flagged `latest_lts_db_connect_version_spec` macro (flagged for removal in #6378; no template references it).

The unrelated dead-code removal in `default-sql/library/versions.tmpl` was split into #6420 (merged); this branch is rebased on top of it.

## Tests

- New acceptance variant `acceptance/bundle/templates/dbt-sql-classic` initializes dbt-sql with `serverless: no` and diffs the generated job against the serverless golden, locking in the classic `new_cluster` `spark_version: 16.4.x-scala2.12`. Before this, no acceptance test rendered the classic (non-serverless) path.
- Note for future editors: this variant diffs against the sibling `dbt-sql` test's committed golden, so any change to the base `dbt-sql` job template requires regenerating both goldens.
- Existing dbt-sql (serverless) template goldens are unchanged; acceptance tests pass.

This pull request and its description were written by Isaac.