### PR TITLE
Temporarily disable AIR git provenance uploads

### DIFF
--- a/experimental/air/cmd/runsubmit_test.go
+++ b/experimental/air/cmd/runsubmit_test.go
@@ -2,7 +2,7 @@ package aircmd
 
 import (
 	"encoding/json"
-	"io"
+	"io/fs"
 	"path"
 	"path/filepath"
 	"strings"
@@ -455,10 +455,10 @@ code_source:
 	assert.Len(t, uploaded, 1, "git_archive cache hit should skip the second upload")
 }
 
-// A git code_source also uploads git provenance sidecars (git_state.json, and
-// git_diff.patch when the tree is dirty) next to the run's launch dir, so the
-// submitted commit + working-tree diff are inspectable.
-func TestSubmitWorkloadUploadsGitSidecars(t *testing.T) {
+// When enabled, a code source uploads provenance sidecars (git_state.json and
+// git_diff.patch when the tree is dirty) next to the run's launch directory.
+// This path is paused to avoid dirty-state query and WSFS write latency.
+func TestSubmitWorkloadSkipsProvenanceSidecars(t *testing.T) {
 	server := testserver.New(t)
 	t.Cleanup(server.Close)
 
@@ -470,7 +470,7 @@ func TestSubmitWorkloadUploadsGitSidecars(t *testing.T) {
 	w, err := databricks.NewWorkspaceClient(&databricks.Config{Host: server.URL, Token: "token"})
 	require.NoError(t, err)
 
-	// Commit, then dirty the tree so both git_state.json and git_diff.patch are produced.
+	// Commit, then dirty the tree to cover the previously active sidecar path.
 	repo := newTestRepo(t)
 	writeRepoFile(t, repo, "train.py", "print()")
 	commitAll(t, repo, "init")
@@ -491,19 +491,13 @@ code_source:
 	snap, err := snapshotViaDABsUpload(ctx, w, loaded.CodeSource.Snapshot, cfgPath, sidecarStore, sidecarBase)
 	require.NoError(t, err)
 
-	// Both sidecars are reported under the launch dir and actually exist there.
-	assert.Equal(t, path.Join(sidecarBase, gitStateName), snap.GitStatePath)
-	assert.Equal(t, path.Join(sidecarBase, gitDiffName), snap.GitDiffPath)
+	assert.Empty(t, snap.GitStatePath)
+	assert.Empty(t, snap.GitDiffPath)
 
-	r, err := sidecarStore.Read(ctx, gitStateName)
-	require.NoError(t, err)
-	stateBytes, err := io.ReadAll(r)
-	require.NoError(t, err)
-	var state map[string]any
-	require.NoError(t, json.Unmarshal(stateBytes, &state))
-	assert.Equal(t, "plain_tar", state["packaging_mode"])
-	assert.Equal(t, true, state["dirty"])
-	assert.Equal(t, "captured", state["diff_status"])
+	_, err = sidecarStore.Read(ctx, gitStateName)
+	assert.ErrorIs(t, err, fs.ErrNotExist)
+	_, err = sidecarStore.Read(ctx, gitDiffName)
+	assert.ErrorIs(t, err, fs.ErrNotExist)
 }
 
 // remote_volume uploads the snapshot to a UC Volume: DABs' artifact uploader handles

--- a/experimental/air/cmd/snapshot_dabs.go
+++ b/experimental/air/cmd/snapshot_dabs.go
@@ -23,6 +23,12 @@ import (
 	"github.com/databricks/databricks-sdk-go/service/jobs"
 )
 
+// uploadProvenanceSidecars controls collection and upload of git_state.json
+// and git_diff.patch during submission. Keep the implementation available, but
+// turn it off for now because the additional local queries and WSFS writes add
+// latency to AIR submissions.
+const uploadProvenanceSidecars = false
+
 // snapshotViaDABsUpload packages the code_source into a tarball and uploads it using
 // DABs' artifact-upload plumbing (the same path a bundle uses for a file-valued
 // code_source_path), returning the remote path to attach to the ai_runtime_task.
@@ -68,7 +74,7 @@ func snapshotViaDABsUpload(ctx context.Context, w *databricks.WorkspaceClient, s
 	// in would force a distinct tarball per run (defeating the cache) or serve a prior
 	// run's stale provenance on a cache hit. They also live in the per-run launch dir,
 	// not the shared artifact dir, so they don't accumulate. Keep them out of the tar.
-	if plan.isGitRepo {
+	if uploadProvenanceSidecars && plan.isGitRepo {
 		result.GitStatePath, result.GitDiffPath = uploadSnapshotSidecars(ctx, sidecarStore, sidecarBase, newGitRepo(repoPath), plan)
 	}
 	return result, nil


### PR DESCRIPTION
## Changes
- Gate AIR git provenance collection and WSFS sidecar uploads off during submission.
- Preserve the implementation for later reactivation and update submission coverage for the paused behavior.

## Why
Dirty-state queries and uploads of `git_state.json` and `git_diff.patch` add latency to AIR submissions. Pause this best-effort provenance path for now while keeping the code available.

## Tests
- `go test ./experimental/air/cmd -run 'TestSubmitWorkload(SkipsProvenanceSidecars|GitArchiveCaching|PlainTarNameIsUnique)|Test(BuildGitStateSidecar|CaptureDirtyDiff)'`
- `./task fmt`
- `./task lint`
- `./task test` (all 9,530 unit tests passed; acceptance prerequisites failed because the local environment has jq 1.6 instead of 1.7)
- `./task checks` (blocked by the local Python version not supporting `glob(..., include_hidden=...)`)

---
<!-- GITHUB_MCP_FOOTER: This attribution is automatically appended by GitHub MCP. -->
_This PR was created with [GitHub MCP](http://go/mcps)._