### PR TITLE
Add `tgz` artifact type

### DIFF
--- a/acceptance/bundle/validate/strict/output.txt
+++ b/acceptance/bundle/validate/strict/output.txt
@@ -33,7 +33,7 @@ Warning: invalid value "INVALID_TYPE" for enum field. Valid values are [complex]
   at variables.my_variable.type
   in databricks.yml:6:11
 
-Warning: invalid value "INVALID_TYPE" for enum field. Valid values are [whl jar]
+Warning: invalid value "INVALID_TYPE" for enum field. Valid values are [whl jar tgz]
   at artifacts.my_artifact.type
   in databricks.yml:16:15
 

--- a/bundle/config/artifact.go
+++ b/bundle/config/artifact.go
@@ -12,11 +12,18 @@ const ArtifactPythonWheel ArtifactType = `whl`
 
 const ArtifactJar ArtifactType = `jar`
 
+// ArtifactTarball is a gzipped tar of source files. Unlike `whl`/`jar` it carries
+// no language-specific build defaults or wheel/jar semantics: the user's `build`
+// command produces the tarball, which is then uploaded and referenced like any
+// other artifact file (e.g. as an AI Runtime task's code_source_path).
+const ArtifactTarball ArtifactType = `tgz`
+
 // Values returns all valid ArtifactType values
 func (ArtifactType) Values() []ArtifactType {
 	return []ArtifactType{
 		ArtifactPythonWheel,
 		ArtifactJar,
+		ArtifactTarball,
 	}
 }
 

--- a/bundle/internal/schema/annotations.yml
+++ b/bundle/internal/schema/annotations.yml
@@ -58,9 +58,9 @@ artifacts:
         The local path of the directory for the artifact.
     "type":
       "description": |-
-        Required if the artifact is a Python wheel. The type of the artifact. Valid values are `whl` and `jar`.
+        Required if the artifact is a Python wheel. The type of the artifact. Valid values are `whl`, `jar`, and `tgz`.
       "markdown_description": |-
-        Required if the artifact is a Python wheel. The type of the artifact. Valid values are `whl` and `jar`.
+        Required if the artifact is a Python wheel. The type of the artifact. Valid values are `whl`, `jar`, and `tgz`.
 bundle:
   "description": |-
     The bundle attributes when deploying to this target.

--- a/bundle/internal/validation/generated/enum_fields.go
+++ b/bundle/internal/validation/generated/enum_fields.go
@@ -6,7 +6,7 @@ package generated
 // EnumFields maps [dyn.Pattern] to valid enum values they should have.
 var EnumFields = map[string][]string{
 	"artifacts.*.executable": {"bash", "sh", "cmd"},
-	"artifacts.*.type":       {"whl", "jar"},
+	"artifacts.*.type":       {"whl", "jar", "tgz"},
 
 	"permissions[*].level": {"CAN_ATTACH_TO", "CAN_BIND", "CAN_CREATE", "CAN_CREATE_APP", "CAN_EDIT", "CAN_EDIT_METADATA", "CAN_MANAGE", "CAN_MANAGE_PRODUCTION_VERSIONS", "CAN_MANAGE_RUN", "CAN_MANAGE_STAGING_VERSIONS", "CAN_MONITOR", "CAN_MONITOR_ONLY", "CAN_QUERY", "CAN_READ", "CAN_RESTART", "CAN_RUN", "CAN_USE", "CAN_VIEW", "CAN_VIEW_METADATA", "IS_OWNER"},
 

--- a/bundle/schema/jsonschema.json
+++ b/bundle/schema/jsonschema.json
@@ -3172,9 +3172,9 @@
                       "$ref": "#/$defs/string"
                     },
                     "type": {
-                      "description": "Required if the artifact is a Python wheel. The type of the artifact. Valid values are `whl` and `jar`.",
+                      "description": "Required if the artifact is a Python wheel. The type of the artifact. Valid values are `whl`, `jar`, and `tgz`.",
                       "$ref": "#/$defs/github.com/databricks/cli/bundle/config.ArtifactType",
-                      "markdownDescription": "Required if the artifact is a Python wheel. The type of the artifact. Valid values are `whl` and `jar`."
+                      "markdownDescription": "Required if the artifact is a Python wheel. The type of the artifact. Valid values are `whl`, `jar`, and `tgz`."
                     }
                   },
                   "additionalProperties": false


### PR DESCRIPTION
Introduce `tgz` as a third `artifacts.*.type` alongside `whl` and `jar`. It is a generic gzipped-tar artifact with no language-specific build defaults or wheel/jar semantics: the user's `build` command produces the tarball, which is then uploaded and referenced like any other artifact file.

This lets a DAB-native user package arbitrary source code and wire it into an AI Runtime task's `code_source_path` through the standard `artifacts` mechanism, consolidating the DAB-native workflow with AIR functionality.

Kept intentionally minimal; native DABs-side tarball building from `include` paths / a `git` ref is proposed separately in #6428.

## Changes
<!-- Brief summary of your changes that is easy to understand -->

## Why
<!-- Why are these changes needed? Provide the context that the reviewer might be missing.
For example, were there any decisions behind the change that are not reflected in the code itself? -->

## Tests
<!-- How have you tested the changes? -->

<!-- If your PR needs to be included in the release notes for next release,
add a changelog fragment: create .nextchanges/<section>/<name>.md with a
one-line description (e.g. .nextchanges/cli/quickstart.md). See .nextchanges/README.md. -->
