### PR TITLE
acceptance: report detected architecture when DBR test archive lacks a Go toolchain

### DIFF
--- a/acceptance/dbr_runner.py
+++ b/acceptance/dbr_runner.py
@@ -116,6 +116,15 @@ def setup_environment(extract_dir: Path) -> dict:
     bin_dir = extract_dir / "bin" / arch
     go_bin_dir = bin_dir / "go" / "bin"
 
+    # Serverless does not guarantee the driver CPU architecture, so it may run one
+    # the archive was not built for. Fail with the detected architecture instead of
+    # a bare "FileNotFoundError: 'go'" that hides which architecture was missing.
+    if not (go_bin_dir / "go").is_file():
+        raise RuntimeError(
+            f"no Go toolchain for architecture {arch!r} (platform.machine()={machine!r}) "
+            f"in the test archive at {go_bin_dir}"
+        )
+
     path_entries = [
         str(go_bin_dir),
         str(bin_dir),


### PR DESCRIPTION
## Summary

When a DBR acceptance run (`TestDbrAcceptance`) lands on a serverless driver whose CPU architecture the test archive was not built for, `dbr_runner.py` failed with a bare:

```
FileNotFoundError: [Errno 2] No such file or directory: 'go'
```

That message hides which architecture the driver actually reported, which makes the intermittent, AWS-only DBR failures hard to diagnose (serverless does not guarantee the driver's CPU architecture).

## Change

`setup_environment` now checks for the Go toolchain at the arch-specific path and, if it's missing, raises with the **detected architecture** and the raw `platform.machine()` value:

```
no Go toolchain for architecture 'arm64' (platform.machine()='aarch64') in the test archive at .../bin/arm64/go/bin
```

The error is surfaced by `dbr_test.go` as the task error, so the architecture shows up directly in the CI log. This is diagnostics only — no behavior change on drivers whose architecture the archive already bundles.

This pull request and its description were written by Isaac.
