### PR TITLE
Fix engine="unknown" in deploy telemetry on failed deploys

### DIFF
--- a/acceptance/bundle/telemetry/deploy-failed-engine-unknown/out.resources_metadata.direct.txt
+++ b/acceptance/bundle/telemetry/deploy-failed-engine-unknown/out.resources_metadata.direct.txt
@@ -1,0 +1,9 @@
+{
+  "state_engine": "direct",
+  "resources": [
+    {
+      "resource_type": "jobs",
+      "count": 1
+    }
+  ]
+}

--- a/acceptance/bundle/telemetry/deploy-failed-engine-unknown/out.resources_metadata.terraform.txt
+++ b/acceptance/bundle/telemetry/deploy-failed-engine-unknown/out.resources_metadata.terraform.txt
@@ -1,0 +1,9 @@
+{
+  "state_engine": "terraform",
+  "resources": [
+    {
+      "resource_type": "jobs",
+      "count": 1
+    }
+  ]
+}

--- a/acceptance/bundle/telemetry/deploy-failed-engine-unknown/output.txt
+++ b/acceptance/bundle/telemetry/deploy-failed-engine-unknown/output.txt
@@ -10,20 +10,3 @@ API message: Internal error
 
 
 Exit code: 1
-
->>> cat out.requests.txt
-
-=== resources_metadata is reported without state_engine on a failed deploy
->>> cat telemetry.json
-{
-  "resources": [
-    {
-      "resource_type": "jobs",
-      "count": 1
-    }
-  ]
-}
-
-=== state_engine is null even though the engine was resolved before the failure
->>> cat telemetry.json
-null

--- a/acceptance/bundle/telemetry/deploy-failed-engine-unknown/script
+++ b/acceptance/bundle/telemetry/deploy-failed-engine-unknown/script
@@ -1,16 +1,13 @@
 errcode trace $CLI bundle deploy
 
-trace cat out.requests.txt | jq 'select(has("path") and .path == "/telemetry-ext") | .body.protoLogs[] | fromjson' > telemetry.json
+cat out.requests.txt | jq 'select(has("path") and .path == "/telemetry-ext") | .body.protoLogs[] | fromjson' > telemetry.json
 
-# resources_metadata is present (per-type counts come from the config), but there is
-# no state_engine key: the deploy failed before deployCore ran, so b.Metrics.StateEngine
-# is still the zero value and its omitempty drops it. This absence is the "unknown
-# engine" the dashboard reports for failed/cancelled deploys.
-title "resources_metadata is reported without state_engine on a failed deploy"
-trace cat telemetry.json | jq '.entry.databricks_cli_log.bundle_deploy_event.resources_metadata'
-
-title "state_engine is null even though the engine was resolved before the failure"
-trace cat telemetry.json | jq '.entry.databricks_cli_log.bundle_deploy_event.resources_metadata.state_engine'
+# The deploy fails before deployCore runs (the deployment-lock write is stubbed to
+# 500), yet resources_metadata still reports state_engine: b.Metrics.StateEngine is
+# set as soon as the deployment state is pulled, not only inside deployCore. Before
+# that fix state_engine was empty on this path, which the dashboard showed as
+# engine="unknown". state_engine is engine-specific, so capture it per-engine.
+cat telemetry.json | jq '.entry.databricks_cli_log.bundle_deploy_event.resources_metadata' > out.resources_metadata.$DATABRICKS_BUNDLE_ENGINE.txt
 
 rm out.requests.txt
 rm telemetry.json

--- a/acceptance/bundle/telemetry/deploy-failed-engine-unknown/test.toml
+++ b/acceptance/bundle/telemetry/deploy-failed-engine-unknown/test.toml
@@ -1,20 +1,14 @@
-# Reproduces the "unknown engine" deploy telemetry.
-#
 # A deploy that fails before it starts applying resources (here it fails while
 # acquiring the deployment lock) still emits a bundle_deploy_event via the deferred
-# LogDeployTelemetry in cmd/bundle/utils/process.go. But b.Metrics.StateEngine is
-# assigned only inside deployCore (bundle/phases/deploy.go), which never runs on this
-# path, so it is still the zero value. resources_metadata is therefore reported with
-# per-type counts (which come from the config) but with no state_engine field, and
-# the dashboard surfaces that null as engine="unknown" - even though the engine was
-# fully resolved (ResolveEngineSetting) long before the deploy failed.
-#
-# The output is engine-agnostic: the lock is acquired in the shared deploy phase
-# before any engine-specific plan/apply, and a failed deploy records no per-resource
-# state sizes for either engine.
+# LogDeployTelemetry in cmd/bundle/utils/process.go. b.Metrics.StateEngine is set as
+# soon as the deployment state is pulled, so resources_metadata reports the engine
+# even though deployCore never runs on this path. Before that fix state_engine was
+# empty here, which the dashboard surfaced as engine="unknown".
 #
 # The stubbed endpoint is the one the workspace filer writes through, so the first
-# write - the deploy.lock file in lock.Acquire - is what fails here.
+# write - the deploy.lock file in lock.Acquire - is what fails here. A failed deploy
+# records no per-resource state sizes for either engine, so resources_metadata
+# diverges across the engine matrix only in state_engine; it is captured per-engine.
 Cloud = false
 
 [[Server]]

--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -80,8 +80,10 @@ type Metrics struct {
 	ExecutionTimes              []protos.IntMapEntry
 	LocalCacheMeasurementsMs    []protos.IntMapEntry // Local cache measurements stored as milliseconds
 
-	// StateEngine is the engine that ran the deploy, set in deployCore. Empty when
-	// telemetry is emitted without a deploy having run.
+	// StateEngine is the engine that ran (or would have run) the deploy, set once
+	// the deployment state is pulled so deploy telemetry reports it even when the
+	// deploy fails or is cancelled before applying resources. Empty only when the
+	// deploy fails before the state is read.
 	StateEngine engine.EngineType
 
 	// ResourceState is the direct engine's per-resource deployment state

--- a/bundle/phases/deploy.go
+++ b/bundle/phases/deploy.go
@@ -87,9 +87,6 @@ func deployCore(ctx context.Context, b *bundle.Bundle, plan *deployplan.Plan, st
 		state statemgmt.ExportedResourcesMap
 		err   error
 	)
-	// ThisOrDefault: an unset setting still runs the default engine, and telemetry
-	// should report the engine that ran.
-	b.Metrics.StateEngine = stateEngine.ThisOrDefault()
 	if stateEngine.IsDirect() {
 		b.DeploymentBundle.Apply(ctx, b.WorkspaceClient(ctx), plan)
 		state, err = b.DeploymentBundle.StateDB.Finalize(ctx)

--- a/cmd/bundle/utils/process.go
+++ b/cmd/bundle/utils/process.go
@@ -212,6 +212,10 @@ func ProcessBundleRet(cmd *cobra.Command, opts ProcessOptions) (b *bundle.Bundle
 		}
 		cmd.SetContext(ctx)
 
+		// Record the engine the resolved state uses now, so deploy telemetry reports
+		// it even when the deploy fails or is cancelled before deployCore runs.
+		b.Metrics.StateEngine = stateDesc.Engine.ThisOrDefault()
+
 		b.MigratingToDirect = requiredEngine.Type == engine.EngineDirect && !stateDesc.Engine.IsDirect()
 
 		// Announce the auto-migration path here (only on deploy) so the user


### PR DESCRIPTION
## Changes
Set `b.Metrics.StateEngine` as soon as the deployment state is pulled, instead of only inside `deployCore`.

## Why
Deploy telemetry is emitted on every exit path, but the engine used to be recorded only inside `deployCore`. A deploy that failed or was cancelled before applying resources therefore reported an empty `state_engine`, which the dashboard shows as `engine="unknown"` - even though the engine had already been resolved.

## Tests
Stacked on #6586, which added an acceptance test reproducing the empty engine; this PR updates that test to show the engine is now reported per variant.

This pull request and its description were written by Isaac.