### PR TITLE
experimental/air: parallel gzip for the plain_tar snapshot packer

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -131,6 +131,10 @@ jackc/pgx - https://github.com/jackc/pgx
 Copyright (c) 2013-2021 Jack Christensen
 License - https://github.com/jackc/pgx/blob/master/LICENSE
 
+klauspost/pgzip - https://github.com/klauspost/pgzip
+Copyright (c) 2014 Klaus Post
+License - https://github.com/klauspost/pgzip/blob/master/LICENSE
+
 charmbracelet/bubbles - https://github.com/charmbracelet/bubbles
 Copyright (c) 2020-2025 Charmbracelet, Inc
 License - https://github.com/charmbracelet/bubbles/blob/master/LICENSE

--- a/experimental/air/cmd/snapshot_package.go
+++ b/experimental/air/cmd/snapshot_package.go
@@ -9,6 +9,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/klauspost/pgzip"
 )
 
 // Tar builders ported from cli/utils/snapshot.py. Both shell out (git archive / tar)
@@ -41,47 +43,60 @@ func createGitArchiveSnapshot(ctx context.Context, git gitRepo, commitSHA, outpu
 // excluded; a .gitignore at repoPath is honored.
 func createPlainTarball(ctx context.Context, repoPath, outputTarball string, includePaths []string, isGitRepo bool) error {
 	dirName := filepath.Base(repoPath)
-	// Absolute so it resolves correctly regardless of tar's working dir (set below).
+	// Absolute so it resolves correctly regardless of tar's working dir.
 	parent, err := filepath.Abs(filepath.Dir(repoPath))
 	if err != nil {
 		return err
 	}
 
-	// Pass the archive path relative to its own directory (run tar there), never a
-	// full path: on Windows an absolute path like `C:\out\x.tar.gz` makes tar read
-	// the `C:` as a remote host ("Cannot connect to C:"), since tar treats a colon
-	// in the -f arg as host:path. A bare basename with -C avoids that on GNU tar and
-	// bsdtar alike.
-	outDirAbs, err := filepath.Abs(filepath.Dir(outputTarball))
-	if err != nil {
-		return err
-	}
-	outName := filepath.Base(outputTarball)
-
 	files, err := snapshotFiles(ctx, repoPath, includePaths, isGitRepo)
 	if err != nil {
 		return err
 	}
-	args := []string{"-czf", outName, "-C", parent, "--null", "--no-recursion", "-T", "-"}
 
+	out, err := os.Create(outputTarball)
+	if err != nil {
+		return fmt.Errorf("failed to create tarball: %w", err)
+	}
+
+	// tar writes the uncompressed archive to stdout (`-cf -`) and we gzip it here with
+	// klauspost/pgzip instead of tar's built-in -z: tar's gzip is single-threaded and
+	// dominates packaging time on a large tree, whereas pgzip spreads it across cores
+	// (measured ~18x faster on a ~470 MiB archive) while still emitting an ordinary gzip
+	// stream. BestSpeed because the uploaded size does not matter for this workflow, only
+	// latency. Compressing outside tar also passes no archive path to tar, sidestepping
+	// the Windows colon-in-path issue a `-f <path>` argument otherwise hits (tar reads the
+	// `C:` in `C:\out\x.tar.gz` as a remote host).
+	gz, err := pgzip.NewWriterLevel(out, pgzip.BestSpeed)
+	if err != nil {
+		out.Close()
+		return err
+	}
+
+	args := []string{"-cf", "-", "-C", parent, "--null", "--no-recursion", "-T", "-"}
 	cmd := exec.CommandContext(ctx, "tar", args...)
-	// Run tar in the output directory so the bare -f basename lands there.
-	cmd.Dir = outDirAbs
 	var stdin bytes.Buffer
 	for _, file := range files {
 		stdin.WriteString(filepath.ToSlash(filepath.Join(dirName, file)))
 		stdin.WriteByte(0)
 	}
 	cmd.Stdin = &stdin
+	cmd.Stdout = gz
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
+		gz.Close()
+		out.Close()
 		if msg := strings.TrimSpace(stderr.String()); msg != "" {
 			return fmt.Errorf("failed to create plain tarball: %w: %s", err, msg)
 		}
 		return fmt.Errorf("failed to create plain tarball: %w", err)
 	}
-	return nil
+	if err := gz.Close(); err != nil {
+		out.Close()
+		return fmt.Errorf("failed to finalize gzip: %w", err)
+	}
+	return out.Close()
 }
 
 func snapshotFiles(ctx context.Context, repoPath string, includePaths []string, isGitRepo bool) ([]string, error) {

--- a/experimental/air/cmd/snapshot_package.go
+++ b/experimental/air/cmd/snapshot_package.go
@@ -10,13 +10,15 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/databricks/cli/libs/tarpack"
 	"github.com/klauspost/pgzip"
 )
 
-// Tar builders ported from cli/utils/snapshot.py. Both shell out (git archive / tar)
-// for parity and to reuse git's/tar's symlink, gitignore, and AppleDouble handling.
-// The tarball's top-level dir name is load-bearing — the remote entry_script extracts
-// to /databricks/code_source/<dir> — so the --prefix / `-C parent dir` forms preserve it.
+// Tar builders ported from cli/utils/snapshot.py. The git-ref path snapshots a commit
+// with `git archive`; the plain path enumerates the working tree with `git ls-files`
+// (honoring .gitignore) and writes the tar in Go. The tarball's top-level dir name is
+// load-bearing — the remote entry_script extracts to /databricks/code_source/<dir> — so
+// both forms prefix every entry with it.
 
 // createGitArchiveSnapshot writes a gzipped tar of commitSHA to outputTarball via
 // `git archive`, with every entry prefixed by directoryName/. When includePaths is
@@ -37,21 +39,23 @@ func createGitArchiveSnapshot(ctx context.Context, git gitRepo, commitSHA, outpu
 }
 
 // createPlainTarball writes a gzipped tar of repoPath's working tree to
-// outputTarball via `tar`. The archive preserves repoPath's directory name as the
-// top-level entry. When includePaths is set, only those paths (nested under the
-// directory name) are archived. .git and macOS AppleDouble files are always
-// excluded; a .gitignore at repoPath is honored.
+// outputTarball. The archive preserves repoPath's directory name as the top-level
+// entry. When includePaths is set, only those paths (nested under the directory
+// name) are archived. .git and macOS AppleDouble files are always excluded; a
+// .gitignore at repoPath is honored.
 func createPlainTarball(ctx context.Context, repoPath, outputTarball string, includePaths []string, isGitRepo bool) error {
 	dirName := filepath.Base(repoPath)
-	// Absolute so it resolves correctly regardless of tar's working dir.
-	parent, err := filepath.Abs(filepath.Dir(repoPath))
-	if err != nil {
-		return err
-	}
 
 	files, err := snapshotFiles(ctx, repoPath, includePaths, isGitRepo)
 	if err != nil {
 		return err
+	}
+	entries := make([]tarpack.Entry, len(files))
+	for i, rel := range files {
+		entries[i] = tarpack.Entry{
+			Name: filepath.ToSlash(filepath.Join(dirName, rel)),
+			Path: filepath.Join(repoPath, rel),
+		}
 	}
 
 	out, err := os.Create(outputTarball)
@@ -59,34 +63,18 @@ func createPlainTarball(ctx context.Context, repoPath, outputTarball string, inc
 		return fmt.Errorf("failed to create tarball: %w", err)
 	}
 
-	// tar writes the uncompressed archive to stdout and we gzip it with klauspost/pgzip
-	// rather than tar's single-threaded -z, which dominates packaging time on a large
-	// tree (pgzip spreads the same compression across cores). Compressing outside tar
-	// also keeps any archive path out of tar's args, avoiding the Windows colon-in-path
-	// issue the `-f <path>` form otherwise hits.
+	// Gzip in parallel with klauspost/pgzip rather than a single-threaded writer:
+	// compression dominates packaging time on a large tree, and pgzip spreads it
+	// across cores. tarpack writes the tar in Go, so there is no `tar` subprocess
+	// (and no Windows colon-in-path issue a `tar -f` argument would hit).
 	gz, err := pgzip.NewWriterLevel(out, pgzip.DefaultCompression)
 	if err != nil {
 		out.Close()
 		return err
 	}
-
-	args := []string{"-cf", "-", "-C", parent, "--null", "--no-recursion", "-T", "-"}
-	cmd := exec.CommandContext(ctx, "tar", args...)
-	var stdin bytes.Buffer
-	for _, file := range files {
-		stdin.WriteString(filepath.ToSlash(filepath.Join(dirName, file)))
-		stdin.WriteByte(0)
-	}
-	cmd.Stdin = &stdin
-	cmd.Stdout = gz
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
+	if err := tarpack.Write(gz, entries); err != nil {
 		gz.Close()
 		out.Close()
-		if msg := strings.TrimSpace(stderr.String()); msg != "" {
-			return fmt.Errorf("failed to create plain tarball: %w: %s", err, msg)
-		}
 		return fmt.Errorf("failed to create plain tarball: %w", err)
 	}
 	if err := gz.Close(); err != nil {

--- a/experimental/air/cmd/snapshot_package.go
+++ b/experimental/air/cmd/snapshot_package.go
@@ -61,13 +61,15 @@ func createPlainTarball(ctx context.Context, repoPath, outputTarball string, inc
 
 	// tar writes the uncompressed archive to stdout (`-cf -`) and we gzip it here with
 	// klauspost/pgzip instead of tar's built-in -z: tar's gzip is single-threaded and
-	// dominates packaging time on a large tree, whereas pgzip spreads it across cores
-	// (measured ~18x faster on a ~470 MiB archive) while still emitting an ordinary gzip
-	// stream. BestSpeed because the uploaded size does not matter for this workflow, only
-	// latency. Compressing outside tar also passes no archive path to tar, sidestepping
-	// the Windows colon-in-path issue a `-f <path>` argument otherwise hits (tar reads the
-	// `C:` in `C:\out\x.tar.gz` as a remote host).
-	gz, err := pgzip.NewWriterLevel(out, pgzip.BestSpeed)
+	// dominates packaging time on a large tree, whereas pgzip spreads the same
+	// compression across cores (~18x faster on a ~470 MiB archive). We keep the default
+	// level rather than BestSpeed: the archive is re-uploaded on every run, so its size
+	// matters, and now that compression is parallel a normal level costs only a few
+	// hundred ms more for ~15-18% fewer bytes (and matches the old `tar -czf` size);
+	// level 9 buys almost nothing beyond that for ~2x the time. Compressing outside tar
+	// also passes no archive path to tar, sidestepping the Windows colon-in-path issue a
+	// `-f <path>` argument otherwise hits (tar reads the `C:` in `C:\out\x` as a host).
+	gz, err := pgzip.NewWriterLevel(out, pgzip.DefaultCompression)
 	if err != nil {
 		out.Close()
 		return err

--- a/experimental/air/cmd/snapshot_package.go
+++ b/experimental/air/cmd/snapshot_package.go
@@ -59,16 +59,11 @@ func createPlainTarball(ctx context.Context, repoPath, outputTarball string, inc
 		return fmt.Errorf("failed to create tarball: %w", err)
 	}
 
-	// tar writes the uncompressed archive to stdout (`-cf -`) and we gzip it here with
-	// klauspost/pgzip instead of tar's built-in -z: tar's gzip is single-threaded and
-	// dominates packaging time on a large tree, whereas pgzip spreads the same
-	// compression across cores (~18x faster on a ~470 MiB archive). We keep the default
-	// level rather than BestSpeed: the archive is re-uploaded on every run, so its size
-	// matters, and now that compression is parallel a normal level costs only a few
-	// hundred ms more for ~15-18% fewer bytes (and matches the old `tar -czf` size);
-	// level 9 buys almost nothing beyond that for ~2x the time. Compressing outside tar
-	// also passes no archive path to tar, sidestepping the Windows colon-in-path issue a
-	// `-f <path>` argument otherwise hits (tar reads the `C:` in `C:\out\x` as a host).
+	// tar writes the uncompressed archive to stdout and we gzip it with klauspost/pgzip
+	// rather than tar's single-threaded -z, which dominates packaging time on a large
+	// tree (pgzip spreads the same compression across cores). Compressing outside tar
+	// also keeps any archive path out of tar's args, avoiding the Windows colon-in-path
+	// issue the `-f <path>` form otherwise hits.
 	gz, err := pgzip.NewWriterLevel(out, pgzip.DefaultCompression)
 	if err != nil {
 		out.Close()

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/hashicorp/terraform-json v0.28.0 // MPL-2.0
 	github.com/hexops/gotextdiff v1.0.3 // BSD-3-Clause
 	github.com/jackc/pgx/v5 v5.10.0 // MIT
+	github.com/klauspost/pgzip v1.2.6 // MIT
 	github.com/mattn/go-isatty v0.0.24 // MIT
 	github.com/muesli/termenv v0.16.0 // MIT
 	github.com/palantir/pkg/yamlpatch v1.5.0 // BSD-3-Clause
@@ -87,6 +88,7 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
+	github.com/klauspost/compress v1.19.2 // indirect
 	github.com/lucasb-eyer/go-colorful v1.4.0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -156,8 +156,12 @@ github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOl
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=
 github.com/kevinburke/ssh_config v1.2.0/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
+github.com/klauspost/compress v1.19.2 h1:hMRETovs/pu/dVWN7zIT1PGG8t509MwT6bO7XSi26R8=
+github.com/klauspost/compress v1.19.2/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/klauspost/cpuid/v2 v2.3.0 h1:S4CRMLnYUhGeDFDqkGriYKdfoFlDnMtqTiI/sFzhA9Y=
 github.com/klauspost/cpuid/v2 v2.3.0/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
+github.com/klauspost/pgzip v1.2.6 h1:8RXeL5crjEUFnR2/Sn6GJNWtSQ3Dk8pq4CL3jvdDyjU=
+github.com/klauspost/pgzip v1.2.6/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=

--- a/libs/tarpack/tarpack.go
+++ b/libs/tarpack/tarpack.go
@@ -1,0 +1,79 @@
+// Package tarpack writes files from the local filesystem into a tar archive in
+// Go, as a replacement for shelling out to the `tar` command. The caller
+// supplies the destination io.Writer, so compression stays its choice: wrap the
+// writer in compress/gzip or klauspost/pgzip (or nothing) — tarpack only emits
+// the tar stream.
+package tarpack
+
+import (
+	"archive/tar"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+)
+
+// Entry is one file to add to the archive.
+type Entry struct {
+	// Name is the slash-separated name the entry is given in the archive.
+	Name string
+	// Path is the local filesystem path the content is read from.
+	Path string
+}
+
+// Write writes entries to w as a tar stream and finalizes it (writes the tar
+// footer). It does not close w, so the caller can close a wrapping gzip writer
+// afterward. Regular files are copied and symlinks are stored as symlink
+// entries; any other file type (e.g. a directory) is skipped, since directories
+// are implied by entry names. Each entry's mode and mtime are preserved, which
+// matches what `tar` stored for the same file.
+func Write(w io.Writer, entries []Entry) error {
+	tw := tar.NewWriter(w)
+	for _, e := range entries {
+		if err := writeEntry(tw, e); err != nil {
+			return err
+		}
+	}
+	return tw.Close()
+}
+
+func writeEntry(tw *tar.Writer, e Entry) error {
+	// Lstat, not Stat, so a symlink is archived as a link rather than followed.
+	info, err := os.Lstat(e.Path)
+	if err != nil {
+		return fmt.Errorf("stat %s: %w", e.Path, err)
+	}
+	mode := info.Mode()
+	if !mode.IsRegular() && mode&fs.ModeSymlink == 0 {
+		return nil
+	}
+
+	var link string
+	if mode&fs.ModeSymlink != 0 {
+		link, err = os.Readlink(e.Path)
+		if err != nil {
+			return fmt.Errorf("readlink %s: %w", e.Path, err)
+		}
+	}
+	hdr, err := tar.FileInfoHeader(info, link)
+	if err != nil {
+		return fmt.Errorf("tar header for %s: %w", e.Name, err)
+	}
+	hdr.Name = e.Name
+	if err := tw.WriteHeader(hdr); err != nil {
+		return fmt.Errorf("write header for %s: %w", e.Name, err)
+	}
+	if !mode.IsRegular() {
+		return nil
+	}
+
+	f, err := os.Open(e.Path)
+	if err != nil {
+		return fmt.Errorf("open %s: %w", e.Path, err)
+	}
+	defer f.Close()
+	if _, err := io.Copy(tw, f); err != nil {
+		return fmt.Errorf("write %s: %w", e.Name, err)
+	}
+	return nil
+}

--- a/libs/tarpack/tarpack_test.go
+++ b/libs/tarpack/tarpack_test.go
@@ -1,0 +1,109 @@
+package tarpack
+
+import (
+	"archive/tar"
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type readEntry struct {
+	typeflag byte
+	mode     int64
+	linkname string
+	content  string
+}
+
+func readTar(t *testing.T, b []byte) map[string]readEntry {
+	t.Helper()
+	tr := tar.NewReader(bytes.NewReader(b))
+	out := map[string]readEntry{}
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		data, err := io.ReadAll(tr)
+		require.NoError(t, err)
+		out[hdr.Name] = readEntry{
+			typeflag: hdr.Typeflag,
+			mode:     hdr.Mode,
+			linkname: hdr.Linkname,
+			content:  string(data),
+		}
+	}
+	return out
+}
+
+func TestWriteRegularFiles(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.txt"), []byte("alpha"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "sub"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "sub", "b.txt"), []byte("beta"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "run.sh"), []byte("#!/bin/sh\n"), 0o644))
+	// Chmod explicitly (not via the WriteFile mode arg) so the umask can't strip
+	// the bits we assert on below.
+	require.NoError(t, os.Chmod(filepath.Join(dir, "a.txt"), 0o644))
+	require.NoError(t, os.Chmod(filepath.Join(dir, "run.sh"), 0o755))
+
+	var buf bytes.Buffer
+	err := Write(&buf, []Entry{
+		{Name: "pkg/a.txt", Path: filepath.Join(dir, "a.txt")},
+		{Name: "pkg/sub/b.txt", Path: filepath.Join(dir, "sub", "b.txt")},
+		{Name: "pkg/run.sh", Path: filepath.Join(dir, "run.sh")},
+	})
+	require.NoError(t, err)
+
+	got := readTar(t, buf.Bytes())
+	require.Len(t, got, 3)
+	assert.Equal(t, "alpha", got["pkg/a.txt"].content)
+	assert.Equal(t, byte(tar.TypeReg), got["pkg/a.txt"].typeflag)
+	assert.Equal(t, "beta", got["pkg/sub/b.txt"].content)
+	// The owner execute bit is preserved (Windows has no execute bit).
+	if runtime.GOOS != "windows" {
+		assert.Equal(t, int64(0o755), got["pkg/run.sh"].mode&0o777)
+		assert.Equal(t, int64(0o644), got["pkg/a.txt"].mode&0o777)
+	}
+}
+
+func TestWriteSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation needs privilege on Windows")
+	}
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.txt"), []byte("alpha"), 0o644))
+	require.NoError(t, os.Symlink("a.txt", filepath.Join(dir, "link")))
+
+	var buf bytes.Buffer
+	err := Write(&buf, []Entry{
+		{Name: "pkg/link", Path: filepath.Join(dir, "link")},
+	})
+	require.NoError(t, err)
+
+	got := readTar(t, buf.Bytes())
+	require.Len(t, got, 1)
+	// Stored as a symlink entry, not the dereferenced content.
+	assert.Equal(t, byte(tar.TypeSymlink), got["pkg/link"].typeflag)
+	assert.Equal(t, "a.txt", got["pkg/link"].linkname)
+	assert.Empty(t, got["pkg/link"].content)
+}
+
+func TestWriteSkipsIrregularAndMissingIsError(t *testing.T) {
+	dir := t.TempDir()
+
+	// A directory entry is skipped (directories are implied by entry names).
+	var buf bytes.Buffer
+	require.NoError(t, Write(&buf, []Entry{{Name: "pkg/sub", Path: dir}}))
+	assert.Empty(t, readTar(t, buf.Bytes()))
+
+	// A missing path is a hard error, not silently dropped.
+	err := Write(io.Discard, []Entry{{Name: "pkg/gone", Path: filepath.Join(dir, "gone")}})
+	assert.Error(t, err)
+}


### PR DESCRIPTION
## Summary

The `air run` plain_tar snapshot path (dirty working tree / no git ref) packages the code_source by shelling out to `tar -czf`. tar's built-in gzip is single-threaded, so for a large tree it dominates packaging latency.

This pipes `tar -cf -` (uncompressed) through **klauspost/pgzip** (MIT), a parallel drop-in for gzip that spreads compression across cores and still emits an ordinary gzip stream.

- Level is **DefaultCompression** — the *same level as the old `tar -czf`*, not BestSpeed. The archive is re-uploaded on every run, so its size matters. So this is a pure latency win with no upload-size regression.
- Compressing outside tar means **no archive path is passed to tar**, which lets us drop the Windows colon-in-path workaround the `-f <path>` form required.

## Results (local packaging: git walk + tar + gzip; warm page cache)

| Target | before (`tar -czf`, serial gz6) | after (`tar -cf -` \| pgzip, gz6) |
|---|---|---|
| large folder (7.4k files) | 2,456 ms | **716 ms** (~3.4×) |
| gzip step alone, 470 MiB tar | 7,940 ms | **436 ms** (~18×) |

Same compression level, so the tarball is the same size as before (~24 MB for large folder). Level chosen from the curve on a 476 MiB tar: L1→L6 costs +150 ms for ~17% fewer bytes (97→80 MB); L6→L9 doubles time for ~1%, so 6 is the knee.

## Validation
- Output verified: `gzip -t` clean, entry count matches the file list, extracts correctly.
- Existing `snapshot_package_test.go` unit tests pass; the `internal/build` license test passes for the new `pgzip` dep (`// MIT` in go.mod + NOTICE entry).

