### PR TITLE
Copy v1.14.1 changelog to main and clean up .nextchanges

### DIFF
--- a/.nextchanges/bundles/fix-app-source-code-path-regression.md
+++ b/.nextchanges/bundles/fix-app-source-code-path-regression.md
@@ -1,1 +1,0 @@
-Fix `bundle deploy` failing with `deployment_source.source_code_path cannot be set on UpdateApp` (400) when updating an app that has an active deployment ([#6401](https://github.com/databricks/cli/issues/6401)).

--- a/.nextchanges/bundles/reference-nonletter-resource-keys.md
+++ b/.nextchanges/bundles/reference-nonletter-resource-keys.md
@@ -1,1 +1,0 @@
-Fixed `${resources...}` references to resource keys starting with an underscore (e.g. `_my_job`). On the direct engine, deploying such a resource with `permissions` or `grants` failed with `cannot parse "/jobs/${resources.jobs._my_job.id}"`, and user-written references to it were silently left unresolved.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Version changelog
 
+## Release v1.14.1 (2026-08-28)
+
+### Bundles
+
+ * Fix `bundle deploy` failing with `deployment_source.source_code_path cannot be set on UpdateApp` (400) when updating an app that has an active deployment ([#6401](https://github.com/databricks/cli/issues/6401)).
+ * Fixed `${resources...}` references to resource keys starting with an underscore (e.g. `_my_job`). On the direct engine, deploying such a resource with `permissions` or `grants` failed with `cannot parse "/jobs/${resources.jobs._my_job.id}"`, and user-written references to it were silently left unresolved.
+
+
 ## Release v1.14.0 (2026-08-26)
 
 ### Notable Changes


### PR DESCRIPTION
v1.14.1 was released from release/v1.14.x, so main never got the CHANGELOG.md entry and still carried the two fragments that went into it. Copied the section verbatim from the tag and removed the consumed fragments. `.nextchanges/version` is already 1.15.0, so the remaining fragments are ready for the 1.15.0 release.