### PR TITLE
Normalize jobs PyDABs acceptance surface and drop coverage exception

### DIFF
--- a/acceptance/bundle/python/jobs-support/databricks.yml
+++ b/acceptance/bundle/python/jobs-support/databricks.yml
@@ -1,0 +1,15 @@
+bundle:
+  name: my_project
+
+sync: {paths: []} # don't need to copy files
+
+python:
+  resources:
+    - "resources:load_resources"
+  mutators:
+    - "mutators:update_job"
+
+resources:
+  jobs:
+    my_job_1:
+      name: "My Job 1"

--- a/acceptance/bundle/python/jobs-support/mutators.py
+++ b/acceptance/bundle/python/jobs-support/mutators.py
@@ -1,0 +1,11 @@
+from dataclasses import replace
+
+from databricks.bundles.core import job_mutator
+from databricks.bundles.jobs import Job
+
+
+@job_mutator
+def update_job(job: Job) -> Job:
+    assert isinstance(job.name, str)
+
+    return replace(job, name=f"{job.name} (updated)")

--- a/acceptance/bundle/python/jobs-support/out.test.toml
+++ b/acceptance/bundle/python/jobs-support/out.test.toml
@@ -1,0 +1,4 @@
+Cloud = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DMS = ["", "true"]
+EnvMatrix.PYDAB_VERSION = ["0.266.0", "current"]

--- a/acceptance/bundle/python/jobs-support/output.txt
+++ b/acceptance/bundle/python/jobs-support/output.txt
@@ -1,0 +1,44 @@
+
+>>> uv run [UV_ARGS] -q [CLI] bundle validate --output json
+{
+  "experimental": {
+    "python": {
+      "mutators": [
+        "mutators:update_job"
+      ],
+      "resources": [
+        "resources:load_resources"
+      ]
+    }
+  },
+  "resources": {
+    "jobs": {
+      "my_job_1": {
+        "deployment": {
+          "kind": "BUNDLE",
+          "metadata_file_path": "/Workspace/Users/[USERNAME]/.bundle/my_project/default/state/metadata.json"
+        },
+        "edit_mode": "UI_LOCKED",
+        "format": "MULTI_TASK",
+        "max_concurrent_runs": 1,
+        "name": "My Job 1 (updated)",
+        "queue": {
+          "enabled": true
+        }
+      },
+      "my_job_2": {
+        "deployment": {
+          "kind": "BUNDLE",
+          "metadata_file_path": "/Workspace/Users/[USERNAME]/.bundle/my_project/default/state/metadata.json"
+        },
+        "edit_mode": "UI_LOCKED",
+        "format": "MULTI_TASK",
+        "max_concurrent_runs": 1,
+        "name": "My Job 2 (updated)",
+        "queue": {
+          "enabled": true
+        }
+      }
+    }
+  }
+}

--- a/acceptance/bundle/python/jobs-support/resources.py
+++ b/acceptance/bundle/python/jobs-support/resources.py
@@ -1,0 +1,9 @@
+from databricks.bundles.core import Resources
+
+
+def load_resources() -> Resources:
+    resources = Resources()
+
+    resources.add_job("my_job_2", {"name": "My Job 2"})
+
+    return resources

--- a/acceptance/bundle/python/jobs-support/script
+++ b/acceptance/bundle/python/jobs-support/script
@@ -1,0 +1,5 @@
+
+trace uv run $UV_ARGS -q $CLI bundle validate --output json | \
+  jq "pick(.experimental.python, .resources)"
+
+rm -fr .databricks __pycache__

--- a/python/databricks_tests/core/test_python_support.py
+++ b/python/databricks_tests/core/test_python_support.py
@@ -13,13 +13,6 @@ from databricks.bundles.core._resource_type import _ResourceType
 
 _ACCEPTANCE_DIR = Path(__file__).parents[3] / "acceptance" / "bundle" / "python"
 
-# Resources knowingly lacking a <plural>-support fixture. Shrink-only: the test fails
-# if an entry here is actually covered, so gaps can only close.
-_LACKING = {
-    # jobs predates the <plural>-support convention; covered across the suite instead.
-    "jobs",
-}
-
 _PLURALS = sorted(t.plural_name for t in _ResourceType.all())
 
 
@@ -27,10 +20,7 @@ _PLURALS = sorted(t.plural_name for t in _ResourceType.all())
 def test_python_support_coverage(plural: str):
     covered = (_ACCEPTANCE_DIR / f"{plural}-support" / "databricks.yml").exists()
 
-    if plural in _LACKING:
-        assert not covered, f"{plural!r} now has a fixture; remove it from _LACKING"
-    else:
-        assert covered, (
-            f"no acceptance/bundle/python/{plural}-support/ fixture for {plural!r}; "
-            "add one (see acceptance/bundle/python/README.md) or add it to _LACKING"
-        )
+    assert covered, (
+        f"no acceptance/bundle/python/{plural}-support/ fixture for {plural!r}; "
+        "add one (see acceptance/bundle/python/README.md)"
+    )


### PR DESCRIPTION
## Summary

Stacked on top of #6528.

`test_python_support_coverage` requires every PyDABs resource to have an `acceptance/bundle/python/<plural>-support/` fixture. `jobs` was the lone exception: it predates the `<plural>-support` convention and was carried in a `_LACKING` shrink-only allowlist ("covered across the suite instead").

This PR covers that gap by:
- adding `jobs-support` test
- removing the `_LACKING` allowlist

## Testing

- `go test ./acceptance -run 'TestAccept/bundle/python/jobs-support'` passes without `-update` across all four variants (both engines × both wheel versions) — deterministic.
- `test_python_support_coverage` passes for all 23 resources with no exceptions.

This pull request and its description were written by Isaac.