### PR TITLE
internal: Add MarshalJSON to resource types that inherited one by promotion

### DIFF
--- a/bundle/config/resources/dashboard.go
+++ b/bundle/config/resources/dashboard.go
@@ -89,6 +89,14 @@ type Dashboard struct {
 	FilePath string `json:"file_path,omitempty"`
 }
 
+func (r *Dashboard) UnmarshalJSON(b []byte) error {
+	return marshal.Unmarshal(b, r)
+}
+
+func (r Dashboard) MarshalJSON() ([]byte, error) {
+	return marshal.Marshal(r)
+}
+
 func (*Dashboard) Exists(ctx context.Context, w *databricks.WorkspaceClient, id string) (bool, error) {
 	_, err := w.Lakeview.Get(ctx, dashboards.GetDashboardRequest{
 		DashboardId: id,

--- a/bundle/config/resources/database_catalog.go
+++ b/bundle/config/resources/database_catalog.go
@@ -8,12 +8,21 @@ import (
 	"github.com/databricks/cli/libs/workspaceurls"
 
 	"github.com/databricks/databricks-sdk-go"
+	"github.com/databricks/databricks-sdk-go/marshal"
 	"github.com/databricks/databricks-sdk-go/service/database"
 )
 
 type DatabaseCatalog struct {
 	BaseResource
 	database.DatabaseCatalog
+}
+
+func (d *DatabaseCatalog) UnmarshalJSON(b []byte) error {
+	return marshal.Unmarshal(b, d)
+}
+
+func (d DatabaseCatalog) MarshalJSON() ([]byte, error) {
+	return marshal.Marshal(d)
 }
 
 func (d *DatabaseCatalog) Exists(ctx context.Context, w *databricks.WorkspaceClient, name string) (bool, error) {

--- a/bundle/config/resources/database_instance.go
+++ b/bundle/config/resources/database_instance.go
@@ -8,6 +8,7 @@ import (
 	"github.com/databricks/cli/libs/workspaceurls"
 
 	"github.com/databricks/databricks-sdk-go"
+	"github.com/databricks/databricks-sdk-go/marshal"
 	"github.com/databricks/databricks-sdk-go/service/database"
 )
 
@@ -16,6 +17,14 @@ type DatabaseInstance struct {
 	database.DatabaseInstance
 
 	Permissions []Permission `json:"permissions,omitempty"`
+}
+
+func (d *DatabaseInstance) UnmarshalJSON(b []byte) error {
+	return marshal.Unmarshal(b, d)
+}
+
+func (d DatabaseInstance) MarshalJSON() ([]byte, error) {
+	return marshal.Marshal(d)
 }
 
 func (d *DatabaseInstance) Exists(ctx context.Context, w *databricks.WorkspaceClient, name string) (bool, error) {

--- a/bundle/config/resources/genie_space.go
+++ b/bundle/config/resources/genie_space.go
@@ -62,6 +62,14 @@ type GenieSpace struct {
 	FilePath string `json:"file_path,omitempty"`
 }
 
+func (r *GenieSpace) UnmarshalJSON(b []byte) error {
+	return marshal.Unmarshal(b, r)
+}
+
+func (r GenieSpace) MarshalJSON() ([]byte, error) {
+	return marshal.Marshal(r)
+}
+
 func (*GenieSpace) Exists(ctx context.Context, w *databricks.WorkspaceClient, id string) (bool, error) {
 	_, err := w.Genie.GetSpace(ctx, dashboards.GenieGetSpaceRequest{
 		SpaceId: id,

--- a/bundle/config/resources/postgres_branch.go
+++ b/bundle/config/resources/postgres_branch.go
@@ -51,6 +51,14 @@ type PostgresBranch struct {
 	PostgresBranchConfig
 }
 
+func (b *PostgresBranch) UnmarshalJSON(data []byte) error {
+	return marshal.Unmarshal(data, b)
+}
+
+func (b PostgresBranch) MarshalJSON() ([]byte, error) {
+	return marshal.Marshal(b)
+}
+
 func (b *PostgresBranch) Exists(ctx context.Context, w *databricks.WorkspaceClient, name string) (bool, error) {
 	_, err := w.Postgres.GetBranch(ctx, postgres.GetBranchRequest{Name: name})
 	if err != nil {

--- a/bundle/config/resources/postgres_catalog.go
+++ b/bundle/config/resources/postgres_catalog.go
@@ -32,6 +32,14 @@ type PostgresCatalog struct {
 	PostgresCatalogConfig
 }
 
+func (c *PostgresCatalog) UnmarshalJSON(b []byte) error {
+	return marshal.Unmarshal(b, c)
+}
+
+func (c PostgresCatalog) MarshalJSON() ([]byte, error) {
+	return marshal.Marshal(c)
+}
+
 func (c *PostgresCatalog) Exists(ctx context.Context, w *databricks.WorkspaceClient, name string) (bool, error) {
 	_, err := w.Postgres.GetCatalog(ctx, postgres.GetCatalogRequest{Name: name})
 	if err != nil {

--- a/bundle/config/resources/postgres_database.go
+++ b/bundle/config/resources/postgres_database.go
@@ -40,6 +40,14 @@ type PostgresDatabase struct {
 	PostgresDatabaseConfig
 }
 
+func (d *PostgresDatabase) UnmarshalJSON(b []byte) error {
+	return marshal.Unmarshal(b, d)
+}
+
+func (d PostgresDatabase) MarshalJSON() ([]byte, error) {
+	return marshal.Marshal(d)
+}
+
 func (d *PostgresDatabase) Exists(ctx context.Context, w *databricks.WorkspaceClient, name string) (bool, error) {
 	_, err := w.Postgres.GetDatabase(ctx, postgres.GetDatabaseRequest{Name: name})
 	if apierr.IsMissing(err) {

--- a/bundle/config/resources/postgres_endpoint.go
+++ b/bundle/config/resources/postgres_endpoint.go
@@ -39,6 +39,14 @@ type PostgresEndpoint struct {
 	PostgresEndpointConfig
 }
 
+func (e *PostgresEndpoint) UnmarshalJSON(b []byte) error {
+	return marshal.Unmarshal(b, e)
+}
+
+func (e PostgresEndpoint) MarshalJSON() ([]byte, error) {
+	return marshal.Marshal(e)
+}
+
 func (e *PostgresEndpoint) Exists(ctx context.Context, w *databricks.WorkspaceClient, name string) (bool, error) {
 	_, err := w.Postgres.GetEndpoint(ctx, postgres.GetEndpointRequest{Name: name})
 	if err != nil {

--- a/bundle/config/resources/postgres_project.go
+++ b/bundle/config/resources/postgres_project.go
@@ -45,6 +45,14 @@ type PostgresProject struct {
 	Permissions []Permission `json:"permissions,omitempty"`
 }
 
+func (p *PostgresProject) UnmarshalJSON(b []byte) error {
+	return marshal.Unmarshal(b, p)
+}
+
+func (p PostgresProject) MarshalJSON() ([]byte, error) {
+	return marshal.Marshal(p)
+}
+
 func (p *PostgresProject) Exists(ctx context.Context, w *databricks.WorkspaceClient, name string) (bool, error) {
 	_, err := w.Postgres.GetProject(ctx, postgres.GetProjectRequest{Name: name})
 	if err != nil {

--- a/bundle/config/resources/postgres_role.go
+++ b/bundle/config/resources/postgres_role.go
@@ -41,6 +41,14 @@ type PostgresRole struct {
 	PostgresRoleConfig
 }
 
+func (r *PostgresRole) UnmarshalJSON(b []byte) error {
+	return marshal.Unmarshal(b, r)
+}
+
+func (r PostgresRole) MarshalJSON() ([]byte, error) {
+	return marshal.Marshal(r)
+}
+
 func (r *PostgresRole) Exists(ctx context.Context, w *databricks.WorkspaceClient, name string) (bool, error) {
 	_, err := w.Postgres.GetRole(ctx, postgres.GetRoleRequest{Name: name})
 	if apierr.IsMissing(err) {

--- a/bundle/config/resources/postgres_synced_table.go
+++ b/bundle/config/resources/postgres_synced_table.go
@@ -34,6 +34,14 @@ type PostgresSyncedTable struct {
 	PostgresSyncedTableConfig
 }
 
+func (s *PostgresSyncedTable) UnmarshalJSON(b []byte) error {
+	return marshal.Unmarshal(b, s)
+}
+
+func (s PostgresSyncedTable) MarshalJSON() ([]byte, error) {
+	return marshal.Marshal(s)
+}
+
 func (s *PostgresSyncedTable) Exists(ctx context.Context, w *databricks.WorkspaceClient, name string) (bool, error) {
 	_, err := w.Postgres.GetSyncedTable(ctx, postgres.GetSyncedTableRequest{Name: name})
 	if err != nil {

--- a/bundle/config/resources/synced_database_table.go
+++ b/bundle/config/resources/synced_database_table.go
@@ -8,12 +8,21 @@ import (
 	"github.com/databricks/cli/libs/workspaceurls"
 
 	"github.com/databricks/databricks-sdk-go"
+	"github.com/databricks/databricks-sdk-go/marshal"
 	"github.com/databricks/databricks-sdk-go/service/database"
 )
 
 type SyncedDatabaseTable struct {
 	BaseResource
 	database.SyncedDatabaseTable
+}
+
+func (s *SyncedDatabaseTable) UnmarshalJSON(b []byte) error {
+	return marshal.Unmarshal(b, s)
+}
+
+func (s SyncedDatabaseTable) MarshalJSON() ([]byte, error) {
+	return marshal.Marshal(s)
 }
 
 func (s *SyncedDatabaseTable) Exists(ctx context.Context, w *databricks.WorkspaceClient, name string) (bool, error) {

--- a/bundle/direct/dresources/serialize_test.go
+++ b/bundle/direct/dresources/serialize_test.go
@@ -3,6 +3,7 @@ package dresources
 import (
 	"encoding/json"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 
@@ -96,8 +97,11 @@ func TestRoundtripFixtureStateType(t *testing.T) {
 // independent of which fields a realistic value would populate. StateType and
 // RemoteType are validated as pointer-to-struct by the adapter, so typeOf always
 // returns a pointer here.
-func testRoundtripAllFields(t *testing.T, label string, typeOf func(*Adapter) reflect.Type) {
+func testRoundtripAllFields(t *testing.T, label string, typeOf func(*Adapter) reflect.Type, skip []string) {
 	for resourceType, resource := range SupportedResources {
+		if slices.Contains(skip, resourceType) {
+			continue
+		}
 		adapter, err := NewAdapter(resource, resourceType, nil)
 		require.NoError(t, err)
 
@@ -112,7 +116,7 @@ func testRoundtripAllFields(t *testing.T, label string, typeOf func(*Adapter) re
 // TestRoundtripAllFieldsStateType verifies StateType survives a JSON round-trip
 // with every field populated. StateType is persisted to the state file.
 func TestRoundtripAllFieldsStateType(t *testing.T) {
-	testRoundtripAllFields(t, "StateType", (*Adapter).StateType)
+	testRoundtripAllFields(t, "StateType", (*Adapter).StateType, nil)
 }
 
 // TestRoundtripAllFieldsRemoteType verifies RemoteType survives a JSON round-trip
@@ -120,7 +124,7 @@ func TestRoundtripAllFieldsStateType(t *testing.T) {
 // field, so a wrapper embedding an SDK type with its own MarshalJSON must define
 // its own or its extra fields vanish.
 func TestRoundtripAllFieldsRemoteType(t *testing.T) {
-	testRoundtripAllFields(t, "RemoteType", (*Adapter).RemoteType)
+	testRoundtripAllFields(t, "RemoteType", (*Adapter).RemoteType, nil)
 }
 
 // TestRoundtripAllFieldsInputConfigType verifies InputConfigType, the typed
@@ -131,8 +135,17 @@ func TestRoundtripAllFieldsRemoteType(t *testing.T) {
 // same trap as StateType and RemoteType: a resource that embeds a member with its
 // own MarshalJSON and defines none of its own inherits that method by promotion
 // and silently drops id, url, lifecycle, modified_status and permissions.
+//
+// cluster_policies is exempt. Its definition and policy_family_definition_overrides
+// are typed `any` and deliberately shadow same-named string fields in the embedded
+// compute.CreatePolicy, so a policy document can be authored as inline YAML
+// (ConfigureClusterPolicyDefinition normalizes it to the JSON string the API wants
+// before deploy). Only the shallower `any` is reachable by that JSON name, but
+// marshal.Unmarshal hands the whole payload to the embedded member, so the shadowed
+// string comes back holding the raw JSON text and reads as a lost field. Its other
+// fields go unchecked on this surface as a result.
 func TestRoundtripAllFieldsInputConfigType(t *testing.T) {
-	testRoundtripAllFields(t, "InputConfigType", (*Adapter).InputConfigType)
+	testRoundtripAllFields(t, "InputConfigType", (*Adapter).InputConfigType, []string{"cluster_policies"})
 }
 
 // fillNonZero recursively populates v with non-zero values so that every
@@ -168,13 +181,8 @@ func fillNonZero(v reflect.Value, depth int) {
 		fillNonZero(val, depth+1)
 		v.SetMapIndex(reflect.ValueOf("k").Convert(v.Type().Key()), val)
 	case reflect.Interface:
-		// A free-form any field is filled with a string rather than a map so that
-		// it also round-trips when it shadows a string field in an embedded struct
-		// (ClusterPolicy.Definition over compute.CreatePolicy.Definition). Only the
-		// shallower field is reachable by that JSON name, but the SDK unmarshaler
-		// writes the raw JSON text into the shadowed one too, so a map would come
-		// back as the string `{"k":"v"}` there and read as a lost field.
-		v.Set(reflect.ValueOf("x"))
+		// Free-form any fields decode to map[string]any from JSON.
+		v.Set(reflect.ValueOf(map[string]any{"k": "v"}))
 	case reflect.Struct:
 		t := v.Type()
 		for i := range t.NumField() {

--- a/bundle/direct/dresources/serialize_test.go
+++ b/bundle/direct/dresources/serialize_test.go
@@ -123,6 +123,18 @@ func TestRoundtripAllFieldsRemoteType(t *testing.T) {
 	testRoundtripAllFields(t, "RemoteType", (*Adapter).RemoteType)
 }
 
+// TestRoundtripAllFieldsInputConfigType verifies InputConfigType, the typed
+// bundle config a resource is loaded into, survives a JSON round-trip with every
+// field populated. Bundle config is normally read and written through libs/dyn,
+// which walks the struct itself and never calls these marshalers, so this is a
+// latent trap rather than live corruption. It is guarded anyway because it is the
+// same trap as StateType and RemoteType: a resource that embeds a member with its
+// own MarshalJSON and defines none of its own inherits that method by promotion
+// and silently drops id, url, lifecycle, modified_status and permissions.
+func TestRoundtripAllFieldsInputConfigType(t *testing.T) {
+	testRoundtripAllFields(t, "InputConfigType", (*Adapter).InputConfigType)
+}
+
 // fillNonZero recursively populates v with non-zero values so that every
 // serializable field is observable in a round-trip. It skips ForceSendFields
 // (json:"-") and bounds recursion depth to avoid runaway on self-referential
@@ -156,8 +168,13 @@ func fillNonZero(v reflect.Value, depth int) {
 		fillNonZero(val, depth+1)
 		v.SetMapIndex(reflect.ValueOf("k").Convert(v.Type().Key()), val)
 	case reflect.Interface:
-		// Free-form any fields decode to map[string]any from JSON.
-		v.Set(reflect.ValueOf(map[string]any{"k": "v"}))
+		// A free-form any field is filled with a string rather than a map so that
+		// it also round-trips when it shadows a string field in an embedded struct
+		// (ClusterPolicy.Definition over compute.CreatePolicy.Definition). Only the
+		// shallower field is reachable by that JSON name, but the SDK unmarshaler
+		// writes the raw JSON text into the shadowed one too, so a map would come
+		// back as the string `{"k":"v"}` there and read as a lost field.
+		v.Set(reflect.ValueOf("x"))
 	case reflect.Struct:
 		t := v.Type()
 		for i := range t.NumField() {


### PR DESCRIPTION
12 of the 33 resource types embed `BaseResource` plus a member that declares its own
`MarshalJSON` (an SDK type, or an inner `*Config`). Go promotes that method to the outer
type, so `json.Marshal` serializes only that member's fields and silently drops
everything else on the struct: `id`, `url`, `lifecycle`, `modified_status` and
`permissions`.

```
PostgresProject -> {"project_id":"proj"}
```

`bundle/direct/dresources/serialize_test.go` was written for exactly this failure mode,
but only pointed at `StateType` and `RemoteType`. Pointing it at `InputConfigType` too
reports all 12. Each gets the same two marshalers the other 21 types already have.

Bundle config is normally read and written through `libs/dyn`, which walks the struct
itself and never calls these marshalers, so this is a latent trap rather than live
corruption - no golden output moves. No changelog entry for that reason.

`cluster_policies` is skipped on the `InputConfigType` surface, with the reason in a
comment: its `definition` is typed `any` and deliberately shadows
`compute.CreatePolicy.Definition` (a string) so the policy document can be authored as
inline YAML, and `marshal.Unmarshal` hands the whole payload to the embedded member, so
the shadowed string comes back holding the raw JSON text and reads as a lost field. It
loses exactly those two fields today and nothing else.

### Side effect worth naming

The new `MarshalJSON` uses a value receiver, per the convention across
`bundle/config/resources/`. For the 7 Postgres types that matters beyond style: the inner
`*Config` declares `MarshalJSON` on a *pointer* receiver, so on `main` only `*T` satisfied
`json.Marshaler` and value-marshalling silently fell back to plain `encoding/json` - a
second code path that ignores `ForceSendFields`. A value receiver collapses the two.

Counting that asymmetry (`*T` marshals itself, `T` does not) across all 34 adapters and 3
surfaces: 14 on `main`, 7 here. The 7 remaining are pre-existing and untouched - 6
`Postgres*Config` reachable as `StateType` via type alias, plus `Secret`. They are latent
too (the state path marshals pointers throughout), and the round-trip test cannot detect
them, since it builds values with `reflect.New` and so only ever marshals a pointer.
Left for a follow-up rather than fixed here, to keep this PR to one change.