### PR TITLE
experimental/ssh: keep the IDE remote authority stable across connects

### DIFF
--- a/.nextchanges/cli/ssh-connect-stable-ide-authority.md
+++ b/.nextchanges/cli/ssh-connect-stable-ide-authority.md
@@ -1,0 +1,1 @@
+* Stop `databricks ssh connect --ide` from adding a duplicate entry to the IDE's Remote Explorer on every connect: the remote authority is now the SSH host alias alone, instead of embedding the per-instance remote OS user.

--- a/.nextchanges/cli/ssh-connect-stable-ide-authority.md
+++ b/.nextchanges/cli/ssh-connect-stable-ide-authority.md
@@ -1,1 +1,1 @@
-* Stop `databricks ssh connect --ide` from adding a duplicate entry to the IDE's Remote Explorer on every connect: the remote authority is now the SSH host alias alone, instead of embedding the per-instance remote OS user.
+* Stop `databricks ssh connect --ide` from adding a duplicate entry to the IDE's Remote Explorer on every connect: the remote authority is now the SSH host alias alone, instead of embedding the per-instance remote OS user. ([#6550](https://github.com/databricks/cli/pull/6550))

--- a/experimental/ssh/internal/client/client.go
+++ b/experimental/ssh/internal/client/client.go
@@ -476,7 +476,7 @@ func runIDE(ctx context.Context, client *databricks.WorkspaceClient, userName, k
 		return fmt.Errorf("failed to ensure SSH config entry: %w", err)
 	}
 
-	return vscode.LaunchIDE(ctx, opts.IDE, connectionName, userName, currentUser.UserName)
+	return vscode.LaunchIDE(ctx, opts.IDE, connectionName, currentUser.UserName)
 }
 
 func ensureSSHConfigEntry(ctx context.Context, configPath, hostName, userName, keyPath string, serverPort int, clusterID string, opts ClientOptions) error {

--- a/experimental/ssh/internal/vscode/run.go
+++ b/experimental/ssh/internal/vscode/run.go
@@ -170,18 +170,30 @@ func CheckIDESSHExtension(ctx context.Context, option string, autoApprove bool) 
 	return nil
 }
 
-// LaunchIDE launches the IDE with a remote SSH connection using special "ssh-remote" URI format.
-func LaunchIDE(ctx context.Context, ideOption, connectionName, userName, databricksUserName string) error {
-	ide := getIDE(ideOption)
-
-	// Construct the remote SSH URI
-	// Format: ssh-remote+<server_user_name>@<connection_name> /Workspace/Users/<databricks_user_name>/
-	remoteURI := fmt.Sprintf("ssh-remote+%s@%s", userName, connectionName)
+// remoteLaunchArgs builds the arguments that open a remote window on the tunnel
+// host at the user's workspace home folder.
+//
+// The remote authority is the SSH host alias alone, without a "<user>@" prefix.
+// The host config the CLI writes for the connection already carries a User
+// directive (see sshconfig.GenerateHostConfig), and on serverless the remote OS
+// user is a fresh per-instance name (spark-<uuid>), so including it would give
+// every connect a different authority. VS Code keys the "previously opened
+// folders" it lists under a host by URI, so a per-connect authority added a
+// duplicate row to the Remote Explorer on every `ssh connect --ide`.
+func remoteLaunchArgs(ideOption, connectionName, databricksUserName string) []string {
+	// Format: ssh-remote+<connection_name> /Workspace/Users/<databricks_user_name>/
+	remoteURI := "ssh-remote+" + connectionName
 	remotePath := fmt.Sprintf("/Workspace/Users/%s/", databricksUserName)
+	return append(append([]string{}, getIDE(ideOption).LaunchArgs...), "--remote", remoteURI, remotePath)
+}
 
-	log.Infof(ctx, "Launching %s with remote URI: %s and path: %s", ideOption, remoteURI, remotePath)
+// LaunchIDE launches the IDE with a remote SSH connection using special "ssh-remote" URI format.
+func LaunchIDE(ctx context.Context, ideOption, connectionName, databricksUserName string) error {
+	ide := getIDE(ideOption)
+	args := remoteLaunchArgs(ideOption, connectionName, databricksUserName)
 
-	args := append(append([]string{}, ide.LaunchArgs...), "--remote", remoteURI, remotePath)
+	log.Infof(ctx, "Launching %s with args: %v", ideOption, args)
+
 	ideCmd := exec.CommandContext(ctx, ide.Command, args...)
 	ideCmd.Stdout = os.Stdout
 	ideCmd.Stderr = os.Stderr

--- a/experimental/ssh/internal/vscode/run.go
+++ b/experimental/ssh/internal/vscode/run.go
@@ -180,17 +180,17 @@ func CheckIDESSHExtension(ctx context.Context, option string, autoApprove bool) 
 // every connect a different authority. VS Code keys the "previously opened
 // folders" it lists under a host by URI, so a per-connect authority added a
 // duplicate row to the Remote Explorer on every `ssh connect --ide`.
-func remoteLaunchArgs(ideOption, connectionName, databricksUserName string) []string {
+func remoteLaunchArgs(ide ideDescriptor, connectionName, databricksUserName string) []string {
 	// Format: ssh-remote+<connection_name> /Workspace/Users/<databricks_user_name>/
 	remoteURI := "ssh-remote+" + connectionName
 	remotePath := fmt.Sprintf("/Workspace/Users/%s/", databricksUserName)
-	return append(append([]string{}, getIDE(ideOption).LaunchArgs...), "--remote", remoteURI, remotePath)
+	return append(append([]string{}, ide.LaunchArgs...), "--remote", remoteURI, remotePath)
 }
 
 // LaunchIDE launches the IDE with a remote SSH connection using special "ssh-remote" URI format.
 func LaunchIDE(ctx context.Context, ideOption, connectionName, databricksUserName string) error {
 	ide := getIDE(ideOption)
-	args := remoteLaunchArgs(ideOption, connectionName, databricksUserName)
+	args := remoteLaunchArgs(ide, connectionName, databricksUserName)
 
 	log.Infof(ctx, "Launching %s with args: %v", ideOption, args)
 

--- a/experimental/ssh/internal/vscode/run_test.go
+++ b/experimental/ssh/internal/vscode/run_test.go
@@ -332,7 +332,7 @@ func TestRemoteLaunchArgs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			args := remoteLaunchArgs(tt.ide, "databricks-cpu-7f189c39", "me@example.com")
+			args := remoteLaunchArgs(getIDE(tt.ide), "databricks-cpu-7f189c39", "me@example.com")
 			assert.Equal(t, tt.want, args)
 		})
 	}

--- a/experimental/ssh/internal/vscode/run_test.go
+++ b/experimental/ssh/internal/vscode/run_test.go
@@ -308,6 +308,36 @@ func TestCheckIDESSHExtension_AutoApproveMissing_Installs(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+// The authority must be the host alias alone. The remote OS user is a fresh
+// spark-<uuid> on every serverless instance, so a "<user>@" prefix would give each
+// connect a different authority and VS Code would remember a separate
+// previously-opened folder for each one.
+func TestRemoteLaunchArgs(t *testing.T) {
+	tests := []struct {
+		name string
+		ide  string
+		want []string
+	}{
+		{
+			name: "vscode",
+			ide:  VSCodeOption,
+			want: []string{"--remote", "ssh-remote+databricks-cpu-7f189c39", "/Workspace/Users/me@example.com/"},
+		},
+		{
+			name: "cursor keeps its launch args first",
+			ide:  CursorOption,
+			want: []string{"--classic", "--remote", "ssh-remote+databricks-cpu-7f189c39", "/Workspace/Users/me@example.com/"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args := remoteLaunchArgs(tt.ide, "databricks-cpu-7f189c39", "me@example.com")
+			assert.Equal(t, tt.want, args)
+		})
+	}
+}
+
 func TestCheckIDESSHExtension_NoPrompt_WithoutAutoApprove_Errors(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("PATH", tmpDir)


### PR DESCRIPTION
Fixes a bug reported by a customer: every `databricks ssh connect --ide=vscode` added another row to the IDE's Remote Explorer, so the connection list filled up with duplicates of the same workspace folder.

## Root cause

The SSH config entry is *not* duplicated — `runIDE` writes one file per connection name and overwrites it in place. What multiplies is the list of *previously opened folders* VS Code shows under the host.

`LaunchIDE` launched the IDE with `--remote ssh-remote+<remote-OS-user>@<connection-name>`. On serverless the remote OS user is a fresh per-instance name. Measured across three consecutive connects:

```
spark-a1db7f91-e076-4718-9660-f9
spark-fa7c0655-52c3-4b47-abd2-2e
spark-c3e2ee41-70ac-4190-8726-6a
```

So the authority — and with it the URI VS Code remembers — differed every time. VS Code keys that list by URI, giving one new row per connect.

## Fix

Use the host alias alone as the authority (`ssh-remote+<connection-name>`). The host config the CLI already writes for the connection carries a `User` directive, so ssh still resolves the right remote user; the value simply stops leaking into the part VS Code persists.

The argument construction moves into a small pure `remoteLaunchArgs` so it can be asserted directly.

## Testing

- New `TestRemoteLaunchArgs` pins the exact arguments for both VS Code and Cursor, including that Cursor keeps `--classic` first.
- `go test ./experimental/ssh/...`, `go test ./cmd/...` and `TestAccept/ssh` pass.
- Verified against real serverless compute: the IDE receives `--remote ssh-remote+<name>`, and `ssh <name>` with no user in the destination connects and lands as the current `spark-<uuid>`.

## Note

Rows already accumulated live in VS Code's own state, so existing users keep theirs (removable from the Remote Explorer context menu). This stops new ones from appearing.

This pull request and its description were written by Isaac.