### PR TITLE
testarchive: bundle arm64 tool binaries for DBR tests

### DIFF
--- a/internal/testarchive/archive.go
+++ b/internal/testarchive/archive.go
@@ -111,12 +111,10 @@ func CreateArchive(archiveDir, binDir, repoRoot string) error {
 		JqDownloader{Arch: "amd64", BinDir: binDir},
 		RuffDownloader{Arch: "amd64", BinDir: binDir},
 
-		// TODO: Serverless clusters do not support arm64 yet.
-		// Enable ARM64 once serverless clusters support it.
-		// GoDownloader{Arch: "arm64", BinDir: binDir, RepoRoot: repoRoot},
-		// UvDownloader{Arch: "arm64", BinDir: binDir},
-		// JqDownloader{Arch: "arm64", BinDir: binDir},
-		// RuffDownloader{Arch: "arm64", BinDir: binDir},
+		GoDownloader{Arch: "arm64", BinDir: binDir, RepoRoot: repoRoot},
+		UvDownloader{Arch: "arm64", BinDir: binDir},
+		JqDownloader{Arch: "arm64", BinDir: binDir},
+		RuffDownloader{Arch: "arm64", BinDir: binDir},
 	}
 
 	for _, downloader := range downloaders {


### PR DESCRIPTION
## Summary

The DBR acceptance tests (`TestDbrAcceptance`) fail on AWS intermittently with:

```
dbr_test.go: Task cloud_tests error: FileNotFoundError: [Errno 2] No such file or directory: 'go'
```

## Root cause

`internal/testarchive/archive.go` (`CreateArchive`) bundled the Go/uv/jq/ruff tool binaries for **amd64 only** — the arm64 downloaders were commented out. `acceptance/dbr_runner.py` selects the architecture at **runtime** from `platform.machine()` and builds `PATH` from `bin/<arch>/go/bin`.

Databricks serverless does not guarantee the driver CPU architecture; it can schedule an arm64 (Graviton) or an x86_64 driver. When a run lands on an arm64 driver, `bin/arm64/go/bin/go` is absent from the archive and `go` fails to resolve on the driver.

This is deducible from the failure itself: `dbr_runner.py` maps `platform.machine()` to exactly `amd64` or `arm64` (anything else raises `ValueError` earlier), and an amd64 driver would resolve the bundled `bin/amd64/go/bin/go` — so a `FileNotFoundError` for `go` implies the driver reported arm64. It shows up intermittently because the architecture is assigned per run.

## Fix

Re-enable the four arm64 downloaders in `CreateArchive`. They are already implemented and covered for both architectures by `integration/testarchive/downloader_test.go`, and `dbr_runner.py` already selects the architecture at runtime — so the archive now works on whichever architecture the driver runs.

This is a no-op for amd64 drivers: `setup_environment` resolves `bin/amd64/...` exactly as before and never touches `bin/arm64/...`. The only cost is a larger archive (both architectures' tool payloads), which is the file's stated design intent ("Download tools for both arm and amd64 architectures").

This pull request and its description were written by Isaac.
