### PR TITLE
Group Databricks Go SDK submodule bumps into a single Dependabot PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,13 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 14
+    groups:
+      # The new Databricks Go SDK ships as ~100 per-service submodules under
+      # github.com/databricks/sdk-go. Bumping them individually would open one PR
+      # per submodule; group them into a single PR.
+      databricks-sdk-go:
+        patterns:
+          - github.com/databricks/sdk-go/*
     ignore:
       # Ignore Databricks Go SDK because its upgrade requires code generation
       - dependency-name: github.com/databricks/databricks-sdk-go


### PR DESCRIPTION
## Changes

The new Databricks Go SDK ships as ~100 per-service submodules under `github.com/databricks/sdk-go` (`core`, `auth`, `files`, `options`, …). Without grouping, Dependabot would open one PR per submodule bump.

This adds a `groups` block to the root `gomod` ecosystem in `.github/dependabot.yml` so all `github.com/databricks/sdk-go/*` submodule bumps collapse into a single PR.

Notes:
- Scoped to the root `/` module only — `/tools` does not depend on the SDK.
- The existing SDK (`github.com/databricks/databricks-sdk-go`) stays in the `ignore` list (its upgrade requires codegen) and is unaffected.

## Tests

Config-only change; validated that `.github/dependabot.yml` parses as valid YAML.

This pull request and its description were written by Isaac.
