### PR TITLE
structdiff: don't panic on a defined string map key

### DIFF
--- a/libs/structs/structdiff/diff.go
+++ b/libs/structs/structdiff/diff.go
@@ -270,13 +270,13 @@ func diffStruct(ctx *diffContext, path *structpath.PathNode, s1, s2 reflect.Valu
 func diffMapStringKey(ctx *diffContext, path *structpath.PathNode, m1, m2 reflect.Value, changes *[]Change) error {
 	keySet := map[string]reflect.Value{}
 	for _, k := range m1.MapKeys() {
-		// Key is always string at this point
-		ks := k.Interface().(string)
-		keySet[ks] = k
+		// Caller guarantees the key kind is String; use Value.String() rather
+		// than a .(string) assertion, which panics on a named string key type
+		// (e.g. `type ScriptHook string`) whose dynamic type is not string.
+		keySet[k.String()] = k
 	}
 	for _, k := range m2.MapKeys() {
-		ks := k.Interface().(string)
-		keySet[ks] = k
+		keySet[k.String()] = k
 	}
 
 	keys := slices.Sorted(maps.Keys(keySet))

--- a/libs/structs/structdiff/diff_test.go
+++ b/libs/structs/structdiff/diff_test.go
@@ -923,3 +923,25 @@ func TestGetStructDiffSliceKeysDuplicates(t *testing.T) {
 		})
 	}
 }
+
+// namedMapKey is a defined string type used as a map key, like config's
+// ScriptHook (`type ScriptHook string`). Its kind is String but its dynamic
+// type is not string.
+type namedMapKey string
+
+type namedKeyMapHolder struct {
+	M map[namedMapKey]string `json:"m"`
+}
+
+// TestGetStructDiffNamedStringMapKey guards against a regression where
+// diffMapStringKey extracted keys with a `k.Interface().(string)` assertion,
+// which panics for a defined string key type (routing only checks the key's
+// Kind is String). Value.String() handles both string and named-string keys.
+func TestGetStructDiffNamedStringMapKey(t *testing.T) {
+	a := namedKeyMapHolder{M: map[namedMapKey]string{"pre": "a", "post": "x"}}
+	b := namedKeyMapHolder{M: map[namedMapKey]string{"pre": "b", "post": "x"}}
+
+	got, err := GetStructDiff(&a, &b, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, []ResolvedChange{{Field: "m['pre']", Old: "a", New: "b"}}, resolveChanges(got))
+}


### PR DESCRIPTION
`diffMapStringKey` runs whenever a map's key Kind is String, but extracted keys with
`k.Interface().(string)` — which panics for a defined string key type
(`type ScriptHook string`), whose dynamic type is not `string`:

```
panic: interface conversion: interface {} is config.ScriptHook, not string
```

`Value.String()` returns the underlying string for any String-kind value and handles both.

Latent today: the only such map in the config tree is `Experimental.Scripts`
(`map[ScriptHook]Command`), and no resource `StateType`/`RemoteType` has a named-string key,
so nothing the direct engine diffs reaches it. This hardens against any caller that does. The
regression test panics without the fix.
