### PR TITLE
Update AI training owners

### DIFF
--- a/.github/OWNERTEAMS
+++ b/.github/OWNERTEAMS
@@ -17,4 +17,4 @@ team:platform   @simonfaltum @renaudhartert-db @hectorcast-db @parthban-db @tanm
 team:eng-apps-devex @fjakobs @Shridhad @atilafassina @keugenek @igrekun @pkosiec @MarioCadenas @pffigueiredo @ditadi @calvarjorge
 team:eng-sandbox @pietern @shuochen0311 @akshaysingla-db @anwell-db @samhuan-db
 team:ide        @rugpanov @rclarey @anton-107 @misha-db @parthban-db
-team:ai-training @apeforest @bfontain @lu-wang-dl @panchalhp-db @vinchenzo-db @maggiewang-db @riddhibhagwat-db @ben-hansen-db @pardis-beikzadeh-db
+team:ai-training @apeforest @bfontain @panchalhp-db @vinchenzo-db @maggiewang-db @ben-hansen-db @pardis-beikzadeh-db @caroline-db


### PR DESCRIPTION
## Changes
Remove former team members. Add caroline-db to AI Training owners list.

## Why
Former team members lu-wang-dl riddhibhagwat-db left the company.
@caroline-db recently joined and will work on the Databricks air project.

## Tests
NA

<!-- If your PR needs to be included in the release notes for next release,
add a changelog fragment: create .nextchanges/<section>/<name>.md with a
one-line description (e.g. .nextchanges/cli/quickstart.md). See .nextchanges/README.md. -->
