### PR TITLE
Make file count validation to not do remote path checks

### DIFF
--- a/acceptance/bundle/resource_deps/remote_app_url/output.txt
+++ b/acceptance/bundle/resource_deps/remote_app_url/output.txt
@@ -15,13 +15,6 @@ create pipelines.mypipeline
 Plan: 2 to add, 0 to change, 0 to delete, 0 unchanged
 
 >>> print_requests.py --nostamp ^//import-file/ ^//api/2.0/bundle
-{
-  "method": "POST",
-  "path": "/api/2.0/workspace/mkdirs",
-  "body": {
-    "path": "/Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files"
-  }
-}
 
 >>> [CLI] bundle deploy
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files...
@@ -51,6 +44,13 @@ Resources: 2 created, 0 changed, 0 deleted, 0 unchanged
   "path": "/api/2.0/workspace/mkdirs",
   "body": {
     "path": "/Workspace/Users/[USERNAME]/.bundle/test-bundle/default/artifacts/.internal"
+  }
+}
+{
+  "method": "POST",
+  "path": "/api/2.0/workspace/mkdirs",
+  "body": {
+    "path": "/Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files"
   }
 }
 {

--- a/acceptance/bundle/run/inline-script/databricks-cli/target-is-passed/default/out.requests.txt
+++ b/acceptance/bundle/run/inline-script/databricks-cli/target-is-passed/default/out.requests.txt
@@ -11,39 +11,3 @@
   "method": "GET",
   "path": "/api/2.0/preview/scim/v2/Me"
 }
-{
-  "headers": {
-    "Authorization": [
-      "Bearer [DATABRICKS_TOKEN]"
-    ]
-  },
-  "method": "GET",
-  "path": "/api/2.0/workspace/get-status",
-  "q": {
-    "path": "/Workspace/Users/[USERNAME]/.bundle/test-bundle/pat/files"
-  }
-}
-{
-  "headers": {
-    "Authorization": [
-      "Bearer [DATABRICKS_TOKEN]"
-    ]
-  },
-  "method": "POST",
-  "path": "/api/2.0/workspace/mkdirs",
-  "body": {
-    "path": "/Workspace/Users/[USERNAME]/.bundle/test-bundle/pat/files"
-  }
-}
-{
-  "headers": {
-    "Authorization": [
-      "Bearer [DATABRICKS_TOKEN]"
-    ]
-  },
-  "method": "GET",
-  "path": "/api/2.0/workspace/get-status",
-  "q": {
-    "path": "/Workspace/Users/[USERNAME]/.bundle/test-bundle/pat/files"
-  }
-}

--- a/acceptance/bundle/run/inline-script/databricks-cli/target-is-passed/from_flag/out.requests.txt
+++ b/acceptance/bundle/run/inline-script/databricks-cli/target-is-passed/from_flag/out.requests.txt
@@ -39,39 +39,3 @@
   "method": "GET",
   "path": "/api/2.0/preview/scim/v2/Me"
 }
-{
-  "headers": {
-    "Authorization": [
-      "Bearer oauth-token"
-    ]
-  },
-  "method": "GET",
-  "path": "/api/2.0/workspace/get-status",
-  "q": {
-    "path": "/Workspace/Users/[USERNAME]/.bundle/test-bundle/oauth/files"
-  }
-}
-{
-  "headers": {
-    "Authorization": [
-      "Bearer oauth-token"
-    ]
-  },
-  "method": "POST",
-  "path": "/api/2.0/workspace/mkdirs",
-  "body": {
-    "path": "/Workspace/Users/[USERNAME]/.bundle/test-bundle/oauth/files"
-  }
-}
-{
-  "headers": {
-    "Authorization": [
-      "Bearer oauth-token"
-    ]
-  },
-  "method": "GET",
-  "path": "/api/2.0/workspace/get-status",
-  "q": {
-    "path": "/Workspace/Users/[USERNAME]/.bundle/test-bundle/oauth/files"
-  }
-}

--- a/acceptance/bundle/run/scripts/databricks-cli/target-is-passed/default/out.requests.txt
+++ b/acceptance/bundle/run/scripts/databricks-cli/target-is-passed/default/out.requests.txt
@@ -24,39 +24,3 @@
   "method": "GET",
   "path": "/api/2.0/preview/scim/v2/Me"
 }
-{
-  "headers": {
-    "Authorization": [
-      "Bearer [DATABRICKS_TOKEN]"
-    ]
-  },
-  "method": "GET",
-  "path": "/api/2.0/workspace/get-status",
-  "q": {
-    "path": "/Workspace/Users/[USERNAME]/.bundle/foobar/pat/files"
-  }
-}
-{
-  "headers": {
-    "Authorization": [
-      "Bearer [DATABRICKS_TOKEN]"
-    ]
-  },
-  "method": "POST",
-  "path": "/api/2.0/workspace/mkdirs",
-  "body": {
-    "path": "/Workspace/Users/[USERNAME]/.bundle/foobar/pat/files"
-  }
-}
-{
-  "headers": {
-    "Authorization": [
-      "Bearer [DATABRICKS_TOKEN]"
-    ]
-  },
-  "method": "GET",
-  "path": "/api/2.0/workspace/get-status",
-  "q": {
-    "path": "/Workspace/Users/[USERNAME]/.bundle/foobar/pat/files"
-  }
-}

--- a/acceptance/bundle/run/scripts/databricks-cli/target-is-passed/from_flag/out.requests.txt
+++ b/acceptance/bundle/run/scripts/databricks-cli/target-is-passed/from_flag/out.requests.txt
@@ -52,39 +52,3 @@
   "method": "GET",
   "path": "/api/2.0/preview/scim/v2/Me"
 }
-{
-  "headers": {
-    "Authorization": [
-      "Bearer oauth-token"
-    ]
-  },
-  "method": "GET",
-  "path": "/api/2.0/workspace/get-status",
-  "q": {
-    "path": "/Workspace/Users/[USERNAME]/.bundle/foobar/oauth/files"
-  }
-}
-{
-  "headers": {
-    "Authorization": [
-      "Bearer oauth-token"
-    ]
-  },
-  "method": "POST",
-  "path": "/api/2.0/workspace/mkdirs",
-  "body": {
-    "path": "/Workspace/Users/[USERNAME]/.bundle/foobar/oauth/files"
-  }
-}
-{
-  "headers": {
-    "Authorization": [
-      "Bearer oauth-token"
-    ]
-  },
-  "method": "GET",
-  "path": "/api/2.0/workspace/get-status",
-  "q": {
-    "path": "/Workspace/Users/[USERNAME]/.bundle/foobar/oauth/files"
-  }
-}

--- a/bundle/config/validate/files_to_sync_test.go
+++ b/bundle/config/validate/files_to_sync_test.go
@@ -12,9 +12,7 @@ import (
 	sdkconfig "github.com/databricks/databricks-sdk-go/config"
 	"github.com/databricks/databricks-sdk-go/experimental/mocks"
 	"github.com/databricks/databricks-sdk-go/service/iam"
-	"github.com/databricks/databricks-sdk-go/service/workspace"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -65,12 +63,6 @@ func setupBundleForFilesToSyncTest(t *testing.T) *bundle.Bundle {
 	m.WorkspaceClient.Config = &sdkconfig.Config{
 		Host: "https://foo.test",
 	}
-
-	// The initialization logic in [sync.New] performs a check on the destination path.
-	// Removing this check at initialization time is tbd...
-	m.GetMockWorkspaceAPI().EXPECT().GetStatusByPath(mock.Anything, "/this/doesnt/matter").Return(&workspace.ObjectInfo{
-		ObjectType: workspace.ObjectTypeDirectory,
-	}, nil)
 
 	b.SetWorkpaceClient(m.WorkspaceClient)
 	return b

--- a/bundle/deploy/files/sync.go
+++ b/bundle/deploy/files/sync.go
@@ -8,11 +8,15 @@ import (
 	"github.com/databricks/cli/libs/sync"
 )
 
+// GetSync returns a new sync instance for the given bundle.
+// The sync instance will be in no validate remote path mode because it's only used to validate files to sync.
+// It does not check or create the remote path.
 func GetSync(ctx context.Context, b *bundle.Bundle) (*sync.Sync, error) {
 	opts, err := GetSyncOptions(ctx, b)
 	if err != nil {
 		return nil, fmt.Errorf("cannot get sync options: %w", err)
 	}
+	opts.NoValidateRemotePath = true
 	return sync.New(ctx, *opts)
 }
 

--- a/libs/sync/sync.go
+++ b/libs/sync/sync.go
@@ -49,6 +49,8 @@ type SyncOptions struct {
 	OutputHandler OutputHandler
 
 	DryRun bool
+
+	NoValidateRemotePath bool
 }
 
 type Sync struct {

--- a/libs/sync/sync.go
+++ b/libs/sync/sync.go
@@ -84,10 +84,12 @@ func New(ctx context.Context, opts SyncOptions) (*Sync, error) {
 
 	WriteGitIgnore(ctx, opts.LocalRoot.Native())
 
-	// Verify that the remote path we're about to synchronize to is valid and allowed.
-	err = EnsureRemotePathIsUsable(ctx, opts.WorkspaceClient, opts.RemotePath, opts.CurrentUser, opts.DryRun)
-	if err != nil {
-		return nil, err
+	if !opts.NoValidateRemotePath {
+		// Verify that the remote path we're about to synchronize to is valid and allowed.
+		err = EnsureRemotePathIsUsable(ctx, opts.WorkspaceClient, opts.RemotePath, opts.CurrentUser, opts.DryRun)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// TODO: The host may be late-initialized in certain Azure setups where we


### PR DESCRIPTION
## Changes
Make file count validation to not do remote path checks

## Why
`files_to_validate` check which is run on `bundle validate` and only used to count local files to be uploaded did a remote calls to check that remote paths are there even though it should not

Discovered in #6084 where the remote path is not known and existent until the deploy

## Tests
Covered by existing acceptance tests

<!-- If your PR needs to be included in the release notes for next release,
add a changelog fragment: create .nextchanges/<section>/<name>.md with a
one-line description (e.g. .nextchanges/cli/quickstart.md). See .nextchanges/README.md. -->
