### PR TITLE
acc: Clean up secrets in cloud tests

### DIFF
--- a/acceptance/bundle/resources/secrets/remove-expire-time/output.txt
+++ b/acceptance/bundle/resources/secrets/remove-expire-time/output.txt
@@ -58,3 +58,11 @@ update secrets.secret1
 Plan: 0 to add, 1 to change, 0 to delete, 0 unchanged
 
 >>> [CLI] bundle plan --var secret_value=secret-value -o json
+
+>>> [CLI] bundle destroy --auto-approve --var secret_value=initial-secret-value
+The following resources will be deleted:
+  delete resources.secrets.secret1
+
+All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/test-bundle-[UNIQUE_NAME]/default
+
+Destroy: 1 deleted

--- a/acceptance/bundle/resources/secrets/remove-expire-time/script
+++ b/acceptance/bundle/resources/secrets/remove-expire-time/script
@@ -1,5 +1,11 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
+cleanup() {
+    trace $CLI bundle destroy --auto-approve --var secret_value=initial-secret-value
+    rm out.requests.txt
+}
+trap cleanup EXIT
+
 trace $CLI bundle deploy --var secret_value=secret-value
 trace print_requests.py //unity-catalog
 read_state.py secrets secret1 name expire_time

--- a/acceptance/bundle/resources/secrets/update-expire-time/output.txt
+++ b/acceptance/bundle/resources/secrets/update-expire-time/output.txt
@@ -51,3 +51,11 @@ Resources: 0 created, 1 changed, 0 deleted, 0 unchanged
   }
 }
 secrets secret1 name='test_secret_[UNIQUE_NAME]' expire_time='[EXPIRE_TIME_AFTER]'
+
+>>> [CLI] bundle destroy --auto-approve --var secret_value=initial-secret-value
+The following resources will be deleted:
+  delete resources.secrets.secret1
+
+All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/test-bundle-[UNIQUE_NAME]/default
+
+Destroy: 1 deleted

--- a/acceptance/bundle/resources/secrets/update-expire-time/script
+++ b/acceptance/bundle/resources/secrets/update-expire-time/script
@@ -1,5 +1,11 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
+cleanup() {
+    trace $CLI bundle destroy --auto-approve --var secret_value=initial-secret-value
+    rm out.requests.txt
+}
+trap cleanup EXIT
+
 trace $CLI bundle deploy --var secret_value=secret-value
 trace print_requests.py //unity-catalog
 read_state.py secrets secret1 name expire_time


### PR DESCRIPTION
## Changes
Clean up secrets in cloud tests

## Why
These tests were missing bundle destroy calls on exit

## Tests
Tests pass

<!-- If your PR needs to be included in the release notes for next release,
add a changelog fragment: create .nextchanges/<section>/<name>.md with a
one-line description (e.g. .nextchanges/cli/quickstart.md). See .nextchanges/README.md. -->
