### PR TITLE
structaccess: two ForceSendFields fixes in Set

### DIFF
--- a/libs/structs/structaccess/set.go
+++ b/libs/structs/structaccess/set.go
@@ -140,9 +140,7 @@ func setStructField(parentVal reflect.Value, fieldName string, valueVal reflect.
 		return fmt.Errorf("field %q cannot be set", sf.Name)
 	}
 
-	// Assign first: a value that cannot be converted must leave the struct exactly as it was,
-	// and updating ForceSendFields before the assignment left the field's send-behaviour
-	// changed after a failed Set.
+	// Assign first: a value that cannot be converted must leave the struct exactly as it was.
 	converted, err := convertValue(valueVal, fv.Type())
 	if err != nil {
 		return err

--- a/libs/structs/structaccess/set.go
+++ b/libs/structs/structaccess/set.go
@@ -140,13 +140,15 @@ func setStructField(parentVal reflect.Value, fieldName string, valueVal reflect.
 		return fmt.Errorf("field %q cannot be set", sf.Name)
 	}
 
-	// Handle ForceSendFields: remove if setting nil, add if setting empty value
-	err := updateForceSendFields(parentVal, sf.Name, embeddedIndex, valueVal, sf)
-	if err != nil {
+	// Assign first: a value that cannot be converted must leave the struct exactly as it was,
+	// and updating ForceSendFields before the assignment left the field's send-behaviour
+	// changed after a failed Set.
+	if err := assignValue(fv, valueVal); err != nil {
 		return err
 	}
 
-	return assignValue(fv, valueVal)
+	// Handle ForceSendFields: remove if setting nil, add if setting empty value
+	return updateForceSendFields(parentVal, sf.Name, embeddedIndex, valueVal, sf)
 }
 
 // setMapValue sets a value in a map

--- a/libs/structs/structaccess/set.go
+++ b/libs/structs/structaccess/set.go
@@ -143,12 +143,23 @@ func setStructField(parentVal reflect.Value, fieldName string, valueVal reflect.
 	// Assign first: a value that cannot be converted must leave the struct exactly as it was,
 	// and updating ForceSendFields before the assignment left the field's send-behaviour
 	// changed after a failed Set.
-	if err := assignValue(fv, valueVal); err != nil {
+	converted, err := convertValue(valueVal, fv.Type())
+	if err != nil {
+		return err
+	}
+	if err := assignValue(fv, converted); err != nil {
 		return err
 	}
 
-	// Handle ForceSendFields: remove if setting nil, add if setting empty value
-	return updateForceSendFields(parentVal, sf.Name, embeddedIndex, valueVal, sf)
+	// ForceSendFields is decided from the converted value, not the caller's: setting an
+	// omitempty int64 from the string "0" stores 0, which is empty and must be forced, while
+	// the string "0" is not empty and would have left the field to be omitted.
+	if !valueVal.IsValid() {
+		// Setting nil: the field is being made absent, which convertValue renders as the zero
+		// value. Pass the invalid value through so it is removed from ForceSendFields.
+		return updateForceSendFields(parentVal, sf.Name, embeddedIndex, valueVal, sf)
+	}
+	return updateForceSendFields(parentVal, sf.Name, embeddedIndex, converted, sf)
 }
 
 // setMapValue sets a value in a map

--- a/libs/structs/structaccess/set_test.go
+++ b/libs/structs/structaccess/set_test.go
@@ -1,6 +1,7 @@
 package structaccess_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/databricks/cli/libs/structs/structaccess"
@@ -799,4 +800,19 @@ func TestSet_FailedConversionLeavesForceSendFields(t *testing.T) {
 	require.Error(t, structaccess.SetByString(job, "max_concurrent_runs", ""))
 	assert.Empty(t, job.ForceSendFields)
 	assert.Equal(t, "n", job.Name)
+}
+
+// ForceSendFields is decided from the value actually stored, not the one the caller passed:
+// setting an omitempty numeric field from the string "0" stores zero, which has to be forced
+// or the field marshals as absent.
+func TestSet_StringZeroIntoOmitemptyNumberIsForced(t *testing.T) {
+	job := &jobs.JobSettings{Name: "n"} //exhaustruct:ignore
+
+	require.NoError(t, structaccess.SetByString(job, "max_concurrent_runs", "0"))
+	assert.Equal(t, 0, job.MaxConcurrentRuns)
+	assert.Contains(t, job.ForceSendFields, "MaxConcurrentRuns")
+
+	blob, err := json.Marshal(job)
+	require.NoError(t, err)
+	assert.Contains(t, string(blob), `"max_concurrent_runs":0`)
 }

--- a/libs/structs/structaccess/set_test.go
+++ b/libs/structs/structaccess/set_test.go
@@ -791,3 +791,12 @@ func TestSet_MixedForceSendFields(t *testing.T) {
 		assert.Equal(t, []string{"SecondFieldOmit"}, obj.Second.ForceSendFields) // no duplicates
 	})
 }
+
+// A value that cannot be converted must leave the struct untouched, ForceSendFields included.
+func TestSet_FailedConversionLeavesForceSendFields(t *testing.T) {
+	job := &jobs.JobSettings{Name: "n"} //exhaustruct:ignore
+
+	require.Error(t, structaccess.SetByString(job, "max_concurrent_runs", ""))
+	assert.Empty(t, job.ForceSendFields)
+	assert.Equal(t, "n", job.Name)
+}


### PR DESCRIPTION
Two independent bugs in `Set`:

- ForceSendFields was updated *before* the assignment, so a value that could not be converted left the field's send-behaviour changed even though the Set failed. Setting an omitempty numeric field to `""` recorded it as force-send and then failed.
- Emptiness was judged from the caller's value, not the converted one, so an omitempty number set from the string `"0"` was stored as zero and left out of ForceSendFields — marshalled as absent. Latent today, since no value library writes a number as a quoted string.

Both tests fail without the fix.

This pull request and its description were written by Isaac.