### PR TITLE
cluster_policies: Stop allowing Sequence types for value

### DIFF
--- a/bundle/config/mutator/resourcemutator/configure_cluster_policy_definition.go
+++ b/bundle/config/mutator/resourcemutator/configure_cluster_policy_definition.go
@@ -45,7 +45,7 @@ func (c configureClusterPolicyDefinition) Apply(_ context.Context, b *bundle.Bun
 				case dyn.KindInvalid, dyn.KindNil, dyn.KindString:
 					// KindInvalid means the field is absent; leave it for backend validation.
 					continue
-				case dyn.KindMap, dyn.KindSequence:
+				case dyn.KindMap:
 					jsonBytes, err := json.Marshal(def.AsAny())
 					if err != nil {
 						return dyn.InvalidValue, fmt.Errorf("failed to marshal inline %s: %w", field, err)
@@ -57,7 +57,7 @@ func (c configureClusterPolicyDefinition) Apply(_ context.Context, b *bundle.Bun
 				default:
 					diags = diags.Append(diag.Diagnostic{
 						Severity:  diag.Error,
-						Summary:   fmt.Sprintf("%s must be a string, map, or sequence, got %s", field, def.Kind()),
+						Summary:   fmt.Sprintf("%s must be a string or map, got %s", field, def.Kind()),
 						Locations: def.Locations(),
 					})
 				}

--- a/bundle/config/mutator/resourcemutator/configure_cluster_policy_definition_test.go
+++ b/bundle/config/mutator/resourcemutator/configure_cluster_policy_definition_test.go
@@ -27,10 +27,10 @@ func TestConfigureClusterPolicyDefinition(t *testing.T) {
 			want:  `{"spark_version":{"type":"fixed","value":"13.3.x"}}`,
 		},
 		{
-			name:  "definition: inline sequence is marshaled to a JSON string",
-			field: "definition",
-			value: []any{"a", "b"},
-			want:  `["a","b"]`,
+			name:    "definition: inline sequence is rejected",
+			field:   "definition",
+			value:   []any{"a", "b"},
+			wantErr: "definition must be a string or map, got sequence",
 		},
 		{
 			name:  "definition: inline string is left unchanged",
@@ -47,7 +47,7 @@ func TestConfigureClusterPolicyDefinition(t *testing.T) {
 			name:    "definition: non-structured is rejected",
 			field:   "definition",
 			value:   true,
-			wantErr: "definition must be a string, map, or sequence, got bool",
+			wantErr: "definition must be a string or map, got bool",
 		},
 		{
 			// Number stays a JSON number (30, not "30").
@@ -66,7 +66,7 @@ func TestConfigureClusterPolicyDefinition(t *testing.T) {
 			name:    "overrides: non-structured is rejected",
 			field:   "policy_family_definition_overrides",
 			value:   true,
-			wantErr: "policy_family_definition_overrides must be a string, map, or sequence, got bool",
+			wantErr: "policy_family_definition_overrides must be a string or map, got bool",
 		},
 	}
 


### PR DESCRIPTION
## Changes
Reject inline sequence (list) values for the cluster policy `definition` and `policy_family_definition_overrides` fields. Previously a top-level YAML sequence was marshaled to a JSON array string and sent to the backend as-is; it is now rejected during bundle validation with `<field> must be a string or map, got sequence`.

## Why
A cluster policy `definition` must be a JSON object (a map of attribute paths to constraint objects). A top-level sequence is valid JSON but never a valid policy, and the backend does **not** validate the definition shape at create time — so without this change the broken policy is accepted and the failure is deferred.

Concretely, for:

```yaml
resources:
  cluster_policies:
    my_policy:
      definition:
        - foo: bar
  jobs:
    my_job:
      ...
      policy_id: ${resources.cluster_policies.my_policy.id}
```

- **Before this PR:** `bundle deploy` **succeeds** — the backend accepts the array definition, returns a `policy_id`, and stores it verbatim (it is never marked invalid), and the job is created. The failure only appears **when the job runs**: launching the job cluster applies the policy, and the backend rejects it with `INVALID_PARAMETER_VALUE: Requests for the policy ... cannot be satisfied due to the malformed policy definition. Please contact your administrator to correct the policy definition.` — an error far from the bundle config that gives no hint the cause is the list under `definition`.
- **After this PR:** `bundle validate` / `bundle deploy` **fails immediately** with `definition must be a string or map, got sequence`, pointing straight at the offending config.

(Verified against the Azure backend and confirmed in the backend source: create-time validation only does field-presence `.has(...)` checks, which pass for an array; the array only fails later during enforcement in `ClusterPolicyDefinition.fromJson`.)

## Tests
Unit tests.

This pull request and its description were written by Isaac.
