### PR TITLE
Add IDE team as aitools owner

### DIFF
--- a/.github/OWNERS
+++ b/.github/OWNERS
@@ -70,8 +70,8 @@
 /internal/                  team:platform
 
 # AI tools
-/cmd/aitools/               team:eng-apps-devex team:platform @lennartkats-db
-/libs/aitools/              team:eng-apps-devex team:platform @lennartkats-db
+/cmd/aitools/               team:eng-apps-devex team:platform team:ide @lennartkats-db
+/libs/aitools/              team:eng-apps-devex team:platform team:ide @lennartkats-db
 
 # CLI compatibility manifest
 /internal/build/cli-compat.json  team:eng-apps-devex team:platform


### PR DESCRIPTION
## Changes
Add `team:ide` as `aitools` owners

## Why
We will be working in this area

## Tests
N/A

<!-- If your PR needs to be included in the release notes for next release,
add a changelog fragment: create .nextchanges/<section>/<name>.md with a
one-line description (e.g. .nextchanges/cli/quickstart.md). See .nextchanges/README.md. -->
