### PR TITLE
Accept major-only DBR runtime versions in cluster picker

### DIFF
--- a/.nextchanges/cli/configure-cluster-major-only-runtime.md
+++ b/.nextchanges/cli/configure-cluster-major-only-runtime.md
@@ -1,0 +1,1 @@
+* Fix `databricks auth login --configure-cluster` reporting "no compatible clusters found" for clusters whose runtime reports a major-only version such as `19.x-scala2.13` ([#6569](https://github.com/databricks/cli/issues/6569)).

--- a/.nextchanges/cli/configure-cluster-major-only-runtime.md
+++ b/.nextchanges/cli/configure-cluster-major-only-runtime.md
@@ -1,1 +1,1 @@
-* Fix `databricks auth login --configure-cluster` reporting "no compatible clusters found" for clusters whose runtime reports a major-only version such as `19.x-scala2.13`. ([#6574](https://github.com/databricks/cli/pull/6574))
+* Support major-only DBR runtime versions such as `19.x-scala2.13` in the cluster picker used by `databricks auth login --configure-cluster` and `databricks labs`. ([#6574](https://github.com/databricks/cli/pull/6574))

--- a/.nextchanges/cli/configure-cluster-major-only-runtime.md
+++ b/.nextchanges/cli/configure-cluster-major-only-runtime.md
@@ -1,1 +1,1 @@
-* Fix `databricks auth login --configure-cluster` reporting "no compatible clusters found" for clusters whose runtime reports a major-only version such as `19.x-scala2.13` ([#6569](https://github.com/databricks/cli/issues/6569)).
+* Fix `databricks auth login --configure-cluster` reporting "no compatible clusters found" for clusters whose runtime reports a major-only version such as `19.x-scala2.13`. ([#6574](https://github.com/databricks/cli/pull/6574))

--- a/libs/databrickscfg/cfgpickers/clusters.go
+++ b/libs/databrickscfg/cfgpickers/clusters.go
@@ -17,7 +17,7 @@ import (
 var minUcRuntime = canonicalVersion("v12.0")
 
 var (
-	dbrVersionRegex         = regexp.MustCompile(`^(\d+\.\d+)\.x-.*`)
+	dbrVersionRegex         = regexp.MustCompile(`^(\d+(?:\.\d+)?)\.x-.*`)
 	dbrSnapshotVersionRegex = regexp.MustCompile(`^(\d+)\.x-snapshot.*`)
 )
 
@@ -26,16 +26,16 @@ func canonicalVersion(v string) string {
 }
 
 func GetRuntimeVersion(cluster compute.ClusterDetails) (string, bool) {
-	match := dbrVersionRegex.FindStringSubmatch(cluster.SparkVersion)
-	if len(match) < 1 {
-		match = dbrSnapshotVersionRegex.FindStringSubmatch(cluster.SparkVersion)
-		if len(match) > 1 {
-			// we return 14.999 for 14.x-snapshot for semver.Compare() to work properly
-			return match[1] + ".999", true
-		}
-		return "", false
+	// Snapshots are checked first: dbrVersionRegex now matches major-only versions
+	// like "14.x-...", which would otherwise swallow "14.x-snapshot-..." here.
+	if match := dbrSnapshotVersionRegex.FindStringSubmatch(cluster.SparkVersion); len(match) > 1 {
+		// we return 14.999 for 14.x-snapshot for semver.Compare() to work properly
+		return match[1] + ".999", true
 	}
-	return match[1], true
+	if match := dbrVersionRegex.FindStringSubmatch(cluster.SparkVersion); len(match) > 1 {
+		return match[1], true
+	}
+	return "", false
 }
 
 func IsCompatibleWithUC(cluster compute.ClusterDetails, minVersion string) bool {

--- a/libs/databrickscfg/cfgpickers/clusters_test.go
+++ b/libs/databrickscfg/cfgpickers/clusters_test.go
@@ -35,6 +35,32 @@ func TestIsCompatible(t *testing.T) {
 	}, "14.0"))
 }
 
+func TestGetRuntimeVersion(t *testing.T) {
+	tests := []struct {
+		sparkVersion string
+		want         string
+		wantOk       bool
+	}{
+		{"13.3.x-scala2.12", "13.3", true},
+		// Newer clusters report the runtime without a minor version, e.g. 19.x.
+		{"19.x-scala2.13", "19", true},
+		{"14.x-snapshot-cpu-ml-scala2.12", "14.999", true},
+		{"custom-9.1.x-photon-scala2.12", "", false},
+	}
+	for _, tc := range tests {
+		got, ok := GetRuntimeVersion(compute.ClusterDetails{SparkVersion: tc.sparkVersion})
+		assert.Equal(t, tc.wantOk, ok, tc.sparkVersion)
+		assert.Equal(t, tc.want, got, tc.sparkVersion)
+	}
+}
+
+func TestIsCompatibleWithMajorOnlyVersion(t *testing.T) {
+	require.True(t, IsCompatibleWithUC(compute.ClusterDetails{
+		SparkVersion:     "19.x-scala2.13",
+		DataSecurityMode: compute.DataSecurityModeUserIsolation,
+	}, "13.0"))
+}
+
 func TestIsCompatibleWithSnapshots(t *testing.T) {
 	require.True(t, IsCompatibleWithUC(compute.ClusterDetails{
 		SparkVersion:     "14.x-snapshot-cpu-ml-scala2.12",


### PR DESCRIPTION
## Summary

Fixes #6569.

`databricks auth login --configure-cluster` reported "no compatible clusters found" for clusters whose runtime reports a major-only Spark version such as `19.x-scala2.13`. The cluster picker's `dbrVersionRegex` only matched `major.minor.x` (e.g. `13.3.x-...`), so newer major-only runtimes failed to parse and no cluster was considered compatible.

## Changes

- Relax `dbrVersionRegex` to make the minor component optional: `^(\d+(?:\.\d+)?)\.x-.*`. This mirrors the fix in [databricks-sdk-go#1805](https://github.com/databricks/databricks-sdk-go/pull/1805).
- Because the relaxed regex now also matches `14.x-snapshot-...`, check `dbrSnapshotVersionRegex` first in `GetRuntimeVersion` so snapshots keep their `.999` synthetic minor and sort correctly under `semver.Compare`.
- Add unit tests covering major-only, major.minor, snapshot, and non-matching runtime strings, plus a UC-compatibility test for a major-only version.

## Testing

- `go test ./libs/databrickscfg/cfgpickers/` — all pass.

This pull request and its description were written by Isaac.
