### PR TITLE
Fix race condition in proxy test client

### DIFF
--- a/experimental/ssh/internal/proxy/client.go
+++ b/experimental/ssh/internal/proxy/client.go
@@ -78,7 +78,12 @@ func RunClientProxy(ctx context.Context, src io.ReadCloser, dst io.Writer, reque
 			for {
 				select {
 				case <-gCtx.Done():
-					return gCtx.Err()
+					// Return nil, not gCtx.Err(): this helper loop does not decide the session's
+					// outcome, proxy.start does. proxy.start's goroutine below cancels the context
+					// (its deferred cancel) before the errgroup records proxy.start's return value,
+					// so a gCtx.Err() here can be recorded as the group's first error and mask that
+					// real error — which normalizeProxyError would then swallow into a silent nil.
+					return nil
 				case <-requestHandoverTick():
 					if err := proxy.initiateHandover(gCtx); err != nil {
 						return err
@@ -95,7 +100,9 @@ func RunClientProxy(ctx context.Context, src io.ReadCloser, dst io.Writer, reque
 			for {
 				select {
 				case <-gCtx.Done():
-					return gCtx.Err()
+					// nil, not gCtx.Err(): see the handover loop above — a helper stopping must
+					// not mask proxy.start's error as the errgroup's first error.
+					return nil
 				case <-ticker.C:
 					// A ping that ticks during a handover goes to the connection being replaced and
 					// may simply fail. Harmless: a handover establishes a fresh connection, which


### PR DESCRIPTION
## Changes

Return nil instead of gCtx.Err() on <-gCtx.Done() in experimental/ssh/internal/proxy/client.go

## Why

TestKeepalivePingFailureDoesNotHangTheSession was failing intermittently

Root cause:

The CI failure was `keepalive_test.go:260`: An error is expected but got nil in 0.11s — the session ended cleanly instead of with an error (it did not hang).

RunClientProxy runs three goroutines in an errgroup: the handover loop, the keepalive loop, and a wrapper around proxy.start:
```go
g.Go(func() error {
    defer cancel()                 // ← cancels gCtx out-of-band
    return proxy.start(gCtx, ...)
})
```

When proxy.start returns its real error (e.g. the keystroke write failing on the poisoned connection), its deferred cancel() fires before errgroup records that error. That cancels gCtx, so the sibling loops wake on <-gCtx.Done() and return gCtx.Err() = context.Canceled. Whichever goroutine reaches errgroup's errOnce first wins — and if a sibling wins, g.Wait() returns context.Canceled, which normalizeProxyError maps to nil. The session's real error is silently swallowed.

The asymmetry: the siblings cancel out-of-band via defer cancel(), not through errgroup's atomic errOnce+cancel — so they can slip in a context.Canceled as the group's first error. This is a genuine (if subtle) shipped-behavior bug: an SSH session dying on a write failure could intermittently be reported as a clean exit.

## Tests

- Before: fails within ~200 iterations (-count=200 -race), identical assertion/timing to CI.
- After: TestKeepalivePingFailureDoesNotHangTheSession — 1000× clean with -race; whole proxy package — 50× clean with -race (exit 0). gofmt and go vet clean.
