### PR TITLE
Reduce engine="unknown" further by using requested engine

### DIFF
--- a/acceptance/bundle/telemetry/deploy-failed-state-pull/.databricks/bundle/default/resources.json
+++ b/acceptance/bundle/telemetry/deploy-failed-state-pull/.databricks/bundle/default/resources.json
@@ -1,0 +1,1 @@
+this is not valid state json

--- a/acceptance/bundle/telemetry/deploy-failed-state-pull/databricks.yml
+++ b/acceptance/bundle/telemetry/deploy-failed-state-pull/databricks.yml
@@ -1,0 +1,8 @@
+bundle:
+  name: test-bundle
+  uuid: 11111111-2222-3333-4444-555555555555
+
+resources:
+  jobs:
+    job_one:
+      name: job one

--- a/acceptance/bundle/telemetry/deploy-failed-state-pull/out.resources_metadata.direct.txt
+++ b/acceptance/bundle/telemetry/deploy-failed-state-pull/out.resources_metadata.direct.txt
@@ -1,0 +1,9 @@
+{
+  "state_engine": "direct",
+  "resources": [
+    {
+      "resource_type": "jobs",
+      "count": 1
+    }
+  ]
+}

--- a/acceptance/bundle/telemetry/deploy-failed-state-pull/out.resources_metadata.terraform.txt
+++ b/acceptance/bundle/telemetry/deploy-failed-state-pull/out.resources_metadata.terraform.txt
@@ -1,0 +1,9 @@
+{
+  "state_engine": "terraform",
+  "resources": [
+    {
+      "resource_type": "jobs",
+      "count": 1
+    }
+  ]
+}

--- a/acceptance/bundle/telemetry/deploy-failed-state-pull/out.test.toml
+++ b/acceptance/bundle/telemetry/deploy-failed-state-pull/out.test.toml
@@ -1,0 +1,3 @@
+Cloud = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DMS = [""]

--- a/acceptance/bundle/telemetry/deploy-failed-state-pull/output.txt
+++ b/acceptance/bundle/telemetry/deploy-failed-state-pull/output.txt
@@ -1,0 +1,6 @@
+
+>>> [CLI] bundle deploy
+Error: parsing [TEST_TMP_DIR]/.databricks/bundle/default/resources.json: invalid character 'h' in literal true (expecting 'r')
+
+
+Exit code: 1

--- a/acceptance/bundle/telemetry/deploy-failed-state-pull/script
+++ b/acceptance/bundle/telemetry/deploy-failed-state-pull/script
@@ -1,0 +1,13 @@
+errcode trace $CLI bundle deploy
+
+cat out.requests.txt | jq 'select(has("path") and .path == "/telemetry-ext") | .body.protoLogs[] | fromjson' > telemetry.json
+
+# resources_metadata reports state_engine even though the deploy failed while pulling
+# the state: b.Metrics.StateEngine is set from the requested engine before the pull.
+# state_engine is engine-specific, so capture it per-engine. state_file_size_bytes is
+# dropped: it is os.Stat of the (committed) resources.json, whose byte count can shift
+# with line-ending conversion across platforms.
+cat telemetry.json | jq '.entry.databricks_cli_log.bundle_deploy_event.resources_metadata | if . then del(.state_file_size_bytes) else . end' > out.resources_metadata.$DATABRICKS_BUNDLE_ENGINE.txt
+
+rm out.requests.txt
+rm telemetry.json

--- a/acceptance/bundle/telemetry/deploy-failed-state-pull/test.toml
+++ b/acceptance/bundle/telemetry/deploy-failed-state-pull/test.toml
@@ -1,0 +1,13 @@
+# A deploy that fails while pulling the deployment state - before the state's engine
+# is known - still emits a bundle_deploy_event via the deferred LogDeployTelemetry.
+# b.Metrics.StateEngine is set from the requested engine as soon as it is resolved
+# (before the state pull), so resources_metadata reports the engine here too. Without
+# that early assignment state_engine was empty on this path, which the dashboard
+# surfaced as engine="unknown".
+#
+# The committed .databricks/bundle/default/resources.json holds invalid JSON, so the
+# local state read fails to parse and the pull errors out before the state's engine is
+# determined. The engine reported is the requested one, which the acceptance matrix
+# varies, so resources_metadata is captured per-engine.
+Cloud = false
+Ignore = [".databricks"]

--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -80,10 +80,11 @@ type Metrics struct {
 	ExecutionTimes              []protos.IntMapEntry
 	LocalCacheMeasurementsMs    []protos.IntMapEntry // Local cache measurements stored as milliseconds
 
-	// StateEngine is the engine that ran (or would have run) the deploy, set once
-	// the deployment state is pulled so deploy telemetry reports it even when the
-	// deploy fails or is cancelled before applying resources. Empty only when the
-	// deploy fails before the state is read.
+	// StateEngine is the engine that ran (or would have run) the deploy. Set to the
+	// requested engine as soon as it is resolved, then refined to the state's engine
+	// once the state is pulled, so deploy telemetry reports it even when the deploy
+	// fails or is cancelled before applying resources. Empty only when the deploy
+	// fails before the engine is resolved.
 	StateEngine engine.EngineType
 
 	// ResourceState is the direct engine's per-resource deployment state

--- a/cmd/bundle/utils/process.go
+++ b/cmd/bundle/utils/process.go
@@ -197,6 +197,12 @@ func ProcessBundleRet(cmd *cobra.Command, opts ProcessOptions) (b *bundle.Bundle
 		return b, nil, err
 	}
 
+	// Record the requested engine up front so deploy telemetry reports it even when
+	// the deploy fails before the state is pulled (e.g. PullResourcesState itself
+	// errors). Refined to the state's engine below once it is known; the two differ
+	// only mid-migration, when the deploy runs on the existing state's engine.
+	b.Metrics.StateEngine = requiredEngine.Type.ThisOrDefault()
+
 	// The current deployment read from the service (nil, id "" if there is none yet). Used for the
 	// metadata diff and to reject a saved plan that predates the deployment's recorded version.
 	var dmsDeployment *bundledeployments.Deployment


### PR DESCRIPTION
## Changes
Set `b.Metrics.StateEngine` from the resolved requested engine as soon as it is resolved — before the state pull — while still refining it to the state's engine after the pull.

## Why
#6587 recorded the engine once the state was pulled, so a deploy that fails during the pull itself (e.g. an unreadable state file) still reported an empty `state_engine`, which the dashboard shows as `engine="unknown"`. The requested engine is known before the pull, so record it then.

## Tests
New acceptance test: a corrupt local state makes the pull fail, and `resources_metadata` reports the requested engine per variant. Confirmed it fails without the change.

This pull request and its description were written by Isaac.