### PR TITLE
Remove unused default-sql versions.tmpl

### DIFF
--- a/libs/template/templates/default-sql/library/versions.tmpl
+++ b/libs/template/templates/default-sql/library/versions.tmpl
@@ -1,7 +1,0 @@
-{{define "latest_lts_dbr_version" -}}
-  15.4.x-scala2.12
-{{- end}}
-
-{{define "latest_lts_db_connect_version_spec" -}}
-  >=15.4,<15.5
-{{- end}}


### PR DESCRIPTION
## Changes

Delete `libs/template/templates/default-sql/library/versions.tmpl`. The `default-sql` bundle template renders no cluster (it targets a SQL warehouse), so its two macros — `latest_lts_dbr_version` and `latest_lts_db_connect_version_spec` — are never referenced by any template. The file contained only these two dead macros.

Split out of #6418 (dbt-sql DBR 16.4 bump) to keep that PR focused on a single change.

## Tests

- No rendered template output changes (the macros were never invoked); no changelog fragment needed.
- `default-sql` template acceptance tests pass unchanged after the deletion.

This pull request and its description were written by Isaac.