### PR TITLE
acc: cut TestInprocessMode from 44s to under 1s

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -529,10 +529,10 @@ tasks:
       # acceptance/install_terraform.py parses the provider version from this file.
       - bundle/internal/tf/codegen/schema/version.go
       - acceptance/**
-      # Pydabs wheel is built in-process by TestInprocessMode (cd python && uv build).
+      # Pydabs wheel is built in-process by TestAccept (cd python && uv build).
       - python/**
       - libs/vendored_py_packages/**
-      # TestInprocessMode builds yamlfmt via tools/go.mod.
+      # TestAccept builds yamlfmt via tools/go.mod.
       - tools/go.mod
       - tools/go.sum
       - go.mod

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -132,7 +132,7 @@ var Scripts = map[string]bool{
 }
 
 func TestAccept(t *testing.T) {
-	testAccept(t, InprocessMode, "")
+	testAccept(t, InprocessMode, nil, false)
 }
 
 func TestInprocessMode(t *testing.T) {
@@ -147,8 +147,13 @@ func TestInprocessMode(t *testing.T) {
 	// testutil.LoadDebugEnvIfRunFromIDE(t, "workspace")
 	// Run the "deco env flip workspace" command to configure a workspace.
 
-	require.Equal(t, 1, testAccept(t, true, "selftest/basic"))
-	require.Equal(t, 1, testAccept(t, true, "selftest/server"))
+	// Keep this to a single cheap test: it only needs to catch in-process mode
+	// rotting, and every testAccept call redoes the whole setup. This used to run
+	// selftest/server too, which meant a second setup after StartDefaultServer had
+	// pointed HOME at an empty temp dir, so building yamlfmt there re-downloaded the
+	// entire module cache: 44s on Linux CI, 140s on Windows. Tool builds are skipped
+	// for the same reason - selftest/basic uses neither terraform, the wheel, nor yamlfmt.
+	require.Equal(t, 1, testAccept(t, true, []string{"selftest/basic"}, true))
 }
 
 // Configure replacements for environment variables we read from test environments.
@@ -219,7 +224,11 @@ func requirePrerequisites(t *testing.T) bool {
 	})
 }
 
-func testAccept(t *testing.T, inprocessMode bool, singleTest string) int {
+// selectedTests, when non-empty, limits the run to those test directories.
+// skipToolBuilds skips building the tools that the selected tests do not use
+// (terraform, the databricks-bundles wheel, yamlfmt); it must stay false for a
+// full run.
+func testAccept(t *testing.T, inprocessMode bool, selectedTests []string, skipToolBuilds bool) int {
 	if testdiff.OverwriteMode && !hasRunFilter() {
 		Subset = true
 	}
@@ -274,7 +283,7 @@ func testAccept(t *testing.T, inprocessMode bool, singleTest string) int {
 	buildDir := getBuildDir(t, cwd, runtime.GOOS, runtime.GOARCH)
 
 	// Set up terraform for tests. Skip on DBR - tests with RunsOnDbr only use direct deployment.
-	if !WorkspaceTmpDir {
+	if !WorkspaceTmpDir && !skipToolBuilds {
 		setupTerraform(t, cwd, buildDir, &repls)
 	}
 
@@ -287,7 +296,10 @@ func testAccept(t *testing.T, inprocessMode bool, singleTest string) int {
 	t.Setenv("UV_FIND_LINKS", vendoredPyPackages)
 	t.Setenv("UV_OFFLINE", "true")
 
-	wheelPath := buildDatabricksBundlesWheel(t, buildDir)
+	wheelPath := ""
+	if !skipToolBuilds {
+		wheelPath = buildDatabricksBundlesWheel(t, buildDir)
+	}
 	if wheelPath != "" {
 		t.Setenv("DATABRICKS_BUNDLES_WHEEL", wheelPath)
 		repls.SetPath(wheelPath, "[DATABRICKS_BUNDLES_WHEEL]")
@@ -346,7 +358,7 @@ func testAccept(t *testing.T, inprocessMode bool, singleTest string) int {
 	// Skip building yamlfmt when running on workspace filesystem (DBR).
 	// This fails today on DBR. Can be looked into and fixed as a follow-up
 	// as and when needed.
-	if !WorkspaceTmpDir {
+	if !WorkspaceTmpDir && !skipToolBuilds {
 		BuildYamlfmt(t)
 	}
 
@@ -471,11 +483,11 @@ func testAccept(t *testing.T, inprocessMode bool, singleTest string) int {
 	}
 	subset.changed = changedTests
 
-	if singleTest != "" {
+	if len(selectedTests) > 0 {
 		testDirs = slices.DeleteFunc(testDirs, func(n string) bool {
-			return n != singleTest
+			return !slices.Contains(selectedTests, n)
 		})
-		require.NotEmpty(t, testDirs, "singleTest=%#v did not match any tests\n%#v", singleTest, testDirs)
+		require.Len(t, testDirs, len(selectedTests), "selectedTests=%#v did not match all tests\n%#v", selectedTests, testDirs)
 	}
 
 	skippedDirs := 0


### PR DESCRIPTION
## Changes

Run a single selftest in `TestInprocessMode` instead of two, and skip the tool builds it does not need (terraform, the databricks-bundles wheel, yamlfmt).

## Why

The test took 44s on Linux CI, 76-95s on macOS and 114-141s on Windows, of which under 6s was actual test work. It called `testAccept` twice, and each call redoes the whole setup. The second one ran after `StartDefaultServer` had pointed HOME at an empty temp dir, so `go tool ... task build-yamlfmt` re-downloaded the entire module cache there: 0.75s on the first call, 64s on the second.

The trap itself remains for anything added to the setup after `StartDefaultServer` that shells out to `go`; pinning GOMODCACHE/GOCACHE would close it off, but that is a separate change.

## Tests

Existing test, 76s -> 1.1s locally. `selftest/basic` still covers the in-process path end to end ($CLI through callserver.py, output capture, repls); `selftest/server` still runs under `TestAccept`. Checked that `TestAccept` and `-inprocess` still do the full setup.

_This PR was written by Claude Code._