### PR TITLE
build: cap unit test packages at a 10m timeout instead of 60m

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -461,6 +461,11 @@ tasks:
     generates:
       - test-output-unit-root.json
     cmds:
+      # Unit packages default to a far shorter per-package timeout than the acceptance
+      # suite (test-acc keeps 60m for the single, legitimately long ./acceptance binary).
+      # The slowest unit package observed across Linux/macOS/Windows is ~83s, so 10m is
+      # ample headroom while a hung package (e.g. a wedged goroutine) fails in minutes
+      # instead of burning the full hour. LOCAL_TIMEOUT still overrides when needed.
       - |
         {{.GO_TOOL}} gotestsum \
           --format ${GOTESTSUM_FORMAT:-pkgname-and-test-fails} \
@@ -468,7 +473,7 @@ tasks:
           --jsonfile test-output-unit-root.json \
           --rerun-fails \
           --packages "{{.TEST_PACKAGES}}" \
-          -- -timeout=${LOCAL_TIMEOUT:-60m}
+          -- -timeout=${LOCAL_TIMEOUT:-10m}
 
   test-unit-tools:
     desc: Run unit tests in tools/ module
@@ -492,7 +497,7 @@ tasks:
           --jsonfile test-output-unit-tools.json \
           --rerun-fails \
           --packages ./... \
-          -- -timeout=${LOCAL_TIMEOUT:-60m}
+          -- -timeout=${LOCAL_TIMEOUT:-10m}
 
   test-unit-codegen:
     desc: Run unit tests in bundle/internal/tf/codegen module
@@ -512,7 +517,7 @@ tasks:
           --jsonfile test-output-unit-codegen.json \
           --rerun-fails \
           --packages ./... \
-          -- -timeout=${LOCAL_TIMEOUT:-60m}
+          -- -timeout=${LOCAL_TIMEOUT:-10m}
 
   test-acc:
     desc: Run acceptance tests


### PR DESCRIPTION
## Summary

The unit test targets (`test-unit-root`, `test-unit-tools`, `test-unit-codegen`) passed `-timeout=${LOCAL_TIMEOUT:-60m}` — the same budget the acceptance suite legitimately needs. Go applies `-timeout` **per package test binary**, so a single hung unit package burns the full hour before the runtime dumps goroutines. That is exactly what happened when `experimental/ssh/internal/proxy` wedged on `macOS/terraform` (it timed out at exactly `1h0m0s`).

This lowers the default for the fast unit targets to `10m`, leaving acceptance (`test-acc`) at `60m`. `LOCAL_TIMEOUT` still overrides both.

## Why 10m

Per-package total runtime from a recent full push-to-main run (`test-output.json`, terraform deployment), slowest unit package excluding `./acceptance`:

| OS | slowest unit package | `./acceptance` |
|----|----------------------|----------------|
| linux | 9.5s (`libs/patchwheel`) | ~14m |
| macos | 67s (`cmd`) | ~19m |
| windows | **83s** (`cmd/aitools`) | **~39m** |

The slowest unit package observed is ~83s, so 10m is ~7× headroom (comfortably absorbing CI variance and Windows slowness) while a genuine hang now surfaces in minutes rather than an hour. The 60m ceiling remains justified for the single, legitimately long `./acceptance` binary.

This pull request and its description were written by Isaac.