### PR TITLE
Deprecate setup-local --constraints-only in favour of --no-dbconnect

### DIFF
--- a/.nextchanges/cli/setup-local-deprecate-constraints-only.md
+++ b/.nextchanges/cli/setup-local-deprecate-constraints-only.md
@@ -1,0 +1,1 @@
+* Deprecated the `databricks environments setup-local --constraints-only` flag in favour of the orthogonal `--no-dbconnect`; the flag still works as a hidden alias but is hidden from `--help` and prints a one-line deprecation notice, and will be removed in a later release. ([#6470](https://github.com/databricks/cli/pull/6470))

--- a/acceptance/localenv/constraints-only-existing/output.txt
+++ b/acceptance/localenv/constraints-only-existing/output.txt
@@ -1,5 +1,6 @@
 
 >>> [CLI] environments setup-local --serverless-version 4 --constraints-only --dry-run --output json
+Flag --constraints-only has been deprecated, use --no-dbconnect instead
 {
   "schemaVersion": 1,
   "command": "environments setup-local",

--- a/acceptance/localenv/constraints-only/output.txt
+++ b/acceptance/localenv/constraints-only/output.txt
@@ -1,5 +1,6 @@
 
 >>> [CLI] environments setup-local --serverless-version 4 --constraints-only --dry-run --output json
+Flag --constraints-only has been deprecated, use --no-dbconnect instead
 {
   "schemaVersion": 1,
   "command": "environments setup-local",

--- a/acceptance/localenv/help/output.txt
+++ b/acceptance/localenv/help/output.txt
@@ -18,7 +18,6 @@ Examples:
 Flags:
       --cluster-id string           cluster ID to use as the compute target
       --cluster-name string         cluster name to use as the compute target (resolved to an ID via the Clusters API)
-      --constraints-only            apply the Python version and constraints without adding the databricks-connect dependency
       --dry-run                     compute the plan without writing files or provisioning
   -h, --help                        help for setup-local
       --job-task string             job task to use as the compute target, as <job-id>.<task-key> (the task key is required)

--- a/cmd/environments/sync.go
+++ b/cmd/environments/sync.go
@@ -60,6 +60,11 @@ func addComputeFlags(cmd *cobra.Command) {
 	cmd.Flags().String("serverless-version", "", "serverless version to use as the compute target (e.g. 5)")
 	cmd.Flags().String("job-task", "", "job task to use as the compute target, as <job-id>.<task-key> (the task key is required)")
 	cmd.Flags().Bool("constraints-only", false, "apply the Python version and constraints without adding the databricks-connect dependency")
+	// --constraints-only is superseded by the orthogonal --no-dbconnect (identical
+	// behaviour). Keep it defined so existing scripts and CI keep working, but hide
+	// it from --help and emit a one-line deprecation notice on stderr when it is
+	// used. MarkDeprecated does both; removal is a separate, later step.
+	cmd.Flags().MarkDeprecated("constraints-only", "use --no-dbconnect instead")
 	// The negative flags (--no-constraints, --no-dbconnect) are orthogonal and
 	// compose. --no-dbconnect and the older --constraints-only are equivalent (both
 	// skip the databricks-connect dependency).

--- a/cmd/environments/sync_test.go
+++ b/cmd/environments/sync_test.go
@@ -1,0 +1,21 @@
+package environments
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSetupLocalConstraintsOnlyDeprecated pins --constraints-only as a hidden,
+// deprecated alias for --no-dbconnect: the flag is kept defined so scripts and CI
+// that already pass it keep working, but it is hidden from --help and pflag prints
+// a one-line deprecation notice pointing at --no-dbconnect when it is used.
+func TestSetupLocalConstraintsOnlyDeprecated(t *testing.T) {
+	cmd := newSetupLocalCommand()
+
+	f := cmd.Flags().Lookup("constraints-only")
+	require.NotNil(t, f, "--constraints-only must remain defined for backward compatibility")
+	assert.True(t, f.Hidden, "--constraints-only should be hidden from --help")
+	assert.Equal(t, "use --no-dbconnect instead", f.Deprecated, "--constraints-only should carry the deprecation notice")
+}


### PR DESCRIPTION
## Why

`databricks environments setup-local` now offers the orthogonal `--no-dbconnect`
flag, which skips the databricks-connect dependency with behaviour identical to
the older `--constraints-only`. Two visible spellings for one behaviour is
confusing, but `--constraints-only` may already live in users' scripts and CI,
so it can't just be removed.

Stacked on #6464 (which introduced `--no-dbconnect`).

## What

Mark `--constraints-only` deprecated with cobra's `MarkDeprecated`, which:

- hides it from `--help`, and
- prints a one-line stderr notice — `Flag --constraints-only has been deprecated,
  use --no-dbconnect instead` — once per run when the flag is used.

The flag stays defined and its behaviour is unchanged, so existing callers keep
working. This matches the repo's existing deprecation pattern (`--compute-id` →
`--cluster-id`, and the aitools `--global`/`--project` flags). Actual removal is
left as a separate, later step.

## Backward compatibility

- Default runs are byte-for-byte unchanged.
- `--constraints-only` still works identically; the only new output is a stderr
  line, so `--output json` consumers (whose contract is stdout) are unaffected —
  `schemaVersion` stays `1`.

## Testing

- **Unit** (`cmd/environments`): a new test asserts `--constraints-only` stays
  defined but is `Hidden` and carries the `use --no-dbconnect instead`
  deprecation message.
- **Acceptance** (`acceptance/localenv`): regenerated goldens — `--constraints-only`
  dropped from the `help` listing; the `constraints-only` and
  `constraints-only-existing` runs now show the stderr deprecation line with
  stdout JSON unchanged.
- `gofmt`, `go vet ./cmd/environments`, `go test ./cmd/environments`, and
  `go build ./...` all clean.

This pull request and its description were written by Isaac.
