### PR TITLE
Fix reason for version_id field

### DIFF
--- a/bundle/direct/dresources/resources.yml
+++ b/bundle/direct/dresources/resources.yml
@@ -30,11 +30,11 @@ resources:
     # left out: it is stable across versions, so a change to it is worth showing.
     ignore_local_changes:
       - field: deployment.version_id
-        reason: managed by the deployment metadata service
+        reason: auto
 
     ignore_remote_changes:
       - field: deployment.version_id
-        reason: managed by the deployment metadata service
+        reason: auto
 
       # Same as clusters.{aws,azure,gcp}_attributes — see clusters/resource_cluster.go#L361-L363
       # s.SchemaPath("aws_attributes").SetSuppressDiff()
@@ -223,7 +223,7 @@ resources:
     # local/remote change. deployment_id is left out so a change to it still shows.
     ignore_remote_changes:
       - field: deployment.version_id
-        reason: managed by the deployment metadata service
+        reason: auto
       # "id" is handled in a special way before any fields changed
       # However, it is also part of RemotePipeline via CreatePipeline.
       # Thus it shows up as a remote change since we don't set on the object.
@@ -244,7 +244,7 @@ resources:
 
     ignore_local_changes:
       - field: deployment.version_id
-        reason: managed by the deployment metadata service
+        reason: auto
       # "id" is output-only, providing it in config would be a mistake
       - field: id
         reason: "!drop"


### PR DESCRIPTION
"managed by deployment metadata service" is not right, it is auto set by CLI.
