### PR TITLE
experimental/ssh: fix keepalive test that could hang the proxy package for an hour

### DIFF
--- a/experimental/ssh/internal/proxy/keepalive_test.go
+++ b/experimental/ssh/internal/proxy/keepalive_test.go
@@ -109,25 +109,34 @@ func startKeepaliveTestServer(t *testing.T) (*httptest.Server, <-chan struct{}) 
 }
 
 // keepaliveTestDialer returns a connection factory for RunClientProxy. onNetConn, when set, receives
-// each connection's underlying socket so a test can control how its writes behave.
+// each connection's underlying socket — the initial one and each one a handover creates — once its
+// websocket handshake has completed, so a test can control how its writes behave.
 func keepaliveTestDialer(serverURL string, onNetConn func(*pausableConn)) createWebsocketConnectionFunc {
 	wsURL := "ws" + serverURL[4:]
-	dialer := websocket.Dialer{
-		NetDialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
-			conn, err := net.Dial(network, addr)
-			if err != nil {
-				return nil, err
-			}
-			wrapped := newPausableConn(conn)
-			if onNetConn != nil {
-				onNetConn(wrapped)
-			}
-			return wrapped, nil
-		},
-	}
 	return func(ctx context.Context, dial DialRequest) (*websocket.Conn, error) {
+		var wrapped *pausableConn
+		dialer := websocket.Dialer{
+			NetDialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+				conn, err := net.Dial(network, addr)
+				if err != nil {
+					return nil, err
+				}
+				wrapped = newPausableConn(conn)
+				return wrapped, nil
+			},
+		}
 		conn, _, err := dialer.DialContext(ctx, fmt.Sprintf("%s?id=%s", wsURL, dial.ConnID), nil) // nolint:bodyclose
-		return conn, err
+		if err != nil {
+			return nil, err
+		}
+		// Hand the socket to the test only after the handshake succeeds. The socket is dialed
+		// before gorilla writes the upgrade request, so exposing it any earlier lets a test that
+		// flips it to a failing mode poison the handshake itself — which fails connect() before the
+		// proxy loops start, leaving nothing to drain the caller's src pipe.
+		if onNetConn != nil {
+			onNetConn(wrapped)
+		}
+		return conn, nil
 	}
 }
 
@@ -252,8 +261,10 @@ func TestKeepalivePingFailureDoesNotHangTheSession(t *testing.T) {
 
 	// The session ends the way it would without a keepalive at all: the next write fails and the
 	// sending loop reports it. Before, the teardown could not close the connection and this hung.
-	_, err := srcWriter.Write([]byte("keystroke"))
-	require.NoError(t, err)
+	// Write from a goroutine: src is an unbuffered pipe the sending loop drains, so if the session
+	// has already ended (nothing draining it) the write blocks forever — doing it concurrently
+	// leaves the select below free to fail fast instead of wedging the whole package on the write.
+	go func() { srcWriter.Write([]byte("keystroke")) }() // nolint:errcheck
 
 	select {
 	case err := <-done:


### PR DESCRIPTION
## Summary

`TestKeepalivePingFailureDoesNotHangTheSession` wedged the entire `experimental/ssh/internal/proxy` test binary until the 60m timeout in one CI run (`task test (macos, terraform)`). The package normally runs in ~15–140ms, so a single hung test consumed the whole hour.

Two independent flaws combined:

1. **Connect-time race in the test dialer.** The test gates its keystroke write on `socket.Load() != nil`, but `keepaliveTestDialer` captured the socket inside `NetDialContext` — i.e. at TCP-dial time, *before* gorilla writes the websocket upgrade request. Flipping the socket to a failing mode in that window poisons the handshake itself, so `connect()` fails and `RunClientProxy` returns before the proxy loops ever start. Nothing then drains the caller's `src` pipe. Fixed by handing the socket to the test only after the handshake completes.

2. **Blocking stimulus write.** The keystroke write went to an unbuffered `io.Pipe` that only the sending loop drains. If the session has already ended, that write blocks forever — before the test can reach its own 30s `done`-guard. Fixed by issuing the write from a goroutine so the `select` is free to fail fast.

The panic dump confirmed the diagnosis: zero proxy goroutines alive, the test goroutine parked in an *open* pipe write, and — uniquely for this run — the `Establishing SSH proxy connection...` log with no matching `SSH proxy connection established`.

## Testing

- `go test ./experimental/ssh/internal/proxy/ -run TestKeepalive -race`
- Stressed the previously-hanging test 400× with no failures.

This pull request and its description were written by Isaac.