### PR TITLE
Add Kiro to `databricks aitools install`

### DIFF
--- a/cmd/aitools/telemetry.go
+++ b/cmd/aitools/telemetry.go
@@ -87,6 +87,8 @@ func agentType(name string) protos.AitoolsAgentType {
 		return protos.AitoolsAgentTypeGemini
 	case agents.NameGoose:
 		return protos.AitoolsAgentTypeGoose
+	case agents.NameKiro:
+		return protos.AitoolsAgentTypeKiro
 	default:
 		return protos.AitoolsAgentTypeUnspecified
 	}

--- a/libs/aitools/agents/agents.go
+++ b/libs/aitools/agents/agents.go
@@ -129,6 +129,7 @@ const (
 	NamePi          = "pi"
 	NameGemini      = "gemini"
 	NameGoose       = "goose"
+	NameKiro        = "kiro"
 )
 
 // Databricks plugin identity, shared across the agents that ship a plugin.
@@ -256,6 +257,19 @@ var Registry = []*Agent{
 		Binary:               "goose",
 		// Goose reads agent skills (SKILL.md) but has no databricks plugin, so it is
 		// skills-only (Plugin nil).
+	},
+	{
+		Name:                 NameKiro,
+		DisplayName:          "Kiro",
+		ConfigDir:            homeSubdir(".kiro"),
+		SupportsProjectScope: true,
+		ProjectConfigDir:     ".kiro",
+		Binary:               "kiro",
+		// Kiro reads agent skills (SKILL.md) but has no databricks plugin, so it is
+		// skills-only (Plugin nil). Kiro's own picker text documents both scopes:
+		// "Skills can be added to ~/.kiro/skills/ (user-level) or .kiro/skills/
+		// (workspace-level)". Kiro is IDE-first, so `kiro` is frequently absent from
+		// PATH; detection then falls back to ConfigDir and reports files-only.
 	},
 }
 

--- a/libs/aitools/agents/agents_test.go
+++ b/libs/aitools/agents/agents_test.go
@@ -20,6 +20,7 @@ func TestSkillsOnlyNamesMatchesRegistry(t *testing.T) {
 	assert.Contains(t, names, "Pi")
 	assert.Contains(t, names, "Gemini CLI")
 	assert.Contains(t, names, "Goose")
+	assert.Contains(t, names, "Kiro")
 	assert.NotContains(t, names, "Claude Code")
 	for _, a := range Registry {
 		if a.Plugin != nil {

--- a/libs/aitools/agents/registry_test.go
+++ b/libs/aitools/agents/registry_test.go
@@ -33,6 +33,7 @@ func TestSkillAgentRegistryPaths(t *testing.T) {
 		{NamePi, "pi", "Pi", filepath.Join(home, ".pi", "agent", "skills"), filepath.Join(cwd, ".pi", "skills")},
 		{NameGemini, "gemini", "Gemini CLI", filepath.Join(home, ".gemini", "skills"), filepath.Join(cwd, ".gemini", "skills")},
 		{NameGoose, "goose", "Goose", gooseGlobalDir, filepath.Join(cwd, ".goose", "skills")},
+		{NameKiro, "kiro", "Kiro", filepath.Join(home, ".kiro", "skills"), filepath.Join(cwd, ".kiro", "skills")},
 	}
 
 	for _, tc := range tests {
@@ -54,7 +55,7 @@ func TestSkillAgentRegistryPaths(t *testing.T) {
 
 func TestDetectProjectInstalled(t *testing.T) {
 	cwd := t.TempDir()
-	for _, name := range []string{NamePi, NameGemini, NameGoose} {
+	for _, name := range []string{NamePi, NameGemini, NameGoose, NameKiro} {
 		dir := filepath.Join(ByName(name).ProjectSkillsDir(cwd), "databricks-core")
 		require.NoError(t, os.MkdirAll(dir, 0o755))
 	}
@@ -65,5 +66,5 @@ func TestDetectProjectInstalled(t *testing.T) {
 	for _, a := range DetectProjectInstalled(cwd) {
 		names = append(names, a.Name)
 	}
-	assert.ElementsMatch(t, []string{NamePi, NameGemini, NameGoose}, names)
+	assert.ElementsMatch(t, []string{NamePi, NameGemini, NameGoose, NameKiro}, names)
 }

--- a/libs/aitools/installer/installer_test.go
+++ b/libs/aitools/installer/installer_test.go
@@ -1032,6 +1032,7 @@ func TestSupportsProjectScopeSetCorrectly(t *testing.T) {
 		"pi":          true,
 		"gemini":      true,
 		"goose":       true,
+		"kiro":        true,
 	}
 
 	for _, agent := range agents.Registry {

--- a/libs/telemetry/protos/aitools_install.go
+++ b/libs/telemetry/protos/aitools_install.go
@@ -16,6 +16,7 @@ const (
 	AitoolsAgentTypePi          AitoolsAgentType = "PI"
 	AitoolsAgentTypeGemini      AitoolsAgentType = "GEMINI_CLI"
 	AitoolsAgentTypeGoose       AitoolsAgentType = "GOOSE"
+	AitoolsAgentTypeKiro        AitoolsAgentType = "KIRO"
 )
 
 // AitoolsInstallScope mirrors AitoolsInstallScope.Type in the databricks_cli


### PR DESCRIPTION
## Summary

Adds Kiro to the agent registry so `databricks aitools install` treats it like any other skills-only agent. Follows the same shape as Goose (#6214), Gemini CLI (#6204) and Pi (#6199).

## Why

Kiro reads agent skills from `~/.kiro/skills` (user-level) and `<workspace>/.kiro/skills` (workspace-level), each skill a directory containing `SKILL.md` — exactly the layout this repo already emits. Today Kiro users have to fall back to `databricks aitools install --path ~/.kiro/skills`, which works but records no state, so `aitools update` and `aitools uninstall` never see those skills and `aitools list` reports every one of them as `not installed`.

## Verification

Tested on macOS with Kiro 1.0.182.

Kiro's loader (`NodeProgressiveContextSource`) rejects a skill when frontmatter is missing, when `name` or `description` is empty, when `name` is outside 1–64 characters, when `description` exceeds 1024, or when `name` does not equal the directory name. Everything this repo emits satisfies that.

With 29 stable skills installed into `~/.kiro/skills`, Kiro accepted all 29. The only rejections in that directory were two deliberately malformed probe skills added to confirm the loader was really scanning, plus two unrelated pre-existing skills whose frontmatter `name` disagrees with their directory:

```
skill.frontmatter.missing   zz-probe-no-frontmatter      (deliberate probe)
skill.fields.missing        zz-probe-no-description      (deliberate probe)
skill.name.mismatch         analyze-mlflow-trace         (pre-existing, unrelated)
skill.name.mismatch         analyze-mlflow-chat-session  (pre-existing, unrelated)
```

Worth knowing for anyone testing this: Kiro resolves skills lazily when a **chat session starts**, not when the IDE launches. Installing and then looking at an already-open Kiro shows nothing until a new session begins.

## Notes on the registry entry

- `SkillsSubdir` is left empty because Kiro's directory is literally `skills`, so the default applies.
- `SupportsProjectScope: true` — Kiro's own picker text documents both scopes.
- `Binary: "kiro"` is set, but Kiro is IDE-first so the binary is frequently absent from `PATH`. Detection then falls back to `ConfigDir` and reports files-only, which is the correct state for a skills-only agent (`Plugin nil`).

## Telemetry

Also adds `AitoolsAgentTypeKiro` and the matching `agentType` case, so Kiro installs are not logged as `TYPE_UNSPECIFIED` and `TestAgentTypeCoversRegistry` stays green.

**The Universe half is already merged, so nothing is owed on the proto side.** That guard's failure message notes the enum lives in `enum.proto` (Universe) as well as `aitools_install.go` (CLI). `KIRO = 10` was added to `AitoolsAgentType.Type` and merged to master on 2026-09-01 (universe 2524420), with `Protobuf-Linter-Pr` and `OpenAPICompatibility-Pr` both green — the latter being the machine check that the additive enum value is backward compatible. The two changes are order-independent: the enum addition is additive, and the CLI only emits `"KIRO"` once this PR merges. So this is the complete change and needs a review rather than any follow-up work.

## Tests

```
go test ./cmd/aitools/... ./libs/aitools/... ./libs/telemetry/...

ok  github.com/databricks/cli/cmd/aitools              2.027s
ok  github.com/databricks/cli/libs/aitools/agents
ok  github.com/databricks/cli/libs/aitools/installer
ok  github.com/databricks/cli/libs/telemetry           4.959s
ok  github.com/databricks/cli/libs/telemetry/protos    0.826s
```

Test coverage added alongside the existing Goose cases: registry paths and project detection in `libs/aitools/agents/registry_test.go`, the skills-only assertion in `agents_test.go`, and the project-scope declaration in `libs/aitools/installer/installer_test.go`.

