### PR TITLE
automigration: run plan on migrated state before committing

### DIFF
--- a/.nextchanges/bundles/automigration-plan-check.md
+++ b/.nextchanges/bundles/automigration-plan-check.md
@@ -1,0 +1,1 @@
+Before committing the automatic terraform→direct state migration, run a full deployment plan against the converted state. If the plan fails, the migration is abandoned and the bundle stays on terraform; `direct_migrate_plan_error` is recorded in telemetry.

--- a/.nextchanges/bundles/automigration-plan-check.md
+++ b/.nextchanges/bundles/automigration-plan-check.md
@@ -1,1 +1,1 @@
-Before committing the automatic terraform→direct state migration, run a full deployment plan against the converted state. If the plan fails, the migration is abandoned and the bundle stays on terraform; `direct_migrate_plan_error` is recorded in telemetry.
+Before committing the automatic terraform→direct migration, run a deployment plan against the converted state; if the plan fails the migration is abandoned.

--- a/acceptance/bundle/migrate/auto-migrate-plan-failure/databricks.yml
+++ b/acceptance/bundle/migrate/auto-migrate-plan-failure/databricks.yml
@@ -1,0 +1,7 @@
+bundle:
+  name: test-bundle
+
+resources:
+  jobs:
+    test_job:
+      name: "Test Auto-Migrate Plan Failure"

--- a/acceptance/bundle/migrate/auto-migrate-plan-failure/out.test.toml
+++ b/acceptance/bundle/migrate/auto-migrate-plan-failure/out.test.toml
@@ -1,0 +1,3 @@
+Cloud = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]
+EnvMatrix.DMS = [""]

--- a/acceptance/bundle/migrate/auto-migrate-plan-failure/output.txt
+++ b/acceptance/bundle/migrate/auto-migrate-plan-failure/output.txt
@@ -24,7 +24,7 @@ Warn: post-deploy dry-run migration to direct: planning failed
 Warn: The warnings above are from a dry-run migration to the direct deployment engine (https://docs.databricks.com/aws/en/dev-tools/bundles/direct).
 Your deployment is not affected and works normally, but you may experience these issues when migrating to the direct deployment engine.
 Please forward these warnings to dabs-feedback@databricks.com
-Warn: Direct engine was selected but the dry-run migration reported issues; automatic migration to the direct deployment engine is stopped. Address the issues above or run "databricks bundle deployment migrate" manually.
+Warn: Direct engine was selected but the migration reported issues; automatic migration to the direct deployment engine is stopped. Address the issues above or run "databricks bundle deployment migrate" manually.
 
 >>> print_migration_telemetry
 direct_migrate_plan_error true

--- a/acceptance/bundle/migrate/auto-migrate-plan-failure/output.txt
+++ b/acceptance/bundle/migrate/auto-migrate-plan-failure/output.txt
@@ -1,0 +1,55 @@
+
+=== Initial deploy on terraform
+>>> DATABRICKS_BUNDLE_ENGINE=terraform [CLI] bundle deploy
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files...
+Created jobs.test_job
+Files: 4 uploaded, 0 deleted
+Resources: 1 created, 0 changed, 0 deleted, 0 unchanged
+
+>>> print_migration_telemetry
+direct_drymigrate_success true
+direct_drymigrate_warnings false
+
+=== Inject GET failure so the plan check blocks the migration
+>>> DATABRICKS_BUNDLE_ENGINE=direct [CLI] bundle deploy
+Warn: Direct engine selected via DATABRICKS_BUNDLE_ENGINE environment variable but the existing state uses "terraform". Deploying on "terraform"; will attempt to migrate the state to the direct engine after this deploy.
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files...
+Files: 2 uploaded, 0 deleted
+Resources: 0 created, 0 changed, 0 deleted, 1 unchanged
+Warn: post-deploy dry-run migration to direct: cannot plan resources.jobs.test_job: reading id="[NUMID]": Fault injected by test. (403 INJECTED): Endpoint: GET [DATABRICKS_URL]/api/2.2/jobs/get?job_id=[NUMID]
+HTTP Status: 403 Forbidden
+API error_code: INJECTED
+API message: Fault injected by test.
+Warn: post-deploy dry-run migration to direct: planning failed
+Warn: The warnings above are from a dry-run migration to the direct deployment engine (https://docs.databricks.com/aws/en/dev-tools/bundles/direct).
+Your deployment is not affected and works normally, but you may experience these issues when migrating to the direct deployment engine.
+Please forward these warnings to dabs-feedback@databricks.com
+Warn: Direct engine was selected but the dry-run migration reported issues; automatic migration to the direct deployment engine is stopped. Address the issues above or run "databricks bundle deployment migrate" manually.
+
+>>> print_migration_telemetry
+direct_migrate_plan_error true
+
+=== Local state was NOT rewritten (still terraform)
+>>> find .databricks/bundle -name resources.json -type f
+
+>>> find .databricks/bundle -name terraform.tfstate* -type f
+.databricks/bundle/default/terraform/terraform.tfstate
+
+=== Retry: plan check passes this time, migration succeeds
+>>> DATABRICKS_BUNDLE_ENGINE=direct [CLI] bundle deploy
+Warn: Direct engine selected via DATABRICKS_BUNDLE_ENGINE environment variable but the existing state uses "terraform". Deploying on "terraform"; will attempt to migrate the state to the direct engine after this deploy.
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files...
+Files: 2 uploaded, 0 deleted
+Resources: 0 created, 0 changed, 0 deleted, 1 unchanged
+Migrating state to direct deployment engine (selected via DATABRICKS_BUNDLE_ENGINE environment variable)...
+Migrated 1 resource to direct deployment engine.
+
+>>> print_migration_telemetry
+direct_migrated_via_env true
+
+=== Local state is now direct
+>>> find .databricks/bundle -name resources.json -type f
+.databricks/bundle/default/resources.json
+
+>>> find .databricks/bundle -name terraform.tfstate* -type f
+.databricks/bundle/default/terraform/terraform.tfstate.backup

--- a/acceptance/bundle/migrate/auto-migrate-plan-failure/script
+++ b/acceptance/bundle/migrate/auto-migrate-plan-failure/script
@@ -1,0 +1,32 @@
+export DATABRICKS_BUNDLE_ENGINE=
+
+title "Initial deploy on terraform"
+trace DATABRICKS_BUNDLE_ENGINE=terraform $CLI bundle deploy
+trace print_migration_telemetry
+rm -f out.requests.txt
+
+title "Inject GET failure so the plan check blocks the migration"
+# The plan check calls GET /api/2.2/jobs/get for each resource to compare
+# local config against remote state. A 403 (non-retryable) causes the plan
+# to fail → the migration is abandoned and the bundle stays on terraform.
+# OFFSET=1: terraform reads the job once during its plan phase; skip that
+# call and fail the 2nd one, which is the plan check's DoRead.
+fault.py "GET /api/2.2/jobs/get*" 403 1 1
+trace DATABRICKS_BUNDLE_ENGINE=direct $CLI bundle deploy
+trace print_migration_telemetry
+rm -f out.requests.txt
+
+title "Local state was NOT rewritten (still terraform)"
+trace find .databricks/bundle -name "resources.json" -type f
+trace find .databricks/bundle -name "terraform.tfstate*" -type f
+
+title "Retry: plan check passes this time, migration succeeds"
+trace DATABRICKS_BUNDLE_ENGINE=direct $CLI bundle deploy
+trace print_migration_telemetry
+rm -f out.requests.txt
+
+title "Local state is now direct"
+trace find .databricks/bundle -name "resources.json" -type f
+trace find .databricks/bundle -name "terraform.tfstate*" -type f
+
+rm -f out.requests.txt

--- a/bundle/metrics/metrics.go
+++ b/bundle/metrics/metrics.go
@@ -31,6 +31,8 @@ const (
 	DirectMigrateError       = "direct_migrate_error"
 	DirectMigrateCommitError = "direct_migrate_commit_error"
 	DirectMigrateWarnings    = "direct_migrate_warnings"
+	// True when the post-convert plan check failed; the migration was not committed.
+	DirectMigratePlanError = "direct_migrate_plan_error"
 
 	// Recorded when an automatic post-deploy migration to the direct engine
 	// actually ran (state was rewritten). Exactly one of the three keys is true;

--- a/bundle/statemgmt/direct_migration.go
+++ b/bundle/statemgmt/direct_migration.go
@@ -176,13 +176,8 @@ func checkPlanOnTempState(ctx context.Context, b *bundle.Bundle, tempStatePath s
 		return fmt.Errorf("opening migrated state for plan check: %w", err)
 	}
 
-	if _, err := planBundle.CalculatePlan(planCtx, b.WorkspaceClient(ctx), cfg); err != nil {
-		return err
-	}
-	if logdiag.HasError(planCtx) {
-		return errors.New("plan check failed")
-	}
-	return nil
+	_, err := planBundle.CalculatePlan(planCtx, b.WorkspaceClient(ctx), cfg)
+	return err
 }
 
 // recordDryRunNoop records dry-run telemetry for a no-op case (no state, or

--- a/bundle/statemgmt/direct_migration.go
+++ b/bundle/statemgmt/direct_migration.go
@@ -14,6 +14,7 @@ import (
 	"github.com/databricks/cli/bundle/config/engine"
 	"github.com/databricks/cli/bundle/config/mutator/resourcemutator"
 	"github.com/databricks/cli/bundle/deploy"
+	"github.com/databricks/cli/bundle/direct"
 	"github.com/databricks/cli/bundle/direct/dresources"
 	"github.com/databricks/cli/bundle/direct/dstate"
 	"github.com/databricks/cli/bundle/metrics"
@@ -91,7 +92,7 @@ func MigrateToDirect(ctx context.Context, b *bundle.Bundle, requestedEngine engi
 		return
 	}
 
-	tempStatePath, resourceCount, hasWarnings, err := convertTFStateToDirect(ctx, b, tfState)
+	tempStatePath, resourceCount, hasWarnings, cfg, err := convertTFStateToDirect(ctx, b, tfState)
 	if tempStatePath != "" {
 		// The temp file sits next to the real resources.json path (same
 		// filesystem, so commitMigration's os.Rename works even when
@@ -133,6 +134,14 @@ func MigrateToDirect(ctx context.Context, b *bundle.Bundle, requestedEngine engi
 		return
 	}
 
+	if planErr := checkPlanOnTempState(ctx, b, tempStatePath, cfg); planErr != nil {
+		log.Warnf(ctx, "%s%v", warnPrefix, planErr)
+		log.Warnf(ctx, "%s", feedbackNotice)
+		b.Metrics.SetBoolValue(metrics.DirectMigratePlanError, true)
+		log.Warnf(ctx, "%s", autoMigrateStoppedNotice)
+		return
+	}
+
 	cmdio.LogString(ctx, "Migrating state to direct deployment engine (selected via "+requestedEngine.Source+")...")
 
 	if err := commitMigration(ctx, b, tempStatePath, resourceCount); err != nil {
@@ -142,6 +151,38 @@ func MigrateToDirect(ctx context.Context, b *bundle.Bundle, requestedEngine engi
 	}
 
 	recordAutoMigrateSource(b, requestedEngine)
+}
+
+// checkPlanOnTempState opens the migrated state at tempStatePath in read mode,
+// runs a full plan against it, and returns a non-nil error if the plan fails.
+// Individual planning errors are emitted as warnings with warnPrefix so they
+// are visible without failing the deploy. The plan is run in an isolated
+// context so its diagnostics do not affect the deploy's own error state.
+func checkPlanOnTempState(ctx context.Context, b *bundle.Bundle, tempStatePath string, cfg *config.Root) error {
+	planCtx := logdiag.IsolatedContext(ctx)
+	logdiag.SetCollect(planCtx, true)
+	defer func() {
+		for _, d := range logdiag.FlushCollected(planCtx) {
+			msg := d.Summary
+			if d.Detail != "" {
+				msg += ": " + d.Detail
+			}
+			log.Warnf(ctx, "%s%s", warnPrefix, msg)
+		}
+	}()
+
+	var planBundle direct.DeploymentBundle
+	if err := planBundle.StateDB.Open(planCtx, tempStatePath, false, false); err != nil {
+		return fmt.Errorf("opening migrated state for plan check: %w", err)
+	}
+
+	if _, err := planBundle.CalculatePlan(planCtx, b.WorkspaceClient(ctx), cfg); err != nil {
+		return err
+	}
+	if logdiag.HasError(planCtx) {
+		return errors.New("plan check failed")
+	}
+	return nil
 }
 
 // recordDryRunNoop records dry-run telemetry for a no-op case (no state, or
@@ -209,12 +250,13 @@ func backupTerraformState(ctx context.Context, b *bundle.Bundle) error {
 
 // convertTFStateToDirect converts the given terraform state to the direct engine state,
 // returning the path to the converted state file, the number of resources
-// migrated, and whether any warnings were emitted. Callers must ensure
-// tfState is non-nil and has at least one resource ID (the empty and nil
-// cases are handled by MigrateToDirect directly, since they take different
-// commit paths). The caller is responsible for deleting the temp state's
-// parent directory when it is done with the file.
-func convertTFStateToDirect(ctx context.Context, b *bundle.Bundle, tfState *migrate.TFState) (string, int, bool, error) {
+// migrated, whether any warnings were emitted, and the bundle config with
+// terraform interpolation reversed (needed by the caller to run a plan against
+// the converted state). Callers must ensure tfState is non-nil and has at least
+// one resource ID (the empty and nil cases are handled by MigrateToDirect
+// directly, since they take different commit paths). The caller is responsible
+// for deleting the temp state's parent directory when it is done with the file.
+func convertTFStateToDirect(ctx context.Context, b *bundle.Bundle, tfState *migrate.TFState) (string, int, bool, *config.Root, error) {
 	// Write the converted state to a sibling of the final resources.json
 	// path so commitMigration's os.Rename stays within one filesystem
 	// (os.TempDir() often lives on a different volume from the project;
@@ -265,7 +307,7 @@ func convertTFStateToDirect(ctx context.Context, b *bundle.Bundle, tfState *migr
 	// the migrated state and config agree on .permissions entries.
 	bundle.ApplyContext(ctx, b, resourcemutator.SecretScopeFixups(engine.EngineDirect))
 	if logdiag.HasError(ctx) {
-		return tempStatePath, resourceCount, false, errors.New("failed to apply secret scope fixups")
+		return tempStatePath, resourceCount, false, nil, errors.New("failed to apply secret scope fixups")
 	}
 
 	// b.Config has been modified by terraform.Interpolate which converts bundle-style
@@ -273,7 +315,7 @@ func convertTFStateToDirect(ctx context.Context, b *bundle.Bundle, tfState *migr
 	// BuildStateFromTF expects ${resources.*} references, so reverse the interpolation first.
 	uninterpolatedRoot, err := reverseInterpolate(b.Config.Value())
 	if err != nil {
-		return tempStatePath, resourceCount, false, fmt.Errorf("failed to reverse interpolation: %w", err)
+		return tempStatePath, resourceCount, false, nil, fmt.Errorf("failed to reverse interpolation: %w", err)
 	}
 
 	var uninterpolatedConfig config.Root
@@ -281,34 +323,34 @@ func convertTFStateToDirect(ctx context.Context, b *bundle.Bundle, tfState *migr
 		return uninterpolatedRoot, nil
 	})
 	if err != nil {
-		return tempStatePath, resourceCount, false, fmt.Errorf("failed to create uninterpolated config: %w", err)
+		return tempStatePath, resourceCount, false, nil, fmt.Errorf("failed to create uninterpolated config: %w", err)
 	}
 
 	adapters, err := dresources.InitAll(nil)
 	if err != nil {
-		return tempStatePath, resourceCount, false, err
+		return tempStatePath, resourceCount, false, nil, err
 	}
 
 	if err := stateDB.UpgradeToWrite(); err != nil {
-		return tempStatePath, resourceCount, false, fmt.Errorf("upgrading state for apply: %w", err)
+		return tempStatePath, resourceCount, false, nil, fmt.Errorf("upgrading state for apply: %w", err)
 	}
 
 	// warnPrefix labels the conversion's warnings as coming from the background dry run.
 	hasWarnings, err := migrate.BuildStateFromTF(ctx, &uninterpolatedConfig, adapters, &stateDB, tfState.Attrs, tfState.IDs, warnPrefix)
 	if err != nil {
-		return tempStatePath, resourceCount, hasWarnings, err
+		return tempStatePath, resourceCount, hasWarnings, nil, err
 	}
 
 	if _, err := stateDB.Finalize(ctx); err != nil {
-		return tempStatePath, resourceCount, hasWarnings, err
+		return tempStatePath, resourceCount, hasWarnings, nil, err
 	}
 
 	// BuildStateFromTF reports some failures via logdiag instead of returning an error.
 	if logdiag.HasError(ctx) {
-		return tempStatePath, resourceCount, hasWarnings, errors.New("state conversion failed")
+		return tempStatePath, resourceCount, hasWarnings, nil, errors.New("state conversion failed")
 	}
 
-	return tempStatePath, resourceCount, hasWarnings, nil
+	return tempStatePath, resourceCount, hasWarnings, &uninterpolatedConfig, nil
 }
 
 // commitMigration finalizes the dry-run migration by pushing the direct state

--- a/bundle/statemgmt/direct_migration.go
+++ b/bundle/statemgmt/direct_migration.go
@@ -39,7 +39,7 @@ Please forward these warnings to dabs-feedback@databricks.com`
 // autoMigrateStoppedNotice is emitted when the direct engine is selected but the
 // dry-run migration surfaced errors or warnings, so the automatic post-deploy
 // migration is skipped.
-const autoMigrateStoppedNotice = `Direct engine was selected but the dry-run migration reported issues; automatic migration to the direct deployment engine is stopped. Address the issues above or run "databricks bundle deployment migrate" manually.`
+const autoMigrateStoppedNotice = `Direct engine was selected but the migration reported issues; automatic migration to the direct deployment engine is stopped. Address the issues above or run "databricks bundle deployment migrate" manually.`
 
 // MigrateToDirect performs a dry-run migration of the just-deployed terraform
 // state to the direct engine and records the outcome in deploy telemetry.


### PR DESCRIPTION
## Why

To prevent automigration for bundles that cannot work on direct without changes to config, for example https://github.com/databricks/cli/issues/6480

## Changes

Run a full `bundle plan` against the converted state (written to a temp file) before committing the automatic terraform→direct migration.

If the plan fails — for example because a resource can't be read from the workspace — the migration is abandoned: the bundle stays on terraform, `direct_migrate_plan_error=true` is recorded in telemetry, and the user sees the planning errors as warnings.

The plan check only runs when the migration would be committed (direct engine selected). Pure dry-run post-deploy migrations (with `engine: terraform` setting) are not running the plan.