### PR TITLE
genie_spaces: Stop allowing Sequence types for serialized_space

### DIFF
--- a/bundle/config/mutator/resourcemutator/configure_genie_space_serialized_space.go
+++ b/bundle/config/mutator/resourcemutator/configure_genie_space_serialized_space.go
@@ -65,7 +65,10 @@ func (c configureGenieSpaceSerializedSpace) Apply(_ context.Context, b *bundle.B
 				// KindInvalid means serialized_space is absent (neither it nor
 				// file_path is set); leave it for backend validation to reject.
 				return v, nil
-			case dyn.KindMap, dyn.KindSequence:
+			case dyn.KindMap:
+				// A top-level sequence would be valid JSON but is meaningless for a
+				// genie space, so KindSequence is not accepted here and falls through
+				// to the default rejection below.
 				jsonBytes, err := json.Marshal(ss.AsAny())
 				if err != nil {
 					return dyn.InvalidValue, fmt.Errorf("failed to marshal inline serialized_space: %w", err)
@@ -74,7 +77,7 @@ func (c configureGenieSpaceSerializedSpace) Apply(_ context.Context, b *bundle.B
 			default:
 				diags = diags.Append(diag.Diagnostic{
 					Severity:  diag.Error,
-					Summary:   fmt.Sprintf("serialized_space must be a string, map, or sequence, got %s", ss.Kind()),
+					Summary:   fmt.Sprintf("serialized_space must be a string or map, got %s", ss.Kind()),
 					Locations: ss.Locations(),
 				})
 				return v, nil

--- a/bundle/config/mutator/resourcemutator/configure_genie_space_serialized_space_test.go
+++ b/bundle/config/mutator/resourcemutator/configure_genie_space_serialized_space_test.go
@@ -70,7 +70,15 @@ func TestConfigureGenieSpaceSerializedSpace(t *testing.T) {
 			name:            "non-structured serialized_space is rejected",
 			setSerialized:   true,
 			serializedSpace: true,
-			wantErr:         "serialized_space must be a string, map, or sequence, got bool",
+			wantErr:         "serialized_space must be a string or map, got bool",
+		},
+		{
+			// A top-level sequence is valid JSON but meaningless for a genie space,
+			// so it is rejected rather than marshaled like an inline map.
+			name:            "inline sequence is rejected",
+			setSerialized:   true,
+			serializedSpace: []any{map[string]any{"version": 1}},
+			wantErr:         "serialized_space must be a string or map, got sequence",
 		},
 		{
 			name:     "unreadable file_path is an error",


### PR DESCRIPTION
## Changes
Stop allowing Sequence types for `serialized_space`

## Why
While these are valid JSON, they are meaningless and the genie API rejects them anyway

## Tests
Unit tests

The genie spaces backend doesn't accept arrays:
```
% databricks genie update-space <space-id> --serialized-space '[{}]'
Error: Invalid JSON in field 'serialized_space': Expected an object, not an array (line 1)
```