### PR TITLE
Translate code_source git and include_paths in convert-to-dabs

### DIFF
--- a/acceptance/experimental/air/convert-to-dabs/output.txt
+++ b/acceptance/experimental/air/convert-to-dabs/output.txt
@@ -55,8 +55,9 @@ resources:
 
 === the generated command.sh carries the run command
 >>> cat generated_artifacts/command.sh
-cd /databricks/code_source/src
+cd $CODE_SOURCE_PATH
 torchrun --nproc_per_node=1 train.py
+
 === the emitted bundle validates
 >>> [CLI] bundle validate
 Name: torchrun-a10-smoke-test

--- a/acceptance/experimental/air/convert-to-dabs/output.txt
+++ b/acceptance/experimental/air/convert-to-dabs/output.txt
@@ -55,6 +55,7 @@ resources:
 
 === the generated command.sh carries the run command
 >>> cat generated_artifacts/command.sh
+cd /databricks/code_source/src
 torchrun --nproc_per_node=1 train.py
 === the emitted bundle validates
 >>> [CLI] bundle validate

--- a/acceptance/experimental/air/convert-to-dabs/output.txt
+++ b/acceptance/experimental/air/convert-to-dabs/output.txt
@@ -9,7 +9,7 @@ Wrote a Databricks Asset Bundle to .:
 To deploy and run this workload as a bundle:
   1. [CLI] bundle validate
   2. [CLI] bundle deploy
-  3. [CLI] bundle run torchrun-a10-smoke-test
+  3. [CLI] bundle run torchrun-a10-smoke-test --no-wait
 
 bundle deploy uploads the code source and launch scripts automatically.
 To see what it deployed and where: [CLI] bundle summary
@@ -82,7 +82,7 @@ Wrote a Databricks Asset Bundle to .:
 To deploy and run this workload as a bundle:
   1. [CLI] bundle validate
   2. [CLI] bundle deploy
-  3. [CLI] bundle run torchrun-a10-smoke-test
+  3. [CLI] bundle run torchrun-a10-smoke-test --no-wait
 
 bundle deploy uploads the code source and launch scripts automatically.
 To see what it deployed and where: [CLI] bundle summary

--- a/acceptance/experimental/air/convert-to-dabs/train.yaml
+++ b/acceptance/experimental/air/convert-to-dabs/train.yaml
@@ -1,5 +1,7 @@
 experiment_name: torchrun-a10-smoke-test
-command: torchrun --nproc_per_node=1 train.py
+command: |
+  cd $CODE_SOURCE_PATH
+  torchrun --nproc_per_node=1 train.py
 compute:
   accelerator_type: GPU_1xA10
   num_accelerators: 1

--- a/experimental/air/cmd/convert_to_dabs.go
+++ b/experimental/air/cmd/convert_to_dabs.go
@@ -169,28 +169,42 @@ func convertToDabs(ctx context.Context, cfg *runConfig, configPath, bundleDir st
 }
 
 // codeArtifact is the `tgz` artifact convert emits when a snapshot pins a git ref or
-// narrows to include_paths. codeRootPath is the source dir relative to the bundle
-// (the artifact's `path`); tgzPath is the built tarball code_source_path points at.
+// narrows to include_paths. path/include follow the artifact snapshotter's semantics
+// (entries relative to `path`); tgzPath is the built tarball code_source_path points at.
 type codeArtifact struct {
-	codeRootPath string
-	tgzPath      string
-	gitBranch    *string
-	gitCommit    *string
-	includePaths []string
+	path      string // artifact `path`: the code dir's parent, relative to the bundle
+	include   []string
+	tgzPath   string
+	gitBranch *string
+	gitCommit *string
 }
 
 // codeArtifactFor returns the artifact to emit when the snapshot pins a git ref or
 // narrows to include_paths, else nil — the plain directory case, packaged by the
-// deploy-time aicode mutator. codeDirPath is the source dir relative to the bundle.
+// deploy-time aicode mutator. codeDirPath is the source dir relative to the bundle
+// ("./"-prefixed).
+//
+// The artifact snapshotter names entries relative to `path`, and the runtime extracts
+// to /databricks/code_source/<dir>, so the code dir's basename must be the top-level
+// entry. To get that, emit path = the code dir's parent and include = basename-prefixed
+// subpaths, so entries come out as "<basename>/..." — the layout the air CLI produced.
 func codeArtifactFor(cfg *runConfig, codeDirPath string) *codeArtifact {
 	snap := codeSnapshot(cfg)
 	if snap == nil || (snap.Git == nil && len(snap.IncludePaths) == 0) {
 		return nil
 	}
+	codeDirRel := strings.TrimPrefix(codeDirPath, "./")
+	dirName := path.Base(codeDirRel)
 	art := &codeArtifact{
-		codeRootPath: codeDirPath,
-		tgzPath:      localBundlePath(codeSourceTgzArtifact),
-		includePaths: snap.IncludePaths,
+		path:    path.Dir(codeDirRel),
+		tgzPath: localBundlePath(codeSourceTgzArtifact),
+	}
+	if len(snap.IncludePaths) > 0 {
+		for _, inc := range snap.IncludePaths {
+			art.include = append(art.include, path.Join(dirName, inc))
+		}
+	} else {
+		art.include = []string{dirName}
 	}
 	if snap.Git != nil {
 		art.gitBranch = snap.Git.Branch
@@ -376,7 +390,7 @@ func buildBundleValue(ctx context.Context, cfg *runConfig, configPath, codeSourc
 func buildArtifactsValue(art *codeArtifact) map[string]dyn.Value {
 	a := map[string]dyn.Value{
 		"type": nv("tgz", 1),
-		"path": nv(art.codeRootPath, 2),
+		"path": nv(art.path, 2),
 	}
 	fileLine := 3
 	if art.gitCommit != nil || art.gitBranch != nil {
@@ -390,14 +404,13 @@ func buildArtifactsValue(art *codeArtifact) map[string]dyn.Value {
 		a["git"] = nv(g, fileLine)
 		fileLine++
 	}
-	if len(art.includePaths) > 0 {
-		vals := make([]dyn.Value, len(art.includePaths))
-		for i, p := range art.includePaths {
-			vals[i] = dyn.V(p)
-		}
-		a["include"] = nv(vals, fileLine)
-		fileLine++
+	// include is always set: the basename (whole dir) or basename-prefixed subpaths.
+	vals := make([]dyn.Value, len(art.include))
+	for i, p := range art.include {
+		vals[i] = dyn.V(p)
 	}
+	a["include"] = nv(vals, fileLine)
+	fileLine++
 	a["files"] = nv([]dyn.Value{
 		dyn.V(map[string]dyn.Value{"source": nv(art.tgzPath, 1)}),
 	}, fileLine)

--- a/experimental/air/cmd/convert_to_dabs.go
+++ b/experimental/air/cmd/convert_to_dabs.go
@@ -593,8 +593,6 @@ func printConvertNextSteps(ctx context.Context, dir string, written []string, jo
 	steps = append(steps,
 		self+" bundle validate",
 		self+" bundle deploy",
-		// --no-wait by default: AI Runtime training runs are long, so submit and
-		// return the terminal rather than blocking on a streamed run.
 		self+" bundle run "+jobKey+" --no-wait",
 	)
 

--- a/experimental/air/cmd/convert_to_dabs.go
+++ b/experimental/air/cmd/convert_to_dabs.go
@@ -593,7 +593,9 @@ func printConvertNextSteps(ctx context.Context, dir string, written []string, jo
 	steps = append(steps,
 		self+" bundle validate",
 		self+" bundle deploy",
-		self+" bundle run "+jobKey,
+		// --no-wait by default: AI Runtime training runs are long, so submit and
+		// return the terminal rather than blocking on a streamed run.
+		self+" bundle run "+jobKey+" --no-wait",
 	)
 
 	cmdio.LogString(ctx, "")

--- a/experimental/air/cmd/convert_to_dabs.go
+++ b/experimental/air/cmd/convert_to_dabs.go
@@ -148,7 +148,10 @@ func convertToDabs(ctx context.Context, cfg *runConfig, configPath, bundleDir st
 		return nil, nil, err
 	}
 	codeSourcePath := codeDirPath
-	art := codeArtifactFor(cfg, codeDirPath)
+	art, err := codeArtifactFor(cfg, codeDirPath)
+	if err != nil {
+		return nil, nil, err
+	}
 	if art != nil {
 		// The artifact snapshotter builds the tarball; code_source_path points at it.
 		codeSourcePath = art.tgzPath
@@ -204,19 +207,28 @@ type codeArtifact struct {
 
 // codeArtifactFor returns the artifact to emit when the snapshot pins a git ref or
 // narrows to include_paths, else nil — the plain directory case, packaged by the
-// deploy-time aicode mutator. codeDirPath is the source dir relative to the bundle
+// deploy-time aicode mutator. It errors when the code dir resolves to the bundle root
+// (no basename to nest under). codeDirPath is the source dir relative to the bundle
 // ("./"-prefixed).
 //
 // The artifact snapshotter names entries relative to `path`, and the runtime extracts
 // to /databricks/code_source/<dir>, so the code dir's basename must be the top-level
 // entry. To get that, emit path = the code dir's parent and include = basename-prefixed
 // subpaths, so entries come out as "<basename>/..." — the layout the air CLI produced.
-func codeArtifactFor(cfg *runConfig, codeDirPath string) *codeArtifact {
+func codeArtifactFor(cfg *runConfig, codeDirPath string) (*codeArtifact, error) {
 	snap := codeSnapshot(cfg)
 	if snap == nil || (snap.Git == nil && len(snap.IncludePaths) == 0) {
-		return nil
+		return nil, nil
 	}
 	codeDirRel := strings.TrimPrefix(codeDirPath, "./")
+	// A code dir that resolves to the bundle root has no basename to nest under: the
+	// archive would sit directly at /databricks/code_source (no <dir>), and an include
+	// rooted at "." would also sweep the bundle's own generated files (databricks.yml,
+	// generated_artifacts/, the output tarball) into it. Reject rather than emit that;
+	// the user should point root_path at a subdirectory.
+	if codeDirRel == "." {
+		return nil, fmt.Errorf("code_source root_path %q resolves to the bundle root; convert-to-dabs cannot translate a git or include_paths snapshot there (no code directory to package under %s/<dir>). Point root_path at a subdirectory", snap.RootPath, runtimeCodeSourceRoot)
+	}
 	dirName := path.Base(codeDirRel)
 	art := &codeArtifact{
 		path:    path.Dir(codeDirRel),
@@ -233,7 +245,7 @@ func codeArtifactFor(cfg *runConfig, codeDirPath string) *codeArtifact {
 		art.gitBranch = snap.Git.Branch
 		art.gitCommit = snap.Git.Commit
 	}
-	return art
+	return art, nil
 }
 
 // codeSnapshot returns the snapshot code source config, or nil if none.

--- a/experimental/air/cmd/convert_to_dabs.go
+++ b/experimental/air/cmd/convert_to_dabs.go
@@ -167,32 +167,16 @@ func convertToDabs(ctx context.Context, cfg *runConfig, configPath, bundleDir st
 		return nil, nil, err
 	}
 
-	// The launcher runs command.sh from the launch dir, but code_source extracts to
-	// /databricks/code_source/<dir>. cd there first so relative paths in the user's
-	// command (e.g. `python train.py`) resolve against the code, matching how the
-	// command reads under `air run`.
-	if codeDirPath != "" {
-		cdIntoCodeSource(artifacts, path.Base(strings.TrimPrefix(codeDirPath, "./")))
-	}
-
 	root := buildBundleValue(ctx, cfg, configPath, codeSourcePath, art)
 	return root, artifacts, nil
 }
 
 // runtimeCodeSourceRoot is where the launcher extracts an AI Runtime task's
-// code_source; the tarball's top-level dir lands directly under it.
+// code_source; the tarball's top-level dir lands directly under it, and the launcher
+// exports it (plus the component subdir) as $CODE_SOURCE_PATH. The user's command is
+// responsible for cd-ing there (every air command does), so convert copies the command
+// verbatim rather than injecting a cd.
 const runtimeCodeSourceRoot = "/databricks/code_source"
-
-// cdIntoCodeSource prepends a `cd` into the extracted code dir to the generated
-// command.sh, so the user's command runs against the code rather than the launch dir.
-func cdIntoCodeSource(artifacts []uploadItem, dirName string) {
-	target := path.Join(runtimeCodeSourceRoot, dirName)
-	for i := range artifacts {
-		if artifacts[i].name == commandScriptName {
-			artifacts[i].data = []byte("cd " + target + "\n" + string(artifacts[i].data))
-		}
-	}
-}
 
 // codeArtifact is the `tgz` artifact convert emits when a snapshot pins a git ref or
 // narrows to include_paths. path/include follow the artifact snapshotter's semantics

--- a/experimental/air/cmd/convert_to_dabs.go
+++ b/experimental/air/cmd/convert_to_dabs.go
@@ -34,6 +34,10 @@ import (
 // it — so convert never touches the code. Dependencies are folded into the job's
 // environments[] spec, which the runtime installs from directly; no requirements.yaml
 // is emitted.
+//
+// When the snapshot pins a git ref or narrows to include_paths, convert instead emits
+// a `tgz` artifact (the DABs artifact snapshotter): DABs builds the tarball from that
+// ref/subset at deploy, and code_source_path points at the built tarball.
 
 // dabsTargetName is the single default target emitted; a development-mode target
 // is the conventional starting point for a generated bundle.
@@ -44,6 +48,14 @@ const dabsTargetName = "dev"
 // The server derives the sidecar paths from command_path's parent, so they must
 // stay beside command.sh.
 const generatedArtifactsDir = "generated_artifacts"
+
+// codeSourceArtifactKey names the `tgz` artifact convert emits for a git/include
+// snapshot. codeSourceTgzArtifact is where DABs writes the built tarball — kept out of
+// sync.paths so it is uploaded once via the artifact path, not also synced.
+const (
+	codeSourceArtifactKey = "code_source"
+	codeSourceTgzArtifact = "dist/code_source.tgz"
+)
 
 func newConvertToDabsCommand() *cobra.Command {
 	var (
@@ -126,24 +138,20 @@ func convertToDabs(ctx context.Context, cfg *runConfig, configPath, bundleDir st
 		if snap.RemoteVolume != nil {
 			return nil, nil, errors.New("code_source.snapshot.remote_volume is not supported by convert-to-dabs; set workspace.artifact_path in the bundle instead")
 		}
-		// git pins to a committed revision, but convert packages nothing — the
-		// deploy-time mutator uploads the working tree as it is on disk. Deploying a
-		// specific revision therefore isn't supported; check it out before converting.
-		if snap.Git != nil {
-			return nil, nil, errors.New("code_source.snapshot.git is not supported by convert-to-dabs; deploy packages your working tree as-is, so check out the revision you want (git checkout <ref>) before converting")
-		}
-		// include_paths narrows the archive to a subset of root_path. The bundle has no
-		// per-code-source equivalent: deploy packages the whole directory, filtered by
-		// .gitignore and the bundle-wide sync.include/sync.exclude. Silently dropping it
-		// would upload files the user meant to leave out.
-		if len(snap.IncludePaths) > 0 {
-			return nil, nil, errors.New("code_source.snapshot.include_paths is not supported by convert-to-dabs; deploy packages the whole directory, so narrow it with sync.exclude in the bundle (or a .gitignore) instead")
-		}
 	}
 
-	codeSourcePath, err := bundleCodeSourcePath(ctx, cfg, configPath, bundleDir)
+	// The source dir relative to the bundle. It becomes code_source_path directly in
+	// the plain case, or the `tgz` artifact's `path` when a git ref / include_paths is
+	// pinned (see codeArtifactFor).
+	codeDirPath, err := bundleCodeSourcePath(ctx, cfg, configPath, bundleDir)
 	if err != nil {
 		return nil, nil, err
+	}
+	codeSourcePath := codeDirPath
+	art := codeArtifactFor(cfg, codeDirPath)
+	if art != nil {
+		// The artifact snapshotter builds the tarball; code_source_path points at it.
+		codeSourcePath = art.tgzPath
 	}
 
 	// buildArtifacts emits command.sh plus the training_config / hyperparameters /
@@ -156,8 +164,39 @@ func convertToDabs(ctx context.Context, cfg *runConfig, configPath, bundleDir st
 		return nil, nil, err
 	}
 
-	root := buildBundleValue(ctx, cfg, configPath, codeSourcePath)
+	root := buildBundleValue(ctx, cfg, configPath, codeSourcePath, art)
 	return root, artifacts, nil
+}
+
+// codeArtifact is the `tgz` artifact convert emits when a snapshot pins a git ref or
+// narrows to include_paths. codeRootPath is the source dir relative to the bundle
+// (the artifact's `path`); tgzPath is the built tarball code_source_path points at.
+type codeArtifact struct {
+	codeRootPath string
+	tgzPath      string
+	gitBranch    *string
+	gitCommit    *string
+	includePaths []string
+}
+
+// codeArtifactFor returns the artifact to emit when the snapshot pins a git ref or
+// narrows to include_paths, else nil — the plain directory case, packaged by the
+// deploy-time aicode mutator. codeDirPath is the source dir relative to the bundle.
+func codeArtifactFor(cfg *runConfig, codeDirPath string) *codeArtifact {
+	snap := codeSnapshot(cfg)
+	if snap == nil || (snap.Git == nil && len(snap.IncludePaths) == 0) {
+		return nil
+	}
+	art := &codeArtifact{
+		codeRootPath: codeDirPath,
+		tgzPath:      localBundlePath(codeSourceTgzArtifact),
+		includePaths: snap.IncludePaths,
+	}
+	if snap.Git != nil {
+		art.gitBranch = snap.Git.Branch
+		art.gitCommit = snap.Git.Commit
+	}
+	return art
 }
 
 // codeSnapshot returns the snapshot code source config, or nil if none.
@@ -211,7 +250,7 @@ func localBundlePath(p string) string {
 // buildBundleValue assembles the bundle root as an ordered map[string]dyn.Value.
 // codeSourcePath is the "./"-prefixed code_source dir relative to the bundle (empty
 // when the config has no code_source); command.sh is a bundle-local artifact.
-func buildBundleValue(ctx context.Context, cfg *runConfig, configPath, codeSourcePath string) map[string]dyn.Value {
+func buildBundleValue(ctx context.Context, cfg *runConfig, configPath, codeSourcePath string, art *codeArtifact) map[string]dyn.Value {
 	name := cfg.ExperimentName
 
 	// ai_runtime_task: experiment + one deployment (command_path + compute) +
@@ -316,14 +355,53 @@ func buildBundleValue(ctx context.Context, cfg *runConfig, configPath, codeSourc
 				"mode":    nv("development", 1),
 				"default": nv(true, 2),
 			}, 1),
-		}, 3),
+		}, 4),
 		"resources": nv(map[string]dyn.Value{
 			"jobs": nv(map[string]dyn.Value{
 				bundleResourceKey(name): nv(job, 1),
 			}, 1),
-		}, 4),
+		}, 5),
+	}
+	// The `tgz` artifact snapshotter, when the snapshot pins a git ref / include_paths.
+	if art != nil {
+		rootValue["artifacts"] = nv(buildArtifactsValue(art), 3)
 	}
 	return rootValue
+}
+
+// buildArtifactsValue builds the `artifacts` block for a git/include snapshot: a
+// single `tgz` artifact whose `path` is the code-source root, carrying the git ref
+// and/or include subpaths, and whose `files` output is the tarball code_source_path
+// points at.
+func buildArtifactsValue(art *codeArtifact) map[string]dyn.Value {
+	a := map[string]dyn.Value{
+		"type": nv("tgz", 1),
+		"path": nv(art.codeRootPath, 2),
+	}
+	fileLine := 3
+	if art.gitCommit != nil || art.gitBranch != nil {
+		g := map[string]dyn.Value{}
+		// commit wins over branch, matching the artifact builder.
+		if art.gitCommit != nil {
+			g["commit"] = nv(*art.gitCommit, 1)
+		} else {
+			g["branch"] = nv(*art.gitBranch, 1)
+		}
+		a["git"] = nv(g, fileLine)
+		fileLine++
+	}
+	if len(art.includePaths) > 0 {
+		vals := make([]dyn.Value, len(art.includePaths))
+		for i, p := range art.includePaths {
+			vals[i] = dyn.V(p)
+		}
+		a["include"] = nv(vals, fileLine)
+		fileLine++
+	}
+	a["files"] = nv([]dyn.Value{
+		dyn.V(map[string]dyn.Value{"source": nv(art.tgzPath, 1)}),
+	}, fileLine)
+	return map[string]dyn.Value{codeSourceArtifactKey: nv(a, 1)}
 }
 
 // bundleEnvironmentDeps resolves the runtime version and the inline dependency

--- a/experimental/air/cmd/convert_to_dabs.go
+++ b/experimental/air/cmd/convert_to_dabs.go
@@ -164,8 +164,31 @@ func convertToDabs(ctx context.Context, cfg *runConfig, configPath, bundleDir st
 		return nil, nil, err
 	}
 
+	// The launcher runs command.sh from the launch dir, but code_source extracts to
+	// /databricks/code_source/<dir>. cd there first so relative paths in the user's
+	// command (e.g. `python train.py`) resolve against the code, matching how the
+	// command reads under `air run`.
+	if codeDirPath != "" {
+		cdIntoCodeSource(artifacts, path.Base(strings.TrimPrefix(codeDirPath, "./")))
+	}
+
 	root := buildBundleValue(ctx, cfg, configPath, codeSourcePath, art)
 	return root, artifacts, nil
+}
+
+// runtimeCodeSourceRoot is where the launcher extracts an AI Runtime task's
+// code_source; the tarball's top-level dir lands directly under it.
+const runtimeCodeSourceRoot = "/databricks/code_source"
+
+// cdIntoCodeSource prepends a `cd` into the extracted code dir to the generated
+// command.sh, so the user's command runs against the code rather than the launch dir.
+func cdIntoCodeSource(artifacts []uploadItem, dirName string) {
+	target := path.Join(runtimeCodeSourceRoot, dirName)
+	for i := range artifacts {
+		if artifacts[i].name == commandScriptName {
+			artifacts[i].data = []byte("cd " + target + "\n" + string(artifacts[i].data))
+		}
+	}
 }
 
 // codeArtifact is the `tgz` artifact convert emits when a snapshot pins a git ref or

--- a/experimental/air/cmd/convert_to_dabs_test.go
+++ b/experimental/air/cmd/convert_to_dabs_test.go
@@ -3,7 +3,6 @@ package aircmd
 import (
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/databricks/cli/libs/dyn"
@@ -47,9 +46,11 @@ func TestConvertToDabsForceOverwrite(t *testing.T) {
 	assert.Contains(t, string(regenerated), "ai_runtime_task")
 }
 
-// The generated command.sh cds into the extracted code dir, so a relative command
-// like `python train.py` resolves against the code rather than the launch dir.
-func TestConvertToDabsCommandCdsIntoCodeSource(t *testing.T) {
+// command.sh is the user's command copied verbatim — convert injects no cd. The
+// launcher exports $CODE_SOURCE_PATH and runs the command in the launch dir without
+// cd-ing, so (as under air run) the command owns its own cd; convert must not add one,
+// which would make it more lenient than air run.
+func TestConvertToDabsCommandVerbatim(t *testing.T) {
 	cfg := minimalConfig + `
 code_source:
   type: snapshot
@@ -70,8 +71,8 @@ code_source:
 			cmd = string(it.data)
 		}
 	}
-	assert.True(t, strings.HasPrefix(cmd, "cd /databricks/code_source/src\n"),
-		"command.sh should cd into the code dir; got %q", cmd)
+	assert.Equal(t, "python train.py", cmd, "command.sh must be the verbatim command, no injected cd")
+	assert.NotContains(t, cmd, "cd /databricks/code_source")
 }
 
 func TestConvertToDabsCommandShape(t *testing.T) {

--- a/experimental/air/cmd/convert_to_dabs_test.go
+++ b/experimental/air/cmd/convert_to_dabs_test.go
@@ -3,6 +3,7 @@ package aircmd
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/databricks/cli/libs/dyn"
@@ -44,6 +45,33 @@ func TestConvertToDabsForceOverwrite(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEqual(t, edited, regenerated)
 	assert.Contains(t, string(regenerated), "ai_runtime_task")
+}
+
+// The generated command.sh cds into the extracted code dir, so a relative command
+// like `python train.py` resolves against the code rather than the launch dir.
+func TestConvertToDabsCommandCdsIntoCodeSource(t *testing.T) {
+	cfg := minimalConfig + `
+code_source:
+  type: snapshot
+  snapshot:
+    root_path: ./src
+`
+	path := writeConfigFile(t, "run.yaml", cfg)
+	require.NoError(t, os.MkdirAll(filepath.Join(filepath.Dir(path), "src"), 0o700))
+	loaded, err := loadRunConfig(path)
+	require.NoError(t, err)
+
+	_, artifacts, err := convertToDabs(t.Context(), loaded, path, filepath.Dir(path))
+	require.NoError(t, err)
+
+	var cmd string
+	for _, it := range artifacts {
+		if it.name == commandScriptName {
+			cmd = string(it.data)
+		}
+	}
+	assert.True(t, strings.HasPrefix(cmd, "cd /databricks/code_source/src\n"),
+		"command.sh should cd into the code dir; got %q", cmd)
 }
 
 func TestConvertToDabsCommandShape(t *testing.T) {

--- a/experimental/air/cmd/convert_to_dabs_test.go
+++ b/experimental/air/cmd/convert_to_dabs_test.go
@@ -471,6 +471,61 @@ func TestConvertToDabsIncludePathsEmitsArtifact(t *testing.T) {
 	assert.Equal(t, "./dist/code_source.tgz", get(t, root, task+".code_source_path").MustString())
 }
 
+// include_paths pointing at directories (the primary use case, not single files):
+// each entry is basename-prefixed the same way, so a subdirectory `pkg` under a
+// `./src` root becomes `src/pkg`. Convert is a syntactic mapping — whether the entry
+// names a directory or a file is identical here; the tgz builder (#6428) walks a
+// directory entry recursively at deploy.
+func TestConvertToDabsIncludePathsDirectories(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "src", "pkg"), 0o700))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "src", "config"), 0o700))
+	cfg := "experiment_name: incdir\ncommand: python train.py\n" +
+		"compute: {accelerator_type: GPU_1xH100, num_accelerators: 1}\n" +
+		"code_source:\n  type: snapshot\n  snapshot:\n    root_path: ./src\n" +
+		"    include_paths:\n      - pkg\n      - config\n"
+	path := filepath.Join(dir, "run.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(cfg), 0o600))
+	loaded, err := loadRunConfig(path)
+	require.NoError(t, err)
+
+	root, _, err := convertToDabs(t.Context(), loaded, path, dir)
+	require.NoError(t, err)
+
+	a := "artifacts." + codeSourceArtifactKey
+	assert.Equal(t, ".", get(t, root, a+".path").MustString())
+	inc := get(t, root, a+".include").MustSequence()
+	require.Len(t, inc, 2)
+	assert.Equal(t, "src/pkg", inc[0].MustString())
+	assert.Equal(t, "src/config", inc[1].MustString())
+}
+
+// root_path "." (the code source is the whole bundle directory) has no basename to
+// nest the archive under, and an include rooted at "." would sweep the bundle's own
+// generated files into the tarball — so a git/include snapshot there is rejected with
+// a message pointing at a subdirectory. (A plain snapshot with root_path "." is not an
+// artifact case and is unaffected.)
+func TestConvertToDabsDotRootPathRejected(t *testing.T) {
+	for _, tc := range []struct{ name, snap string }{
+		{"git", "code_source:\n  type: snapshot\n  snapshot:\n    root_path: .\n    git:\n      commit: abc123\n"},
+		{"include", "code_source:\n  type: snapshot\n  snapshot:\n    root_path: .\n    include_paths:\n      - foo\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			require.NoError(t, os.MkdirAll(filepath.Join(dir, "foo"), 0o700))
+			cfg := "experiment_name: dot\ncommand: python train.py\n" +
+				"compute: {accelerator_type: GPU_1xA10, num_accelerators: 1}\n" + tc.snap
+			path := filepath.Join(dir, "run.yaml")
+			require.NoError(t, os.WriteFile(path, []byte(cfg), 0o600))
+			loaded, err := loadRunConfig(path)
+			require.NoError(t, err)
+
+			_, _, err = convertToDabs(t.Context(), loaded, path, dir)
+			require.ErrorContains(t, err, "resolves to the bundle root")
+		})
+	}
+}
+
 func TestConvertToDabsRejectsUnsupported(t *testing.T) {
 	t.Run("docker_image", func(t *testing.T) {
 		cfg := minimalConfig + `

--- a/experimental/air/cmd/convert_to_dabs_test.go
+++ b/experimental/air/cmd/convert_to_dabs_test.go
@@ -298,12 +298,13 @@ func TestConvertToDabsRejectsCodeOutsideBundle(t *testing.T) {
 	require.ErrorContains(t, err, "not inside the bundle")
 }
 
-// A git-pinned code_source is rejected: convert no longer materializes a commit;
-// the deploy-time mutator packages the working tree in place.
-func TestConvertToDabsRejectsGitPin(t *testing.T) {
+// A git-pinned code_source is emitted as a `tgz` artifact (the DABs artifact
+// snapshotter): DABs builds the tarball from the ref at deploy and code_source_path
+// points at it.
+func TestConvertToDabsGitPinEmitsArtifact(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, os.MkdirAll(filepath.Join(dir, "src"), 0o700))
-	cfg := "experiment_name: git-pin\ncommand: python train.py\n" +
+	cfg := "experiment_name: gitpin\ncommand: python train.py\n" +
 		"compute: {accelerator_type: GPU_1xH100, num_accelerators: 1}\n" +
 		"code_source:\n  type: snapshot\n  snapshot:\n    root_path: ./src\n    git:\n      commit: abc123\n"
 	path := filepath.Join(dir, "run.yaml")
@@ -311,8 +312,17 @@ func TestConvertToDabsRejectsGitPin(t *testing.T) {
 	loaded, err := loadRunConfig(path)
 	require.NoError(t, err)
 
-	_, _, err = convertToDabs(t.Context(), loaded, path, dir)
-	require.ErrorContains(t, err, "git is not supported")
+	root, _, err := convertToDabs(t.Context(), loaded, path, dir)
+	require.NoError(t, err)
+
+	a := "artifacts." + codeSourceArtifactKey
+	assert.Equal(t, "tgz", get(t, root, a+".type").MustString())
+	assert.Equal(t, "./src", get(t, root, a+".path").MustString())
+	assert.Equal(t, "abc123", get(t, root, a+".git.commit").MustString())
+	assert.Equal(t, "./dist/code_source.tgz", get(t, root, a+".files[0].source").MustString())
+
+	task := "resources.jobs." + loaded.ExperimentName + ".tasks[0].ai_runtime_task"
+	assert.Equal(t, "./dist/code_source.tgz", get(t, root, task+".code_source_path").MustString())
 }
 
 // A requirements-FILE dependency set (environment.dependencies is a path) is folded
@@ -398,9 +408,9 @@ func TestConvertToDabsSafeJobKey(t *testing.T) {
 	}
 }
 
-// include_paths narrows the archive to a subset of root_path, which a bundle can't
-// express per code source. Rejected rather than silently uploading the whole dir.
-func TestConvertToDabsRejectsIncludePaths(t *testing.T) {
+// include_paths narrows the archive to a subset of root_path: emitted as the `tgz`
+// artifact's include (relative to the code-source root), matching air CLI semantics.
+func TestConvertToDabsIncludePathsEmitsArtifact(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, os.MkdirAll(filepath.Join(dir, "src"), 0o700))
 	cfg := "experiment_name: inc\ncommand: python train.py\n" +
@@ -412,8 +422,18 @@ func TestConvertToDabsRejectsIncludePaths(t *testing.T) {
 	loaded, err := loadRunConfig(path)
 	require.NoError(t, err)
 
-	_, _, err = convertToDabs(t.Context(), loaded, path, dir)
-	require.ErrorContains(t, err, "include_paths is not supported")
+	root, _, err := convertToDabs(t.Context(), loaded, path, dir)
+	require.NoError(t, err)
+
+	a := "artifacts." + codeSourceArtifactKey
+	assert.Equal(t, "tgz", get(t, root, a+".type").MustString())
+	assert.Equal(t, "./src", get(t, root, a+".path").MustString())
+	inc := get(t, root, a+".include").MustSequence()
+	require.Len(t, inc, 1)
+	assert.Equal(t, "keep", inc[0].MustString())
+
+	task := "resources.jobs." + loaded.ExperimentName + ".tasks[0].ai_runtime_task"
+	assert.Equal(t, "./dist/code_source.tgz", get(t, root, task+".code_source_path").MustString())
 }
 
 func TestConvertToDabsRejectsUnsupported(t *testing.T) {

--- a/experimental/air/cmd/convert_to_dabs_test.go
+++ b/experimental/air/cmd/convert_to_dabs_test.go
@@ -317,8 +317,13 @@ func TestConvertToDabsGitPinEmitsArtifact(t *testing.T) {
 
 	a := "artifacts." + codeSourceArtifactKey
 	assert.Equal(t, "tgz", get(t, root, a+".type").MustString())
-	assert.Equal(t, "./src", get(t, root, a+".path").MustString())
+	// path is the code dir's parent; include is the basename, so archive entries are
+	// "src/..." (the layout the runtime extracts to /databricks/code_source/src).
+	assert.Equal(t, ".", get(t, root, a+".path").MustString())
 	assert.Equal(t, "abc123", get(t, root, a+".git.commit").MustString())
+	inc := get(t, root, a+".include").MustSequence()
+	require.Len(t, inc, 1)
+	assert.Equal(t, "src", inc[0].MustString())
 	assert.Equal(t, "./dist/code_source.tgz", get(t, root, a+".files[0].source").MustString())
 
 	task := "resources.jobs." + loaded.ExperimentName + ".tasks[0].ai_runtime_task"
@@ -427,10 +432,12 @@ func TestConvertToDabsIncludePathsEmitsArtifact(t *testing.T) {
 
 	a := "artifacts." + codeSourceArtifactKey
 	assert.Equal(t, "tgz", get(t, root, a+".type").MustString())
-	assert.Equal(t, "./src", get(t, root, a+".path").MustString())
+	// path is the code dir's parent; include_paths are basename-prefixed, so the
+	// entry is "src/keep" (relative to the bundle root, path ".").
+	assert.Equal(t, ".", get(t, root, a+".path").MustString())
 	inc := get(t, root, a+".include").MustSequence()
 	require.Len(t, inc, 1)
-	assert.Equal(t, "keep", inc[0].MustString())
+	assert.Equal(t, "src/keep", inc[0].MustString())
 
 	task := "resources.jobs." + loaded.ExperimentName + ".tasks[0].ai_runtime_task"
 	assert.Equal(t, "./dist/code_source.tgz", get(t, root, task+".code_source_path").MustString())


### PR DESCRIPTION
## Summary

`experimental air convert-to-dabs` previously rejected a `code_source.snapshot` that
pinned a git ref or narrowed to `include_paths` — it errored and told the user to work
around it. Now it translates them into a `tgz` artifact (added in #6428): DABs builds
the tarball from the git ref / include subset at deploy, and `code_source_path` points
at the built tarball.

This closes the conversion gaps for the two cases convert used to refuse.

## Mapping

For a snapshot that pins a git ref and/or `include_paths`, convert emits a `tgz`
artifact and points `code_source_path` at its output:

- `snapshot.git.{branch,commit}` → artifact `git.{branch,commit}`
- `snapshot.include_paths` → artifact `include`

Archive entries must nest under the code directory's basename (the runtime extracts to
`/databricks/code_source/<dir>`), so convert emits `path` = the code dir's parent and
`include` = basename-prefixed subpaths:

- `root_path: ./src` → `path: ".", include: ["src"]`
- `root_path: ./src`, `include_paths: [foo]` → `path: ".", include: ["src/foo"]`

A plain snapshot (no git / include_paths) is unchanged: `code_source_path` stays the
source directory, packaged at deploy. `remote_volume` is still rejected — a per-source
volume isn't representable in a bundle (set `workspace.artifact_path` instead).

## Testing

Unit tests assert the emitted artifact (`type`, `path`, `git`/`include`, `files`) and
the rewritten `code_source_path` for both the git-ref and include_paths cases; the
plain-snapshot path is covered by the existing convert acceptance golden.

E2E test:
TEST INCLUDE
Setup
```
$ rm -rf /tmp/pr2-include && mkdir -p /tmp/pr2-include/src && cd /tmp/pr2-include
printf 'print("include ok")\n' > src/train.py
printf 'python train.py\n'      > src/command.sh
printf 'excluded\n'             > src/extra.txt
cat > train.yaml <<'YAML'
experiment_name: pr2_include_demo
command: python train.py
compute: {accelerator_type: GPU_1xA10, num_accelerators: 1}
code_source:
  type: snapshot
  snapshot:
    root_path: ./src
    include_paths: [train.py, command.sh]
YAML
```
convert to dabs
```
$ /tmp/cli-pr2 experimental air convert-to-dabs train.yaml
Wrote a Databricks Asset Bundle to .:
  databricks.yml
  generated_artifacts/training_config.yaml
  generated_artifacts/command.sh

To deploy and run this workload as a bundle:
  1. /tmp/cli-pr2 bundle validate
  2. /tmp/cli-pr2 bundle deploy
  3. /tmp/cli-pr2 bundle run pr2_include_demo --no-wait

bundle deploy uploads the code source and launch scripts automatically.
To see what it deployed and where: /tmp/cli-pr2 bundle summary

Unlike `air run` (which submits an ephemeral run), bundle deploy creates a
persistent job that is not garbage-collected. When you are done, remove the
job and its uploaded files with:
  /tmp/cli-pr2 bundle destroy
```
investigate artifacts:
```
$ cat databricks.yml
cat generated_artifacts/command.sh
bundle:
  name: pr2_include_demo
sync:
  paths:
    - generated_artifacts
artifacts:
  code_source:
    type: tgz
    path: .
    include:
      - src/train.py
      - src/command.sh
    files:
      - source: ./dist/code_source.tgz
targets:
  dev:
    mode: development
    default: true
resources:
  jobs:
    pr2_include_demo:
      name: pr2_include_demo
      tasks:
        - task_key: pr2_include_demo
          environment_key: default
          max_retries: 3
          ai_runtime_task:
            experiment: pr2_include_demo
            deployments:
              - command_path: ./generated_artifacts/command.sh
                compute:
                  accelerator_type: GPU_1xA10
                  accelerator_count: 1
            code_source_path: ./dist/code_source.tgz
      environments:
        - environment_key: default
          spec:
            environment_version: "4"
cd /databricks/code_source/src
python train.py%  
```
deploy:
```
$ /tmp/cli-pr2 bundle validate && /tmp/cli-pr2 bundle deploy
Name: pr2_include_demo
Target: dev
Workspace:
  User: v.chen@databricks.com
  Path: /Workspace/Users/v.chen@databricks.com/.bundle/pr2_include_demo/dev

Validation OK!
Building code_source...
Uploading dist/code_source.tgz...
Uploading bundle files to /Workspace/Users/v.chen@databricks.com/.bundle/pr2_include_demo/dev/files...
Files: 2 uploaded, 0 deleted
Resources: 0 created, 0 changed, 0 deleted, 1 unchanged
# v.chen at ip-10-90-20-219 in /tmp/pr2-include (git:) [19:22:29]
$ tar tzf dist/code_source.tgz
src/command.sh
src/train.py
```
run:
```
# v.chen at ip-10-90-20-219 in /tmp/pr2-include (git:) [19:22:34]
$ /tmp/cli-pr2 bundle summary
Name: pr2_include_demo
Target: dev
Workspace:
  User: v.chen@databricks.com
  Path: /Workspace/Users/v.chen@databricks.com/.bundle/pr2_include_demo/dev
Resources:
  Jobs:
    pr2_include_demo:
      Name: [dev v_chen] pr2_include_demo
      URL:  https://e2-dogfood.staging.cloud.databricks.com/jobs/212600874211444?w=6051921418418893
# v.chen at ip-10-90-20-219 in /tmp/pr2-include (git:) [19:22:39]
$ /tmp/cli-pr2 bundle run pr2_include_demo --no-wait
Run URL: https://e2-dogfood.staging.cloud.databricks.com/jobs/212600874211444/runs/882449706897243?o=6051921418418893
```
<img width="1421" height="510" alt="image" src="https://github.com/user-attachments/assets/ef824a46-9288-4ef3-aee0-537231949a6e" />
<img width="1043" height="530" alt="image" src="https://github.com/user-attachments/assets/ce9fbb9d-496f-4736-95bb-211a9ee0fe36" />


TEST GIT
Setup dirty git:
```
# v.chen at ip-10-90-20-219 in /tmp/pr2-include (git:) [19:22:48]
$ rm -rf /tmp/pr2-git && mkdir -p /tmp/pr2-git/src && cd /tmp/pr2-git
git init -q -b main
printf 'print("git v1 committed")\n' > src/train.py
printf 'python train.py\n'           > src/command.sh
git add -A && git commit -qm "v1"
Databricks pre-commit Git Hook V2.5.0
Running secret scanning on changes staged for commit.
secret-scan hook completed in 74 ms
Unknown project name: None, skipping linting.
pre-commit-total hook completed in 90 ms
Databricks commit-msg Git Hook V2.5.0
Running secret scanning on commit message.
secret-scan hook completed in 23 ms
commit-msg-total hook completed in 29 ms
# v.chen at ip-10-90-20-219 in /tmp/pr2-git (git:main) [19:26:30]
$ printf 'print("v2 UNCOMMITTED - should NOT appear")\n' > src/train.py

cat > train.yaml <<'YAML'
experiment_name: pr2_git_demo
command: python train.py
compute: {accelerator_type: GPU_1xA10, num_accelerators: 1}
code_source:
  type: snapshot
  snapshot:
    root_path: ./src
    git: {branch: main}
YAML

```
convert to dabs and investigate artifact:
```
$ /tmp/cli-pr2 experimental air convert-to-dabs train.yaml
cat databricks.yml
Wrote a Databricks Asset Bundle to .:
  databricks.yml
  generated_artifacts/training_config.yaml
  generated_artifacts/command.sh

To deploy and run this workload as a bundle:
  1. /tmp/cli-pr2 bundle validate
  2. /tmp/cli-pr2 bundle deploy
  3. /tmp/cli-pr2 bundle run pr2_git_demo --no-wait

bundle deploy uploads the code source and launch scripts automatically.
To see what it deployed and where: /tmp/cli-pr2 bundle summary

Unlike `air run` (which submits an ephemeral run), bundle deploy creates a
persistent job that is not garbage-collected. When you are done, remove the
job and its uploaded files with:
  /tmp/cli-pr2 bundle destroy
bundle:
  name: pr2_git_demo
sync:
  paths:
    - generated_artifacts
artifacts:
  code_source:
    type: tgz
    path: .
    git:
      branch: main
    include:
      - src
    files:
      - source: ./dist/code_source.tgz
targets:
  dev:
    mode: development
    default: true
resources:
  jobs:
    pr2_git_demo:
      name: pr2_git_demo
      tasks:
        - task_key: pr2_git_demo
          environment_key: default
          max_retries: 3
          ai_runtime_task:
            experiment: pr2_git_demo
            deployments:
              - command_path: ./generated_artifacts/command.sh
                compute:
                  accelerator_type: GPU_1xA10
                  accelerator_count: 1
            code_source_path: ./dist/code_source.tgz
      environments:
        - environment_key: default
          spec:
            environment_version: "4"
```
deploy:
```
$ /tmp/cli-pr2 bundle validate && /tmp/cli-pr2 bundle deploy
Name: pr2_git_demo
Target: dev
Workspace:
  User: v.chen@databricks.com
  Path: /Workspace/Users/v.chen@databricks.com/.bundle/pr2_git_demo/dev

Validation OK!
Building code_source...
Uploading dist/code_source.tgz...
Uploading bundle files to /Workspace/Users/v.chen@databricks.com/.bundle/pr2_git_demo/dev/files...
Created jobs.pr2_git_demo
Files: 2 uploaded, 0 deleted
Resources: 1 created, 0 changed, 0 deleted, 0 unchanged
```
Prove we properly exclude dirty git:
```
# v.chen at ip-10-90-20-219 in /tmp/pr2-git (git:main) [19:28:02]
$ mkdir -p /tmp/pr2-git-check && tar xzf dist/code_source.tgz -C /tmp/pr2-git-check
grep -R "committed" /tmp/pr2-git-check/src/train.py    # -> "git v1 committed"
grep -R "UNCOMMITTED" /tmp/pr2-git-check/src/train.py || echo "OK: uncommitted change correctly excluded"
print("git v1 committed")
OK: uncommitted change correctly excluded
```

run:
```
$ /tmp/cli-pr2 bundle summary
Name: pr2_git_demo
Target: dev
Workspace:
  User: v.chen@databricks.com
  Path: /Workspace/Users/v.chen@databricks.com/.bundle/pr2_git_demo/dev
Resources:
  Jobs:
    pr2_git_demo:
      Name: [dev v_chen] pr2_git_demo
      URL:  https://e2-dogfood.staging.cloud.databricks.com/jobs/235795448342543?w=6051921418418893
# v.chen at ip-10-90-20-219 in /tmp/pr2-git (git:main) [19:28:47]
$ /tmp/cli-pr2 bundle run pr2_git_demo --no-wait
Run URL: https://e2-dogfood.staging.cloud.databricks.com/jobs/235795448342543/runs/137864060324526?o=6051921418418893
```
<img width="1437" height="539" alt="image" src="https://github.com/user-attachments/assets/0474aba1-2b4c-4cf1-b646-34a785efdc88" />
<img width="1035" height="494" alt="image" src="https://github.com/user-attachments/assets/5a72ec33-03e7-4df1-9385-cdd942cfadf4" />
