### PR TITLE
structaccess: finish the move to reflect.TypeAssert

### DIFF
--- a/libs/structs/structaccess/set.go
+++ b/libs/structs/structaccess/set.go
@@ -394,7 +394,7 @@ func getEmbeddedStructForSetting(fieldValue reflect.Value) reflect.Value {
 // removeFromForceSendFields removes fieldName from the ForceSendFields slice
 func removeFromForceSendFields(forceSendFieldsSlice reflect.Value, fieldName string) {
 	// Get the original []string slice
-	fields := forceSendFieldsSlice.Interface().([]string)
+	fields, _ := reflect.TypeAssert[[]string](forceSendFieldsSlice)
 
 	// Find the index of the field to remove
 	index := slices.Index(fields, fieldName)
@@ -410,7 +410,7 @@ func removeFromForceSendFields(forceSendFieldsSlice reflect.Value, fieldName str
 // addToForceSendFields adds fieldName to the ForceSendFields slice if not already present
 func addToForceSendFields(forceSendFieldsSlice reflect.Value, fieldName string) {
 	// Get the original []string slice
-	fields := forceSendFieldsSlice.Interface().([]string)
+	fields, _ := reflect.TypeAssert[[]string](forceSendFieldsSlice)
 
 	// Check if already present
 	if slices.Contains(fields, fieldName) {


### PR DESCRIPTION
Two `.Interface().([]string)` sites in set.go were left behind when the package moved to `reflect.TypeAssert`. No behaviour change.

This pull request and its description were written by Isaac.