### PR TITLE
Make bundle sync default to text output, matching sync

### DIFF
--- a/.nextchanges/cli/bundle-sync-default-output.md
+++ b/.nextchanges/cli/bundle-sync-default-output.md
@@ -1,0 +1,1 @@
+* `databricks bundle sync` now prints sync progress (`Action: PUT`, `Uploaded ...`) by default, matching `databricks sync`. Previously it was silent unless `--output` was passed. Use `--output json` for machine-readable output.

--- a/.nextchanges/cli/bundle-sync-default-output.md
+++ b/.nextchanges/cli/bundle-sync-default-output.md
@@ -1,1 +1,1 @@
-* `databricks bundle sync` now prints sync progress (`Action: PUT`, `Uploaded ...`) by default, matching `databricks sync`. Previously it was silent unless `--output` was passed. Use `--output json` for machine-readable output.
+* `databricks bundle sync` now prints sync progress (`Action: PUT`, `Uploaded ...`) by default, matching `databricks sync`. Previously it was silent unless `--output` was passed. Use `--output json` for machine-readable output. ([#6568](https://github.com/databricks/cli/pull/6568))

--- a/acceptance/bundle/sync-default-output/databricks.yml
+++ b/acceptance/bundle/sync-default-output/databricks.yml
@@ -1,0 +1,2 @@
+bundle:
+  name: test-bundle

--- a/acceptance/bundle/sync-default-output/out.test.toml
+++ b/acceptance/bundle/sync-default-output/out.test.toml
@@ -1,0 +1,3 @@
+Cloud = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DMS = ["", "true"]

--- a/acceptance/bundle/sync-default-output/output.txt
+++ b/acceptance/bundle/sync-default-output/output.txt
@@ -1,0 +1,9 @@
+
+>>> [CLI] bundle sync
+Action: PUT: .gitignore, databricks.yml, project-folder/app.py, project-folder/query.sql
+Initial Sync Complete
+Uploaded .gitignore
+Uploaded databricks.yml
+Uploaded project-folder
+Uploaded project-folder/app.py
+Uploaded project-folder/query.sql

--- a/acceptance/bundle/sync-default-output/script
+++ b/acceptance/bundle/sync-default-output/script
@@ -1,0 +1,16 @@
+mkdir "project-folder"
+touch "project-folder/app.py" "project-folder/query.sql"
+cat > .gitignore << EOF
+script
+output.txt
+EOF
+
+cleanup() {
+  rm .gitignore
+  rm -rf project-folder .git .databricks
+}
+trap cleanup EXIT
+
+# bundle sync installs a text output handler by default (no --output flag),
+# matching the standalone sync command. See issue #6499.
+trace $CLI bundle sync | sort

--- a/cmd/bundle/sync.go
+++ b/cmd/bundle/sync.go
@@ -29,20 +29,16 @@ func (f *syncFlags) syncOptionsFromBundle(cmd *cobra.Command, b *bundle.Bundle) 
 		return nil, fmt.Errorf("cannot get sync options: %w", err)
 	}
 
-	// The root --output flag always has a value (defaults to text), so gate on
-	// it being explicitly set to keep bundle sync silent by default.
-	if cmd.Flag("output").Changed {
-		var outputFunc func(context.Context, <-chan sync.Event, io.Writer)
-		switch root.OutputType(cmd) {
-		case flags.OutputText:
-			outputFunc = sync.TextOutput
-		case flags.OutputJSON:
-			outputFunc = sync.JsonOutput
-		}
-		if outputFunc != nil {
-			opts.OutputHandler = func(ctx context.Context, c <-chan sync.Event) {
-				outputFunc(ctx, c, cmd.OutOrStdout())
-			}
+	var outputFunc func(context.Context, <-chan sync.Event, io.Writer)
+	switch root.OutputType(cmd) {
+	case flags.OutputText:
+		outputFunc = sync.TextOutput
+	case flags.OutputJSON:
+		outputFunc = sync.JsonOutput
+	}
+	if outputFunc != nil {
+		opts.OutputHandler = func(ctx context.Context, c <-chan sync.Event) {
+			outputFunc(ctx, c, cmd.OutOrStdout())
 		}
 	}
 

--- a/cmd/bundle/sync_test.go
+++ b/cmd/bundle/sync_test.go
@@ -27,7 +27,7 @@ func TestBundleSyncShorthandFlags(t *testing.T) {
 	assert.Equal(t, "myprofile", cmd.Flag("profile").Value.String())
 }
 
-func TestBundleSyncOutputHandlerOnlyWhenOutputSet(t *testing.T) {
+func TestBundleSyncInstallsOutputHandler(t *testing.T) {
 	tempDir := t.TempDir()
 	b := &bundle.Bundle{
 		BundleRootPath: tempDir,
@@ -46,12 +46,14 @@ func TestBundleSyncOutputHandlerOnlyWhenOutputSet(t *testing.T) {
 
 	f := syncFlags{}
 
+	// bundle sync defaults to text output, matching the standalone sync command:
+	// the root --output flag resolves to text when unset, so a handler is installed.
 	cmd := newTestSyncCommand(t)
 	cmd.SetContext(t.Context())
 	require.NoError(t, cmd.ParseFlags(nil))
 	opts, err := f.syncOptionsFromBundle(cmd, b)
 	require.NoError(t, err)
-	assert.Nil(t, opts.OutputHandler)
+	assert.NotNil(t, opts.OutputHandler)
 
 	cmd = newTestSyncCommand(t)
 	cmd.SetContext(t.Context())


### PR DESCRIPTION
## Why

`databricks bundle sync` was silent by default, while `databricks sync` defaulted to `text` output. A plain `databricks bundle sync` printed no file actions, so with `--dry-run` the only output was `Running in dry-run mode. No actual changes will be made.` — making it look like the real command would do nothing. Reported as #6499.

The divergence is not a deliberate design decision. When the two commands were first split in #207 (Feb 2023) they were **both** silent — neither wired up any output handler — and that PR explicitly framed the split as temporary ("Once the VS Code extension is bundle aware they can again be consolidated"). Standalone `sync` later gained a text-default `--output`; `bundle sync` only got an opt-in `--output` in #1853 (Oct 2024), which kept the pre-existing silence as the no-flag default. So the silence was incidental and never revisited.

## Changes

- `cmd/bundle/sync.go`: install the sync output handler from the resolved root `--output` type (which defaults to `text`) instead of gating on the flag being explicitly `.Changed`. `bundle sync` now behaves like `sync`; `--output json` is unchanged. Removed the now-inaccurate comment that went with the guard.
- `cmd/bundle/sync_test.go`: the old unit test pinned "handler only when `--output` set"; updated it to assert the handler is installed for the default (text) and for explicit `-o json`.
- `acceptance/bundle/sync-default-output/`: new acceptance test covering `bundle sync` with no `--output` flag — the case the change alters, which had no coverage. The two existing `bundle sync` acceptance tests both pass `--output text`, so they are unaffected.

## Tests

- `go test ./cmd/bundle/` passes.
- New acceptance test passes across all inherited matrix variants (terraform, direct, direct+DMS).
- Full local acceptance suite: the only failures were two pre-existing load-induced timeout flakes (`clusters/.../resize-autoscale`, `permissions/pipelines`), neither of which touches `bundle sync`; both confirmed passing in isolation.

Closes #6499

This pull request and its description were written by Isaac.
