### PR TITLE
Fix race condition in TestJobRunWaitAbandonedLinksTheRun

### DIFF
--- a/bundle/direct/dresources/job_run_test.go
+++ b/bundle/direct/dresources/job_run_test.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
-	"time"
 
 	"github.com/databricks/cli/libs/structs/structpath"
 	"github.com/databricks/cli/libs/testserver"
@@ -232,10 +231,22 @@ func TestJobRunWaitReportsOnlyTheLastAttemptOfATask(t *testing.T) {
 }
 
 func TestJobRunWaitAbandonedLinksTheRun(t *testing.T) {
-	client := jobRunClient(t, &jobs.RunState{LifeCycleState: jobs.RunLifeCycleStateRunning})
-
-	ctx, cancel := context.WithTimeout(t.Context(), time.Millisecond)
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
+
+	// The first poll reports the run page and finds the run still going; the
+	// second cancels the wait. Driving the interrupt from the handler keeps it
+	// deterministic: the run page URL is always captured before the wait ends,
+	// instead of racing a wall-clock timeout against the first GetRun.
+	var gets atomic.Int32
+	client := jobRunServer(t, func(req testserver.Request) any {
+		if gets.Add(1) >= 2 {
+			cancel()
+		}
+		return jobs.Run{RunId: 123, JobId: 456, State: &jobs.RunState{
+			LifeCycleState: jobs.RunLifeCycleStateRunning,
+		}, RunPageUrl: testRunPageURL}
+	})
 
 	_, err := waitForTestRun(t, ctx, client)
 


### PR DESCRIPTION
## Changes
Don't rely on timing - slower machines like CI runners don't guarantee completion

## Why
Observed it during 2 different PR's CI runs, e.g. https://github.com/databricks/cli/actions/runs/33664383046/job/100362562756?pr=6454
```
=== FAIL: bundle/direct/dresources TestJobRunWaitAbandonedLinksTheRun (0.01s)
    job_run_test.go:244: 
        	Error Trace:	/Users/runner/work/cli/cli/bundle/direct/dresources/job_run_test.go:244
        	Error:      	Error "interrupted while waiting for the run to finish: context deadline exceeded" does not contain "run page: https://myworkspace.databricks.test/jobs/456/runs/123?o=900800700600"
        	Test:       	TestJobRunWaitAbandonedLinksTheRun

=== FAIL: bundle/direct/dresources TestJobRunWaitAbandonedLinksTheRun (re-run 1) (0.01s)
    job_run_test.go:244: 
        	Error Trace:	/Users/runner/work/cli/cli/bundle/direct/dresources/job_run_test.go:244
        	Error:      	Error "interrupted while waiting for the run to finish: context deadline exceeded" does not contain "run page: https://myworkspace.databricks.test/jobs/456/runs/123?o=900800700600"
        	Test:       	TestJobRunWaitAbandonedLinksTheRun

=== FAIL: bundle/direct/dresources TestJobRunWaitAbandonedLinksTheRun (re-run 2) (0.00s)
    job_run_test.go:244: 
        	Error Trace:	/Users/runner/work/cli/cli/bundle/direct/dresources/job_run_test.go:244
        	Error:      	Error "interrupted while waiting for the run to finish: context deadline exceeded" does not contain "run page: https://myworkspace.databricks.test/jobs/456/runs/123?o=900800700600"
        	Test:       	TestJobRunWaitAbandonedLinksTheRun
```

## Tests
Ran repeatedly in local, all passed (before failure rate was ~8%)