### PR TITLE
Fix pipelines event filtering on event_type

### DIFF
--- a/.nextchanges/cli/pipelines-event-type-filter.md
+++ b/.nextchanges/cli/pipelines-event-type-filter.md
@@ -1,0 +1,1 @@
+Fixed `pipelines run` returning a non-zero exit code on successful runs and the `pipelines logs --event-type` filter being unusable, both caused by filtering pipeline events on the unsupported `event_type` field. Events are now filtered by type client-side.

--- a/cmd/pipelines/logs.go
+++ b/cmd/pipelines/logs.go
@@ -24,7 +24,9 @@ func buildFieldFilter(field string, values []string) string {
 }
 
 // buildPipelineEventFilter constructs a SQL filter string for pipeline events based on the provided parameters.
-func buildPipelineEventFilter(updateId string, levels, eventTypes []string, startTime, endTime string) string {
+// event_type is intentionally not included: the pipeline events API only supports
+// filtering on level, id, and timestamp, so events are filtered by type client-side.
+func buildPipelineEventFilter(updateId string, levels []string, startTime, endTime string) string {
 	var filterParts []string
 
 	if updateId != "" {
@@ -33,10 +35,6 @@ func buildPipelineEventFilter(updateId string, levels, eventTypes []string, star
 
 	if levelFilter := buildFieldFilter("level", levels); levelFilter != "" {
 		filterParts = append(filterParts, levelFilter)
-	}
-
-	if typeFilter := buildFieldFilter("event_type", eventTypes); typeFilter != "" {
-		filterParts = append(filterParts, typeFilter)
 	}
 
 	if startTime != "" {
@@ -123,7 +121,7 @@ Example usage:
 			}
 		}
 
-		filter := buildPipelineEventFilter(updateId, levels, eventTypes, startTime, endTime)
+		filter := buildPipelineEventFilter(updateId, levels, startTime, endTime)
 
 		params := &PipelineEventsQueryParams{
 			Filter:  filter,
@@ -139,6 +137,9 @@ Example usage:
 		if err != nil {
 			return fmt.Errorf("failed to fetch events for pipeline %s with update ID %s: %w", pipelineId, updateId, err)
 		}
+
+		// event_type is not filterable server-side, so filter by type here.
+		events = filterEventsByType(events, eventTypes)
 
 		return cmdio.Render(ctx, events)
 	}

--- a/cmd/pipelines/logs_test.go
+++ b/cmd/pipelines/logs_test.go
@@ -49,13 +49,12 @@ func TestBuildFieldFilter(t *testing.T) {
 
 func TestBuildPipelineEventFilter(t *testing.T) {
 	tests := []struct {
-		name       string
-		updateId   string
-		levels     []string
-		eventTypes []string
-		startTime  string
-		endTime    string
-		expected   string
+		name      string
+		updateId  string
+		levels    []string
+		startTime string
+		endTime   string
+		expected  string
 	}{
 		{
 			name:     "no filters",
@@ -67,43 +66,33 @@ func TestBuildPipelineEventFilter(t *testing.T) {
 			expected: "update_id = 'update-1'",
 		},
 		{
-			name:       "multiple filters",
-			updateId:   "update-1",
-			levels:     []string{"ERROR", "METRICS"},
-			eventTypes: []string{"update_progress"},
-			expected:   "update_id = 'update-1' AND level in ('ERROR', 'METRICS') AND event_type in ('update_progress')",
+			name:     "update id and levels",
+			updateId: "update-1",
+			levels:   []string{"ERROR", "METRICS"},
+			expected: "update_id = 'update-1' AND level in ('ERROR', 'METRICS')",
 		},
 		{
-			name:       "event types with multiple values",
-			updateId:   "update-2",
-			levels:     []string{"INFO"},
-			eventTypes: []string{"update_progress", "flow_progress"},
-			expected:   "update_id = 'update-2' AND level in ('INFO') AND event_type in ('update_progress', 'flow_progress')",
+			name:      "start time only",
+			updateId:  "",
+			levels:    []string{},
+			startTime: "2025-01-15T10:30:00Z",
+			expected:  "timestamp >= '2025-01-15T10:30:00Z'",
 		},
 		{
-			name:       "start time only",
-			updateId:   "",
-			levels:     []string{},
-			eventTypes: []string{},
-			startTime:  "2025-01-15T10:30:00Z",
-			expected:   "timestamp >= '2025-01-15T10:30:00Z'",
-		},
-		{
-			name:       "start time and end time",
-			updateId:   "update-3",
-			levels:     []string{"ERROR"},
-			eventTypes: []string{},
-			startTime:  "2025-01-15T10:30:00Z",
-			endTime:    "2025-01-15T11:30:00Z",
-			expected:   "update_id = 'update-3' AND level in ('ERROR') AND timestamp >= '2025-01-15T10:30:00Z' AND timestamp <= '2025-01-15T11:30:00Z'",
+			name:      "start time and end time",
+			updateId:  "update-3",
+			levels:    []string{"ERROR"},
+			startTime: "2025-01-15T10:30:00Z",
+			endTime:   "2025-01-15T11:30:00Z",
+			expected:  "update_id = 'update-3' AND level in ('ERROR') AND timestamp >= '2025-01-15T10:30:00Z' AND timestamp <= '2025-01-15T11:30:00Z'",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := buildPipelineEventFilter(tt.updateId, tt.levels, tt.eventTypes, tt.startTime, tt.endTime)
+			result := buildPipelineEventFilter(tt.updateId, tt.levels, tt.startTime, tt.endTime)
 			if result != tt.expected {
-				t.Errorf("buildPipelineEventFilter(%q, %v, %v, %q, %q) = %q, want %q", tt.updateId, tt.levels, tt.eventTypes, tt.startTime, tt.endTime, result, tt.expected)
+				t.Errorf("buildPipelineEventFilter(%q, %v, %q, %q) = %q, want %q", tt.updateId, tt.levels, tt.startTime, tt.endTime, result, tt.expected)
 			}
 		})
 	}

--- a/cmd/pipelines/run.go
+++ b/cmd/pipelines/run.go
@@ -180,14 +180,19 @@ func fetchAndDisplayPipelineUpdate(ctx context.Context, w *databricks.WorkspaceC
 	latestUpdate := *getUpdateResponse.Update
 
 	params := &PipelineEventsQueryParams{
-		Filter:  fmt.Sprintf("update_id='%s' AND event_type='update_progress'", updateId),
-		OrderBy: "timestamp asc",
+		Filter:     fmt.Sprintf("update_id='%s'", updateId),
+		MaxResults: maxResultsPerPage,
+		OrderBy:    "timestamp asc",
 	}
 
 	events, err := fetchAllPipelineEvents(ctx, w, pipelineId, params)
 	if err != nil {
 		return err
 	}
+
+	// event_type is not filterable server-side, so keep only the update_progress
+	// events (the ones enrichEvents/phaseFromUpdateProgress expect) client-side.
+	events = filterEventsByType(events, []string{"update_progress"})
 
 	err = displayPipelineUpdate(ctx, latestUpdate, pipelineId, events)
 	if err != nil {

--- a/cmd/pipelines/utils.go
+++ b/cmd/pipelines/utils.go
@@ -153,11 +153,35 @@ type PipelineEventsQueryParams struct {
 	OrderBy    string `json:"order_by,omitempty"`
 }
 
+const maxResultsPerPage = 250
+
+// filterEventsByType returns only the events whose EventType is one of eventTypes.
+// The pipeline events API does not support filtering on event_type server-side
+// (only level, id, and timestamp are filterable), so type filtering happens here.
+// When eventTypes is empty the events are returned unchanged.
+func filterEventsByType(events []pipelines.PipelineEvent, eventTypes []string) []pipelines.PipelineEvent {
+	if len(eventTypes) == 0 {
+		return events
+	}
+
+	wanted := make(map[string]struct{}, len(eventTypes))
+	for _, t := range eventTypes {
+		wanted[t] = struct{}{}
+	}
+
+	filtered := make([]pipelines.PipelineEvent, 0, len(events))
+	for _, e := range events {
+		if _, ok := wanted[e.EventType]; ok {
+			filtered = append(filtered, e)
+		}
+	}
+	return filtered
+}
+
 // fetchAllPipelineEvents retrieves pipeline events with optional SQL filtering and ordering.
 // Necessary as current Go SDK endpoints don't support OrderBy parameter.
 // Retrieves only one page of results, so the number of results is bound by the API's limit of results per page.
 func fetchAllPipelineEvents(ctx context.Context, w *databricks.WorkspaceClient, pipelineID string, params *PipelineEventsQueryParams) ([]pipelines.PipelineEvent, error) {
-	maxResultsPerPage := 250
 	if params.MaxResults > maxResultsPerPage {
 		return nil, fmt.Errorf("number of results must be %d or less", maxResultsPerPage)
 	}

--- a/cmd/pipelines/utils_test.go
+++ b/cmd/pipelines/utils_test.go
@@ -1,0 +1,55 @@
+package pipelines
+
+import (
+	"testing"
+
+	"github.com/databricks/databricks-sdk-go/service/pipelines"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFilterEventsByType(t *testing.T) {
+	events := []pipelines.PipelineEvent{
+		{EventType: "update_progress", Message: "a"},
+		{EventType: "flow_progress", Message: "b"},
+		{EventType: "update_progress", Message: "c"},
+		{EventType: "maintenance_progress", Message: "d"},
+	}
+
+	tests := []struct {
+		name       string
+		eventTypes []string
+		wantMsgs   []string
+	}{
+		{
+			name:       "no types returns all events unchanged",
+			eventTypes: nil,
+			wantMsgs:   []string{"a", "b", "c", "d"},
+		},
+		{
+			name:       "single type",
+			eventTypes: []string{"update_progress"},
+			wantMsgs:   []string{"a", "c"},
+		},
+		{
+			name:       "multiple types preserve order",
+			eventTypes: []string{"flow_progress", "maintenance_progress"},
+			wantMsgs:   []string{"b", "d"},
+		},
+		{
+			name:       "unmatched type yields no events",
+			eventTypes: []string{"does_not_exist"},
+			wantMsgs:   []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := filterEventsByType(events, tt.eventTypes)
+			msgs := []string{}
+			for _, e := range got {
+				msgs = append(msgs, e.Message)
+			}
+			assert.Equal(t, tt.wantMsgs, msgs)
+		})
+	}
+}


### PR DESCRIPTION
## Changes
The events API (`ListPipelineEvents`) only allows filtering on `timestamp`, `id`, `update_id`, and `level` — not `event_type`. Two paths filtered on `event_type` and always errored:

- **`pipelines run`** sent `event_type='update_progress'` → failed with `Operation '=' not allowed on 'event_type'`, returning a **non-zero exit code even on successful runs** and dropping the per-phase duration summary.
- **`pipelines logs --event-type …`** sent `event_type in (…)` → `Operation 'IN' not allowed`, so the flag never worked.

Fix: don't send `event_type` server-side; filter events by type **client-side** after fetching (shared `filterEventsByType` helper). Accepted filters (`update_id`, `level`, `timestamp`) are unchanged.

## Why
Each event carries an `event_type` field, so it looked filterable and was wired in like `--level`. It isn't a valid filter column, and acceptance tests mock the endpoint (accepting any filter), so it went unnoticed.

## Verified on a live workspace
`event_type='…'`, `in (…)`, `LIKE`, `!=` all → 400; the same request without `event_type` → 200. The API confirms its filterable columns are `timestamp, id, update_id, level`.

## Open question
`--event-type` was broken because it relied on unsupported server-side filtering. I kept it and made it work client-side. If you'd rather drop the flag, happy to do that instead.

## Tests
New `TestFilterEventsByType` (also exercised on real API events); updated `TestBuildPipelineEventFilter`; `go test ./cmd/pipelines/`, `run-info` acceptance, `gofmt`, `go vet` pass.

This pull request and its description were written by Isaac.
