### PR TITLE
python: honor the $${...} escape in the variable regex

### DIFF
--- a/.github/workflows/python_push.yml
+++ b/.github/workflows/python_push.yml
@@ -1,14 +1,13 @@
 name: python build
 
 on:
+  # Not restricted to python/**: these tests also cover contracts shared with the Go
+  # code, such as libs/dyn/dynvar/testdata/reference_vectors.json, so a change outside
+  # python/ can break them.
   pull_request:
     types: [opened, synchronize]
-    paths:
-      - python/**
   merge_group:
     types: [checks_requested]
-    paths:
-      - python/**
   push:
     # Always run on push to main. The build cache can only be reused
     # if it was saved by a run from the repository's default branch.

--- a/python/databricks/bundles/core/_transform.py
+++ b/python/databricks/bundles/core/_transform.py
@@ -277,13 +277,17 @@ def _unwrap_variable(tpe: type) -> Optional[type]:
 # The source of truth is regex in libs/dyn/dynvar/ref.go.
 # Behavioral parity is enforced by libs/dyn/dynvar/testdata/reference_vectors.json.
 #
+# The (?<!\$) lookbehind skips references escaped by a preceding "$": "$${a.b}" is a
+# literal "${a.b}" for the Databricks runtime, not a bundle reference.
+#
 # Example:
 #   - "${a.b}"
 #   - "${a.b.c}"
 #   - "${a.b[0].c}"
 _base_var_def = r"_*[^\W\d_]+([-_]*[^\W_]+)*"
 _variable_regex = re.compile(
-    r"\$\{(%s(\.%s(\[[0-9]+\])*)*(\[[0-9]+\])*)\}" % (_base_var_def, _base_var_def)
+    r"(?<!\$)\$\{(%s(\.%s(\[[0-9]+\])*)*(\[[0-9]+\])*)\}"
+    % (_base_var_def, _base_var_def)
 )
 
 


### PR DESCRIPTION
Fixes the python build on main, broken by #6484.

That PR added escaped-reference vectors to the shared `reference_vectors.json` but only taught the Go regex to skip them, so `test_variable_reference_vectors.py` fails on main with 4 failures.

Also drops the `python/**` path filter from the workflow — that filter is why the break was invisible on #6484. The parity test is driven by a file under `libs/`, so a Go-side change can break it while the PR stays green.