### PR TITLE
Optimize AIR snapshot git queries

### DIFF
--- a/experimental/air/cmd/runsubmit_test.go
+++ b/experimental/air/cmd/runsubmit_test.go
@@ -2,7 +2,7 @@ package aircmd
 
 import (
 	"encoding/json"
-	"io"
+	"io/fs"
 	"path"
 	"path/filepath"
 	"strings"
@@ -455,9 +455,10 @@ code_source:
 	assert.Len(t, uploaded, 1, "git_archive cache hit should skip the second upload")
 }
 
-// A code source uploads provenance sidecars (git_state.json and git_diff.patch
-// when the tree is dirty) next to the run's launch directory.
-func TestSubmitWorkloadUploadsProvenanceSidecars(t *testing.T) {
+// When enabled, a code source uploads provenance sidecars (git_state.json and
+// git_diff.patch when the tree is dirty) next to the run's launch directory.
+// This path is paused to avoid dirty-state query and WSFS write latency.
+func TestSubmitWorkloadSkipsProvenanceSidecars(t *testing.T) {
 	server := testserver.New(t)
 	t.Cleanup(server.Close)
 
@@ -490,25 +491,13 @@ code_source:
 	snap, err := snapshotViaDABsUpload(ctx, w, loaded.CodeSource.Snapshot, cfgPath, sidecarStore, sidecarBase)
 	require.NoError(t, err)
 
-	assert.Equal(t, path.Join(sidecarBase, gitStateName), snap.GitStatePath)
-	assert.Equal(t, path.Join(sidecarBase, gitDiffName), snap.GitDiffPath)
+	assert.Empty(t, snap.GitStatePath)
+	assert.Empty(t, snap.GitDiffPath)
 
-	stateReader, err := sidecarStore.Read(ctx, gitStateName)
-	require.NoError(t, err)
-	defer stateReader.Close()
-	stateBytes, err := io.ReadAll(stateReader)
-	require.NoError(t, err)
-	var state gitStateSidecar
-	require.NoError(t, json.Unmarshal(stateBytes, &state))
-	assert.True(t, state.Dirty)
-	assert.Equal(t, diffStatusCaptured, state.DiffStatus)
-
-	diffReader, err := sidecarStore.Read(ctx, gitDiffName)
-	require.NoError(t, err)
-	defer diffReader.Close()
-	diffBytes, err := io.ReadAll(diffReader)
-	require.NoError(t, err)
-	assert.Contains(t, string(diffBytes), "train.py")
+	_, err = sidecarStore.Read(ctx, gitStateName)
+	assert.ErrorIs(t, err, fs.ErrNotExist)
+	_, err = sidecarStore.Read(ctx, gitDiffName)
+	assert.ErrorIs(t, err, fs.ErrNotExist)
 }
 
 // remote_volume uploads the snapshot to a UC Volume: DABs' artifact uploader handles

--- a/experimental/air/cmd/runsubmit_test.go
+++ b/experimental/air/cmd/runsubmit_test.go
@@ -2,7 +2,7 @@ package aircmd
 
 import (
 	"encoding/json"
-	"io/fs"
+	"io"
 	"path"
 	"path/filepath"
 	"strings"
@@ -455,10 +455,9 @@ code_source:
 	assert.Len(t, uploaded, 1, "git_archive cache hit should skip the second upload")
 }
 
-// When enabled, a code source uploads provenance sidecars (git_state.json and
-// git_diff.patch when the tree is dirty) next to the run's launch directory.
-// This path is paused to avoid dirty-state query and WSFS write latency.
-func TestSubmitWorkloadSkipsProvenanceSidecars(t *testing.T) {
+// A code source uploads provenance sidecars (git_state.json and git_diff.patch
+// when the tree is dirty) next to the run's launch directory.
+func TestSubmitWorkloadUploadsProvenanceSidecars(t *testing.T) {
 	server := testserver.New(t)
 	t.Cleanup(server.Close)
 
@@ -491,13 +490,25 @@ code_source:
 	snap, err := snapshotViaDABsUpload(ctx, w, loaded.CodeSource.Snapshot, cfgPath, sidecarStore, sidecarBase)
 	require.NoError(t, err)
 
-	assert.Empty(t, snap.GitStatePath)
-	assert.Empty(t, snap.GitDiffPath)
+	assert.Equal(t, path.Join(sidecarBase, gitStateName), snap.GitStatePath)
+	assert.Equal(t, path.Join(sidecarBase, gitDiffName), snap.GitDiffPath)
 
-	_, err = sidecarStore.Read(ctx, gitStateName)
-	assert.ErrorIs(t, err, fs.ErrNotExist)
-	_, err = sidecarStore.Read(ctx, gitDiffName)
-	assert.ErrorIs(t, err, fs.ErrNotExist)
+	stateReader, err := sidecarStore.Read(ctx, gitStateName)
+	require.NoError(t, err)
+	defer stateReader.Close()
+	stateBytes, err := io.ReadAll(stateReader)
+	require.NoError(t, err)
+	var state gitStateSidecar
+	require.NoError(t, json.Unmarshal(stateBytes, &state))
+	assert.True(t, state.Dirty)
+	assert.Equal(t, diffStatusCaptured, state.DiffStatus)
+
+	diffReader, err := sidecarStore.Read(ctx, gitDiffName)
+	require.NoError(t, err)
+	defer diffReader.Close()
+	diffBytes, err := io.ReadAll(diffReader)
+	require.NoError(t, err)
+	assert.Contains(t, string(diffBytes), "train.py")
 }
 
 // remote_volume uploads the snapshot to a UC Volume: DABs' artifact uploader handles

--- a/experimental/air/cmd/snapshot_dabs.go
+++ b/experimental/air/cmd/snapshot_dabs.go
@@ -24,8 +24,10 @@ import (
 )
 
 // uploadProvenanceSidecars controls collection and upload of git_state.json
-// and git_diff.patch during submission.
-const uploadProvenanceSidecars = true
+// and git_diff.patch during submission. Keep the implementation available, but
+// turn it off for now because the additional local queries and WSFS writes add
+// latency to AIR submissions.
+const uploadProvenanceSidecars = false
 
 // snapshotViaDABsUpload packages the code_source into a tarball and uploads it using
 // DABs' artifact-upload plumbing (the same path a bundle uses for a file-valued

--- a/experimental/air/cmd/snapshot_dabs.go
+++ b/experimental/air/cmd/snapshot_dabs.go
@@ -93,7 +93,7 @@ func uploadSnapshotSidecars(ctx context.Context, sidecarStore filer.Filer, sidec
 		pinnedTip = plan.commitSHA
 	}
 
-	sidecar, err := buildGitStateSidecar(ctx, git, mode, pinnedTip, time.Now())
+	sidecar, err := buildGitStateSidecar(ctx, git, mode, pinnedTip, plan.hasUncommit, time.Now())
 	if err != nil {
 		log.Warnf(ctx, "skipping git provenance sidecar: %v", err)
 		return "", ""
@@ -101,7 +101,7 @@ func uploadSnapshotSidecars(ctx context.Context, sidecarStore filer.Filer, sidec
 
 	// Capture the dirty diff first so its status/path land in git_state.json.
 	if sidecar.Dirty {
-		status, diff := captureDirtyDiff(ctx, git, dirtyDiffSizeCapBytes, dirtyDiffTimeout)
+		status, diff := captureDirtyDiff(ctx, git, plan.includePaths, dirtyDiffSizeCapBytes, dirtyDiffTimeout)
 		sidecar.DiffStatus = status
 		if status == diffStatusCaptured {
 			if err := sidecarStore.Write(ctx, gitDiffName, bytes.NewReader(diff), filer.OverwriteIfExists, filer.CreateParentDirectories); err != nil {
@@ -147,7 +147,7 @@ func packageSnapshot(ctx context.Context, repoPath string, plan snapshotPlan, ta
 	if plan.mode == modeGitArchive {
 		return createGitArchiveSnapshot(ctx, newGitRepo(repoPath), plan.commitSHA, tarball, dirName, plan.includePaths)
 	}
-	return createPlainTarball(ctx, repoPath, tarball, plan.includePaths)
+	return createPlainTarball(ctx, repoPath, tarball, plan.includePaths, plan.isGitRepo)
 }
 
 // uploadSnapshotViaDABs uploads the snapshot through DABs' artifact-upload machinery

--- a/experimental/air/cmd/snapshot_dabs.go
+++ b/experimental/air/cmd/snapshot_dabs.go
@@ -24,10 +24,8 @@ import (
 )
 
 // uploadProvenanceSidecars controls collection and upload of git_state.json
-// and git_diff.patch during submission. Keep the implementation available, but
-// turn it off for now because the additional local queries and WSFS writes add
-// latency to AIR submissions.
-const uploadProvenanceSidecars = false
+// and git_diff.patch during submission.
+const uploadProvenanceSidecars = true
 
 // snapshotViaDABsUpload packages the code_source into a tarball and uploads it using
 // DABs' artifact-upload plumbing (the same path a bundle uses for a file-valued

--- a/experimental/air/cmd/snapshot_git.go
+++ b/experimental/air/cmd/snapshot_git.go
@@ -258,7 +258,7 @@ func nilIfEmpty(s string) *string {
 // buildGitStateSidecar gathers git provenance. pinnedTip overrides the HEAD-derived
 // tip for git_archive (the tarball reflects that commit, not HEAD); pass "" for
 // plain_tar. Metadata is best-effort — unavailable fields become null.
-func buildGitStateSidecar(ctx context.Context, git gitRepo, packagingMode, pinnedTip string, now time.Time) (gitStateSidecar, error) {
+func buildGitStateSidecar(ctx context.Context, git gitRepo, packagingMode, pinnedTip string, dirty bool, now time.Time) (gitStateSidecar, error) {
 	tip := pinnedTip
 	if tip == "" {
 		head, err := git.headSHA(ctx)
@@ -266,11 +266,6 @@ func buildGitStateSidecar(ctx context.Context, git gitRepo, packagingMode, pinne
 			return gitStateSidecar{}, err
 		}
 		tip = head
-	}
-
-	dirty, err := git.hasUncommittedChanges(ctx)
-	if err != nil {
-		return gitStateSidecar{}, err
 	}
 
 	return gitStateSidecar{
@@ -295,11 +290,16 @@ func (s gitStateSidecar) marshal() ([]byte, error) {
 // captureDirtyDiff runs `git diff HEAD` over the repo subtree, returning a diff_status
 // and the diff bytes (non-nil only when captured): clean (no changes or diff failed),
 // captured (under the cap), size_exceeded, or timeout.
-func captureDirtyDiff(ctx context.Context, git gitRepo, sizeCapBytes int, timeout time.Duration) (string, []byte) {
+func captureDirtyDiff(ctx context.Context, git gitRepo, includePaths []string, sizeCapBytes int, timeout time.Duration) (string, []byte) {
 	diffCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	out, err := git.runBytes(diffCtx, "diff", "HEAD", "--", ".")
+	pathspecs := includePaths
+	if len(pathspecs) == 0 {
+		pathspecs = []string{"."}
+	}
+	args := append([]string{"diff", "HEAD", "--"}, pathspecs...)
+	out, err := git.runBytes(diffCtx, args...)
 	if err != nil {
 		if errors.Is(diffCtx.Err(), context.DeadlineExceeded) {
 			return diffStatusTimeout, nil

--- a/experimental/air/cmd/snapshot_git_test.go
+++ b/experimental/air/cmd/snapshot_git_test.go
@@ -202,7 +202,7 @@ func TestBuildGitStateSidecar_PlainTarClean(t *testing.T) {
 	writeRepoFile(t, repo, "a.txt", "1")
 	head := commitAll(t, repo, "init")
 
-	sc, err := buildGitStateSidecar(ctx, newGitRepo(repo), packagingModePlainTar, "", fixedNow)
+	sc, err := buildGitStateSidecar(ctx, newGitRepo(repo), packagingModePlainTar, "", false, fixedNow)
 	require.NoError(t, err)
 	assert.Equal(t, snapshotStateSchemaVersion, sc.SchemaVersion)
 	assert.Equal(t, packagingModePlainTar, sc.PackagingMode)
@@ -228,7 +228,7 @@ func TestBuildGitStateSidecar_GitArchivePinsTip(t *testing.T) {
 	writeRepoFile(t, repo, "b.txt", "2")
 	commitAll(t, repo, "second")
 
-	sc, err := buildGitStateSidecar(ctx, newGitRepo(repo), packagingModeGitArchive, first, fixedNow)
+	sc, err := buildGitStateSidecar(ctx, newGitRepo(repo), packagingModeGitArchive, first, false, fixedNow)
 	require.NoError(t, err)
 	require.NotNil(t, sc.TipCommit)
 	assert.Equal(t, first, *sc.TipCommit)
@@ -242,7 +242,7 @@ func TestBuildGitStateSidecar_Dirty(t *testing.T) {
 	commitAll(t, repo, "init")
 	writeRepoFile(t, repo, "a.txt", "2") // uncommitted
 
-	sc, err := buildGitStateSidecar(ctx, newGitRepo(repo), packagingModePlainTar, "", fixedNow)
+	sc, err := buildGitStateSidecar(ctx, newGitRepo(repo), packagingModePlainTar, "", true, fixedNow)
 	require.NoError(t, err)
 	assert.True(t, sc.Dirty)
 }
@@ -253,7 +253,7 @@ func TestGitStateSidecar_MarshalNullsAbsentFields(t *testing.T) {
 	writeRepoFile(t, repo, "a.txt", "1")
 	commitAll(t, repo, "init")
 
-	sc, err := buildGitStateSidecar(ctx, newGitRepo(repo), packagingModePlainTar, "", fixedNow)
+	sc, err := buildGitStateSidecar(ctx, newGitRepo(repo), packagingModePlainTar, "", false, fixedNow)
 	require.NoError(t, err)
 	data, err := sc.marshal()
 	require.NoError(t, err)
@@ -277,20 +277,36 @@ func TestCaptureDirtyDiff(t *testing.T) {
 	commitAll(t, repo, "init")
 
 	// Clean tree → no diff.
-	status, diff := captureDirtyDiff(ctx, newGitRepo(repo), dirtyDiffSizeCapBytes, dirtyDiffTimeout)
+	status, diff := captureDirtyDiff(ctx, newGitRepo(repo), nil, dirtyDiffSizeCapBytes, dirtyDiffTimeout)
 	assert.Equal(t, diffStatusClean, status)
 	assert.Nil(t, diff)
 
 	// Dirty tree → captured, and the diff mentions the changed file.
 	writeRepoFile(t, repo, "a.txt", "two\n")
-	status, diff = captureDirtyDiff(ctx, newGitRepo(repo), dirtyDiffSizeCapBytes, dirtyDiffTimeout)
+	status, diff = captureDirtyDiff(ctx, newGitRepo(repo), nil, dirtyDiffSizeCapBytes, dirtyDiffTimeout)
 	assert.Equal(t, diffStatusCaptured, status)
 	assert.Contains(t, string(diff), "a.txt")
 
 	// A tiny size cap forces size_exceeded and drops the bytes.
-	status, diff = captureDirtyDiff(ctx, newGitRepo(repo), 1, dirtyDiffTimeout)
+	status, diff = captureDirtyDiff(ctx, newGitRepo(repo), nil, 1, dirtyDiffTimeout)
 	assert.Equal(t, diffStatusSizeExceeded, status)
 	assert.Nil(t, diff)
+}
+
+func TestCaptureDirtyDiff_IncludePaths(t *testing.T) {
+	ctx := t.Context()
+	repo := newTestRepo(t)
+	writeRepoFile(t, repo, "included/a.txt", "one\n")
+	writeRepoFile(t, repo, "excluded/b.txt", "one\n")
+	commitAll(t, repo, "init")
+	writeRepoFile(t, repo, "included/a.txt", "two\n")
+	writeRepoFile(t, repo, "excluded/b.txt", "two\n")
+
+	status, diff := captureDirtyDiff(ctx, newGitRepo(repo), []string{"included"}, dirtyDiffSizeCapBytes, dirtyDiffTimeout)
+
+	assert.Equal(t, diffStatusCaptured, status)
+	assert.Contains(t, string(diff), "included/a.txt")
+	assert.NotContains(t, string(diff), "excluded/b.txt")
 }
 
 var fixedNow = time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)

--- a/experimental/air/cmd/snapshot_package.go
+++ b/experimental/air/cmd/snapshot_package.go
@@ -39,7 +39,7 @@ func createGitArchiveSnapshot(ctx context.Context, git gitRepo, commitSHA, outpu
 // top-level entry. When includePaths is set, only those paths (nested under the
 // directory name) are archived. .git and macOS AppleDouble files are always
 // excluded; a .gitignore at repoPath is honored.
-func createPlainTarball(ctx context.Context, repoPath, outputTarball string, includePaths []string) error {
+func createPlainTarball(ctx context.Context, repoPath, outputTarball string, includePaths []string, isGitRepo bool) error {
 	dirName := filepath.Base(repoPath)
 	// Absolute so it resolves correctly regardless of tar's working dir (set below).
 	parent, err := filepath.Abs(filepath.Dir(repoPath))
@@ -58,7 +58,7 @@ func createPlainTarball(ctx context.Context, repoPath, outputTarball string, inc
 	}
 	outName := filepath.Base(outputTarball)
 
-	files, err := snapshotFiles(ctx, repoPath, includePaths)
+	files, err := snapshotFiles(ctx, repoPath, includePaths, isGitRepo)
 	if err != nil {
 		return err
 	}
@@ -84,9 +84,9 @@ func createPlainTarball(ctx context.Context, repoPath, outputTarball string, inc
 	return nil
 }
 
-func snapshotFiles(ctx context.Context, repoPath string, includePaths []string) ([]string, error) {
+func snapshotFiles(ctx context.Context, repoPath string, includePaths []string, isGitRepo bool) ([]string, error) {
 	args := []string{"-C", repoPath, "ls-files", "-z", "--cached", "--others", "--exclude-standard"}
-	if !newGitRepo(repoPath).isRepository(ctx) {
+	if !isGitRepo {
 		gitDir, err := os.MkdirTemp("", "air-snapshot-git-")
 		if err != nil {
 			return nil, fmt.Errorf("failed to create temporary git metadata: %w", err)

--- a/experimental/air/cmd/snapshot_package_test.go
+++ b/experimental/air/cmd/snapshot_package_test.go
@@ -87,7 +87,7 @@ func TestCreatePlainTarball(t *testing.T) {
 	writeRepoFile(t, repo, ".git/config", "x")
 
 	out := filepath.Join(t.TempDir(), "snap.tar.gz")
-	require.NoError(t, createPlainTarball(ctx, repo, out, nil))
+	require.NoError(t, createPlainTarball(ctx, repo, out, nil, false))
 
 	dirName := filepath.Base(repo)
 	entries := tarballEntries(t, out)
@@ -107,7 +107,7 @@ func TestCreatePlainTarball_HonorsGitignore(t *testing.T) {
 	writeRepoFile(t, repo, ".gitignore", "*.log\n")
 
 	out := filepath.Join(t.TempDir(), "snap.tar.gz")
-	require.NoError(t, createPlainTarball(ctx, repo, out, nil))
+	require.NoError(t, createPlainTarball(ctx, repo, out, nil, false))
 
 	dirName := filepath.Base(repo)
 	entries := tarballEntries(t, out)
@@ -122,7 +122,7 @@ func TestCreatePlainTarball_IncludePaths(t *testing.T) {
 	writeRepoFile(t, repo, "src/model.py", "print()")
 
 	out := filepath.Join(t.TempDir(), "snap.tar.gz")
-	require.NoError(t, createPlainTarball(ctx, repo, out, []string{"src"}))
+	require.NoError(t, createPlainTarball(ctx, repo, out, []string{"src"}, false))
 
 	dirName := filepath.Base(repo)
 	entries := tarballEntries(t, out)
@@ -142,7 +142,7 @@ func TestCreatePlainTarball_HonorsNestedGitignoreAndNegation(t *testing.T) {
 	writeRepoFile(t, repo, "nested/keep.tmp", "keep")
 
 	out := filepath.Join(t.TempDir(), "snap.tar.gz")
-	require.NoError(t, createPlainTarball(t.Context(), repo, out, nil))
+	require.NoError(t, createPlainTarball(t.Context(), repo, out, nil, false))
 
 	dirName := filepath.Base(repo)
 	entries := tarballEntries(t, out)
@@ -162,7 +162,7 @@ func TestCreatePlainTarball_SkipsDeletedTrackedFiles(t *testing.T) {
 	require.NoError(t, os.Remove(filepath.Join(repo, "deleted.txt")))
 
 	out := filepath.Join(t.TempDir(), "snap.tar.gz")
-	require.NoError(t, createPlainTarball(t.Context(), repo, out, nil))
+	require.NoError(t, createPlainTarball(t.Context(), repo, out, nil, true))
 
 	dirName := filepath.Base(repo)
 	entries := tarballEntries(t, out)


### PR DESCRIPTION
## Summary

Reuse repository and dirty state already computed while resolving the AIR snapshot plan. Scope the provenance diff to the same `include_paths` used by the snapshot.

This removes redundant `git status` and `git rev-parse --is-inside-work-tree` calls. Provenance sidecars remain disabled by default; the enabled commit was retained only as a benchmark comparison point.

## Latency measurements

Controlled client-side benchmark with five iterations per build. Both snapshots were clean; the benchmark measures Git resolution, tarball creation, and sidecar generation while excluding remote API/upload jitter.

| Snapshot | Disabled | Enabled before optimization | Enabled after optimization |
|---|---:|---:|---:|
| Simple example (16 KB) | 0.791 s | 1.734 s | 1.183 s |
| Universe `research/` (102 MB) | 3.287 s | 4.248 s | 3.651 s |

The optimization saves 0.551 s for the simple snapshot and 0.597 s for `research/`. Enabled overhead relative to disabled drops from roughly 0.95 s to 0.38 s.

A clean real-workspace A/B cross-check showed about 0.50 s of current enabled overhead for both snapshots. A dirty snapshot additionally runs `git diff` (about 0.31 s in this checkout) and uploads the patch.

THIS FEATURES IS STILL DISABLED BY DEFAULT!

## Tests

- `go test ./experimental/air/cmd`
- `./task fmt-q`
- `./task lint-q`
