### PR TITLE
fix(bundle/direct): construct UpdateApp update_mask dynamically based on changed fields (#6400)

### DIFF
--- a/.nextchanges/bundles/app_update_mask.md
+++ b/.nextchanges/bundles/app_update_mask.md
@@ -1,0 +1,1 @@
+Construct `UpdateApp` `update_mask` dynamically based on changed fields (#6400).

--- a/acceptance/bundle/resources/apps/update/out.requests.direct.json
+++ b/acceptance/bundle/resources/apps/update/out.requests.direct.json
@@ -17,7 +17,7 @@
       "description": "MY_APP_DESCRIPTION",
       "name": "myappname"
     },
-    "update_mask": "description,budget_policy_id,usage_policy_id,resources,user_api_scopes,forward_user_access_token,compute_size,compute_min_instances,compute_max_instances,git_repository,telemetry_export_destinations"
+    "update_mask": "description"
   }
 }
 {

--- a/bundle/direct/dresources/app.go
+++ b/bundle/direct/dresources/app.go
@@ -171,30 +171,34 @@ var UpdateMaskFields = []string{
 	"telemetry_export_destinations",
 }
 
-var updateMask = strings.Join(UpdateMaskFields, ",")
-
 func (r *ResourceApp) DoUpdate(ctx context.Context, id string, config *AppState, entry *PlanEntry) (*AppRemote, error) {
 	// Deploy-only fields (source_code_path, config, git_source, lifecycle) are excluded
 	// from the request body; see appRequestBody.
 	if hasAppChanges(entry) {
 		app := appRequestBody(config)
-		request := apps.AsyncUpdateAppRequest{
-			App:        &app,
-			AppName:    id,
-			UpdateMask: updateMask,
-		}
-		updateWaiter, err := r.client.Apps.CreateUpdate(ctx, request)
-		if err != nil {
-			return nil, err
-		}
+		fieldPaths := collectUpdatePathsWithPrefix(entry.Changes, "")
+		fieldPaths = slices.DeleteFunc(fieldPaths, func(p string) bool {
+			return p == "source_code_path" || p == "config" || p == "git_source" || p == "lifecycle" || strings.HasPrefix(p, "lifecycle.")
+		})
+		if len(fieldPaths) > 0 {
+			request := apps.AsyncUpdateAppRequest{
+				App:        &app,
+				AppName:    id,
+				UpdateMask: strings.Join(fieldPaths, ","),
+			}
+			updateWaiter, err := r.client.Apps.CreateUpdate(ctx, request)
+			if err != nil {
+				return nil, err
+			}
 
-		response, err := updateWaiter.Get()
-		if err != nil {
-			return nil, err
-		}
+			response, err := updateWaiter.Get()
+			if err != nil {
+				return nil, err
+			}
 
-		if response.Status.State != apps.AppUpdateUpdateStatusUpdateStateSucceeded {
-			return nil, fmt.Errorf("update status: %s: %s", response.Status.State, response.Status.Message)
+			if response.Status.State != apps.AppUpdateUpdateStatusUpdateStateSucceeded {
+				return nil, fmt.Errorf("update status: %s: %s", response.Status.State, response.Status.Message)
+			}
 		}
 	}
 


### PR DESCRIPTION
## Changes
- Dynamically construct `update_mask` in `ResourceApp.DoUpdate` using `collectUpdatePathsWithPrefix(entry.Changes, "")`.
- Filter out non-API / deploy-only fields (`source_code_path`, `config`, `git_source`, `lifecycle`, `lifecycle.*`) from `update_mask`.
- Removed the static, hardcoded `updateMask` variable string in `bundle/direct/dresources/app.go`.
- Updated the acceptance test request recording `acceptance/bundle/resources/apps/update/out.requests.direct.json`.
- Added a changelog fragment in `.nextchanges/bundles/app_update_mask.md`.

## Why
Previously, `ResourceApp.DoUpdate` sent a fixed `update_mask` string containing all updatable `apps.App` fields (including `compute_size`, `compute_min_instances`, `compute_max_instances`, etc.) on every `UpdateApp` call regardless of what was specified in the bundle config. Because `apps.App` fields use `omitempty`, omitted fields were dropped from the request body while still being specified in `update_mask`. Building the `update_mask` dynamically ensures it strictly matches the fields modified in `entry.Changes`.

## Tests
- Updated `acceptance/bundle/resources/apps/update/out.requests.direct.json` fixture to verify that updating only `description` yields `"update_mask": "description"`.
- Verified `TestAppDoUpdate_UpdateMaskHasAllFields` in `bundle/direct/dresources/app_test.go`.
