### PR TITLE
Remove forward_user_access_token from update_mask for Apps

### DIFF
--- a/.nextchanges/bundles/forward_user_access_token.md
+++ b/.nextchanges/bundles/forward_user_access_token.md
@@ -1,0 +1,1 @@
+Remove forward_user_access_token from update_mask for Apps because it's not supported. Fixes regression in 1.14.1

--- a/.nextchanges/bundles/forward_user_access_token.md
+++ b/.nextchanges/bundles/forward_user_access_token.md
@@ -1,1 +1,1 @@
-Remove forward_user_access_token from update_mask for Apps because it's not supported. Fixes regression in 1.14.1
+* Remove forward_user_access_token from update_mask for Apps because it's not supported. Fixes regression in 1.14.1

--- a/.nextchanges/bundles/forward_user_access_token.md
+++ b/.nextchanges/bundles/forward_user_access_token.md
@@ -1,1 +1,1 @@
-* Remove forward_user_access_token from update_mask for Apps because it's not supported. Fixes regression in 1.14.1.
+* Remove forward_user_access_token from update_mask for Apps because it's not supported. Fixes regression in 1.14.1. ([#6510](https://github.com/databricks/cli/pull/6510))

--- a/.nextchanges/bundles/forward_user_access_token.md
+++ b/.nextchanges/bundles/forward_user_access_token.md
@@ -1,1 +1,1 @@
-* Remove forward_user_access_token from update_mask for Apps because it's not supported. Fixes regression in 1.14.1
+* Remove forward_user_access_token from update_mask for Apps because it's not supported. Fixes regression in 1.14.1.

--- a/acceptance/bundle/resources/apps/lifecycle-started/output.txt
+++ b/acceptance/bundle/resources/apps/lifecycle-started/output.txt
@@ -90,7 +90,7 @@ Resources: 0 created, 1 changed, 0 deleted, 0 unchanged
       "description": "MY_APP_DESCRIPTION_2",
       "name": "[UNIQUE_NAME]"
     },
-    "update_mask": "description,budget_policy_id,usage_policy_id,resources,user_api_scopes,forward_user_access_token,compute_size,compute_min_instances,compute_max_instances,git_repository,telemetry_export_destinations"
+    "update_mask": "description,budget_policy_id,usage_policy_id,resources,user_api_scopes,compute_size,compute_min_instances,compute_max_instances,git_repository,telemetry_export_destinations"
   }
 }
 
@@ -117,7 +117,7 @@ Resources: 0 created, 1 changed, 0 deleted, 0 unchanged
       "description": "MY_APP_DESCRIPTION_3",
       "name": "[UNIQUE_NAME]"
     },
-    "update_mask": "description,budget_policy_id,usage_policy_id,resources,user_api_scopes,forward_user_access_token,compute_size,compute_min_instances,compute_max_instances,git_repository,telemetry_export_destinations"
+    "update_mask": "description,budget_policy_id,usage_policy_id,resources,user_api_scopes,compute_size,compute_min_instances,compute_max_instances,git_repository,telemetry_export_destinations"
   }
 }
 {

--- a/acceptance/bundle/resources/apps/update/out.requests.direct.json
+++ b/acceptance/bundle/resources/apps/update/out.requests.direct.json
@@ -17,7 +17,7 @@
       "description": "MY_APP_DESCRIPTION",
       "name": "myappname"
     },
-    "update_mask": "description,budget_policy_id,usage_policy_id,resources,user_api_scopes,forward_user_access_token,compute_size,compute_min_instances,compute_max_instances,git_repository,telemetry_export_destinations"
+    "update_mask": "description,budget_policy_id,usage_policy_id,resources,user_api_scopes,compute_size,compute_min_instances,compute_max_instances,git_repository,telemetry_export_destinations"
   }
 }
 {

--- a/bundle/direct/dresources/app.go
+++ b/bundle/direct/dresources/app.go
@@ -170,7 +170,6 @@ var UpdateMaskFields = []string{
 	"usage_policy_id",
 	"resources",
 	"user_api_scopes",
-	"forward_user_access_token",
 	"compute_size",
 	"compute_min_instances",
 	"compute_max_instances",

--- a/bundle/direct/dresources/app_test.go
+++ b/bundle/direct/dresources/app_test.go
@@ -129,7 +129,8 @@ func TestAppDoUpdate_UpdateMaskHasAllFields(t *testing.T) {
 	// iterate over all apps.App fields using reflection and ensure that UpdateMaskFields contains all of them.
 	config := GetGeneratedResourceConfig("apps")
 	require.NotNil(t, config)
-	var nonUpdatableFields []string
+	// forward_user_access_token is not supported, so it's not in UpdateMaskFields.
+	nonUpdatableFields := []string{"forward_user_access_token"}
 	for _, field := range config.IgnoreRemoteChanges {
 		nonUpdatableFields = append(nonUpdatableFields, field.Field.String())
 	}


### PR DESCRIPTION
## Changes
Remove forward_user_access_token from update_mask for Apps

## Why
Fixes #6496

## Tests
Existing tests pass

<!-- If your PR needs to be included in the release notes for next release,
add a changelog fragment: create .nextchanges/<section>/<name>.md with a
one-line description (e.g. .nextchanges/cli/quickstart.md). See .nextchanges/README.md. -->
