### PR TITLE
[air] Upload the finalized training config

### DIFF
--- a/acceptance/experimental/air/run-submit-deps/output.txt
+++ b/acceptance/experimental/air/run-submit-deps/output.txt
@@ -12,7 +12,7 @@ Stream logs after submission using:
 === only config + command are uploaded; no requirements.yaml
 >>> print_requests.py //api/2.0/workspace-files/import-file --oneline --sort --unique --keep
 {"method": "POST", "path": "/api/2.0/workspace-files/import-file/Workspace/Users/[USERNAME]/.air/cli_launch/deps-smoke/deps-smoke_[RUN_ID]/command.sh", "q": {"overwrite": "true"}, "raw_body": "python train.py"}
-{"method": "POST", "path": "/api/2.0/workspace-files/import-file/Workspace/Users/[USERNAME]/.air/cli_launch/deps-smoke/deps-smoke_[RUN_ID]/training_config.yaml", "q": {"overwrite": "true"}, "raw_body": "experiment_name: deps-smoke\ncompute:\n    num_accelerators: 1\n    accelerator_type: GPU_1xH100\n    provisioned_capacity_id: capacity-123\nenvironment:\n    dependencies:\n        - numpy\n        - torch==2.3.0\n    version: 5\ncommand: python train.py\nmlflow_artifact_location: dbfs:/Volumes/main/default/air-artifacts\n"}
+{"method": "POST", "path": "/api/2.0/workspace-files/import-file/Workspace/Users/[USERNAME]/.air/cli_launch/deps-smoke/deps-smoke_[RUN_ID]/training_config.yaml", "q": {"overwrite": "true"}, "raw_body": "experiment_name: deps-smoke\ncommand: python train.py\ncompute:\n    accelerator_type: GPU_1xH100\n    num_accelerators: 1\n    provisioned_capacity_id: capacity-123\nenvironment:\n    version: 5\n    dependencies:\n        - numpy\n        - torch==2.3.0\nmlflow_artifact_location: /Volumes/main/default/air-artifacts\n"}
 
 === inline deps, artifact location, and capacity id reach the submit payload
 >>> print_requests.py //api/2.2/jobs/runs/submit

--- a/acceptance/experimental/air/run-submit-deps/output.txt
+++ b/acceptance/experimental/air/run-submit-deps/output.txt
@@ -12,7 +12,7 @@ Stream logs after submission using:
 === only config + command are uploaded; no requirements.yaml
 >>> print_requests.py //api/2.0/workspace-files/import-file --oneline --sort --unique --keep
 {"method": "POST", "path": "/api/2.0/workspace-files/import-file/Workspace/Users/[USERNAME]/.air/cli_launch/deps-smoke/deps-smoke_[RUN_ID]/command.sh", "q": {"overwrite": "true"}, "raw_body": "python train.py"}
-{"method": "POST", "path": "/api/2.0/workspace-files/import-file/Workspace/Users/[USERNAME]/.air/cli_launch/deps-smoke/deps-smoke_[RUN_ID]/training_config.yaml", "q": {"overwrite": "true"}, "raw_body": "experiment_name: deps-smoke\ncommand: python train.py\ncompute:\n  accelerator_type: GPU_1xH100\n  num_accelerators: 1\n  provisioned_capacity_id: capacity-123\nenvironment:\n  version: 5\n  dependencies:\n    - numpy\n    - torch==2.3.0\nmlflow_artifact_location: /Volumes/main/default/air-artifacts\n"}
+{"method": "POST", "path": "/api/2.0/workspace-files/import-file/Workspace/Users/[USERNAME]/.air/cli_launch/deps-smoke/deps-smoke_[RUN_ID]/training_config.yaml", "q": {"overwrite": "true"}, "raw_body": "experiment_name: deps-smoke\ncompute:\n    num_accelerators: 1\n    accelerator_type: GPU_1xH100\n    provisioned_capacity_id: capacity-123\nenvironment:\n    dependencies:\n        - numpy\n        - torch==2.3.0\n    version: 5\ncommand: python train.py\nmlflow_artifact_location: dbfs:/Volumes/main/default/air-artifacts\n"}
 
 === inline deps, artifact location, and capacity id reach the submit payload
 >>> print_requests.py //api/2.2/jobs/runs/submit

--- a/acceptance/experimental/air/run-submit-overrides/.gitattributes
+++ b/acceptance/experimental/air/run-submit-overrides/.gitattributes
@@ -1,0 +1,1 @@
+run.yaml text eol=lf

--- a/acceptance/experimental/air/run-submit-overrides/databricks.yml
+++ b/acceptance/experimental/air/run-submit-overrides/databricks.yml
@@ -1,0 +1,2 @@
+bundle:
+  name: air-run-submit-overrides

--- a/acceptance/experimental/air/run-submit-overrides/out.test.toml
+++ b/acceptance/experimental/air/run-submit-overrides/out.test.toml
@@ -1,0 +1,2 @@
+Cloud = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/experimental/air/run-submit-overrides/output.txt
+++ b/acceptance/experimental/air/run-submit-overrides/output.txt
@@ -12,8 +12,8 @@ Tip: use --watch when submitting a run to stream logs to your terminal.
 Stream logs after submission using:
   databricks experimental air logs 555
 
-=== the uploaded config contains normalization and overrides
+=== the uploaded config preserves source order and contains overrides
 >>> print_requests.py //api/2.0/workspace-files/import-file --oneline --sort --unique
 {"method": "POST", "path": "/api/2.0/workspace-files/import-file/Workspace/Users/[USERNAME]/.air/cli_launch/overrides-smoke/overrides-smoke_[RUN_ID]/command.sh", "q": {"overwrite": "true"}, "raw_body": "python train.py"}
 {"method": "POST", "path": "/api/2.0/workspace-files/import-file/Workspace/Users/[USERNAME]/.air/cli_launch/overrides-smoke/overrides-smoke_[RUN_ID]/hyperparameters.yaml", "q": {"overwrite": "true"}, "raw_body": "model:\n    hidden_size: 2048\noptimizer:\n    learning_rate: 0.001\n    name: adamw\n"}
-{"method": "POST", "path": "/api/2.0/workspace-files/import-file/Workspace/Users/[USERNAME]/.air/cli_launch/overrides-smoke/overrides-smoke_[RUN_ID]/training_config.yaml", "q": {"overwrite": "true"}, "raw_body": "experiment_name: overrides-smoke\ncompute:\n    num_accelerators: 2\n    accelerator_type: GPU_1xH100\ncommand: python train.py\nparameters:\n    model:\n        hidden_size: 2048\n    optimizer:\n        learning_rate: 0.001\n        name: adamw\nmlflow_artifact_location: dbfs:/Volumes/main/default/air-artifacts\n"}
+{"method": "POST", "path": "/api/2.0/workspace-files/import-file/Workspace/Users/[USERNAME]/.air/cli_launch/overrides-smoke/overrides-smoke_[RUN_ID]/training_config.yaml", "q": {"overwrite": "true"}, "raw_body": "experiment_name: overrides-smoke\ncommand: python train.py\ncompute:\n    accelerator_type: GPU_1xH100\n    num_accelerators: 2\nparameters:\n    model:\n        hidden_size: 2048\n    optimizer:\n        name: adamw\n        learning_rate: 0.001\nmlflow_artifact_location: /Volumes/main/default/air-artifacts\n"}

--- a/acceptance/experimental/air/run-submit-overrides/output.txt
+++ b/acceptance/experimental/air/run-submit-overrides/output.txt
@@ -1,0 +1,19 @@
+
+=== submit with nested overrides
+>>> [CLI] experimental air run -f run.yaml --override compute.num_accelerators=2 --override parameters.model.hidden_size=2048 --override parameters.optimizer.learning_rate=0.001
+Override: changing compute.num_accelerators from 1 to 2
+Override: changing parameters.model.hidden_size from 1024 to 2048
+Override: setting parameters.optimizer.learning_rate to 0.001
+Submitting experiment: overrides-smoke
+Submitted workload with Job Run ID: 555
+View job run at: [DATABRICKS_URL]/jobs/runs/555
+
+Tip: use --watch when submitting a run to stream logs to your terminal.
+Stream logs after submission using:
+  databricks experimental air logs 555
+
+=== the uploaded config contains normalization and overrides
+>>> print_requests.py //api/2.0/workspace-files/import-file --oneline --sort --unique
+{"method": "POST", "path": "/api/2.0/workspace-files/import-file/Workspace/Users/[USERNAME]/.air/cli_launch/overrides-smoke/overrides-smoke_[RUN_ID]/command.sh", "q": {"overwrite": "true"}, "raw_body": "python train.py"}
+{"method": "POST", "path": "/api/2.0/workspace-files/import-file/Workspace/Users/[USERNAME]/.air/cli_launch/overrides-smoke/overrides-smoke_[RUN_ID]/hyperparameters.yaml", "q": {"overwrite": "true"}, "raw_body": "model:\n    hidden_size: 2048\noptimizer:\n    learning_rate: 0.001\n    name: adamw\n"}
+{"method": "POST", "path": "/api/2.0/workspace-files/import-file/Workspace/Users/[USERNAME]/.air/cli_launch/overrides-smoke/overrides-smoke_[RUN_ID]/training_config.yaml", "q": {"overwrite": "true"}, "raw_body": "experiment_name: overrides-smoke\ncompute:\n    num_accelerators: 2\n    accelerator_type: GPU_1xH100\ncommand: python train.py\nparameters:\n    model:\n        hidden_size: 2048\n    optimizer:\n        learning_rate: 0.001\n        name: adamw\nmlflow_artifact_location: dbfs:/Volumes/main/default/air-artifacts\n"}

--- a/acceptance/experimental/air/run-submit-overrides/run.yaml
+++ b/acceptance/experimental/air/run-submit-overrides/run.yaml
@@ -1,0 +1,11 @@
+experiment_name: overrides-smoke
+command: python train.py
+compute:
+  accelerator_type: GPU_1xH100
+  num_accelerators: 1
+parameters:
+  model:
+    hidden_size: 1024
+  optimizer:
+    name: adamw
+mlflow_artifact_location: /Volumes/main/default/air-artifacts

--- a/acceptance/experimental/air/run-submit-overrides/script
+++ b/acceptance/experimental/air/run-submit-overrides/script
@@ -4,5 +4,5 @@ trace $CLI experimental air run -f run.yaml \
   --override parameters.model.hidden_size=2048 \
   --override parameters.optimizer.learning_rate=0.001
 
-title "the uploaded config contains normalization and overrides"
+title "the uploaded config preserves source order and contains overrides"
 trace print_requests.py //api/2.0/workspace-files/import-file --oneline --sort --unique

--- a/acceptance/experimental/air/run-submit-overrides/script
+++ b/acceptance/experimental/air/run-submit-overrides/script
@@ -1,0 +1,8 @@
+title "submit with nested overrides"
+trace $CLI experimental air run -f run.yaml \
+  --override compute.num_accelerators=2 \
+  --override parameters.model.hidden_size=2048 \
+  --override parameters.optimizer.learning_rate=0.001
+
+title "the uploaded config contains normalization and overrides"
+trace print_requests.py //api/2.0/workspace-files/import-file --oneline --sort --unique

--- a/acceptance/experimental/air/run-submit-overrides/test.toml
+++ b/acceptance/experimental/air/run-submit-overrides/test.toml
@@ -1,5 +1,5 @@
-# A non-dry-run submit that verifies training_config.yaml contains the finalized
-# config after normalization and nested command-line overrides.
+# A non-dry-run submit that verifies training_config.yaml preserves source order
+# and contains nested command-line overrides.
 RecordRequests = true
 
 [[Server]]

--- a/acceptance/experimental/air/run-submit-overrides/test.toml
+++ b/acceptance/experimental/air/run-submit-overrides/test.toml
@@ -1,0 +1,21 @@
+# A non-dry-run submit that verifies training_config.yaml contains the finalized
+# config after normalization and nested command-line overrides.
+RecordRequests = true
+
+[[Server]]
+Pattern = "HEAD /"
+Response.Body = ''
+
+[[Server]]
+Pattern = "POST /api/2.0/ai-training/config:validate"
+Response.Body = '{}'
+
+[[Server]]
+Pattern = "POST /api/2.2/jobs/runs/submit"
+Response.Body = '''
+{"run_id": 555}
+'''
+
+[[Repls]]
+Old = 'overrides-smoke_[0-9a-f]{16}'
+New = 'overrides-smoke_[RUN_ID]'

--- a/experimental/air/cmd/compute.go
+++ b/experimental/air/cmd/compute.go
@@ -91,8 +91,8 @@ func gpusPerNode(g gpuType) (int, error) {
 type computeConfig struct {
 	NumAccelerators       int     `yaml:"num_accelerators" help:"Total number of GPUs to allocate. Must be a positive multiple of the accelerator type's per-node GPU count. See https://docs.databricks.com/aws/en/machine-learning/ai-runtime/cli/yaml-config#reference for supported GPU types."`
 	AcceleratorType       string  `yaml:"accelerator_type" help:"Which accelerator to run on, e.g. GPU_1xA10. See https://docs.databricks.com/aws/en/machine-learning/ai-runtime/cli/yaml-config#reference for the current list of supported GPU types. Matched case-sensitively."`
-	ProvisionedCapacityID *string `yaml:"provisioned_capacity_id" help:"Pre-provisioned AIR capacity reservation id. Must be 1-255 characters. Contact your Databricks account team to provision capacity."`
-	PriorityClass         *string `yaml:"priority_class" help:"Scheduling priority within the reservation: BEST_EFFORT (lowest, preemptable), NORMAL, or CRITICAL (highest). Requires provisioned_capacity_id."`
+	ProvisionedCapacityID *string `yaml:"provisioned_capacity_id,omitempty" help:"Pre-provisioned AIR capacity reservation id. Must be 1-255 characters. Contact your Databricks account team to provision capacity."`
+	PriorityClass         *string `yaml:"priority_class,omitempty" help:"Scheduling priority within the reservation: BEST_EFFORT (lowest, preemptable), NORMAL, or CRITICAL (highest). Requires provisioned_capacity_id."`
 }
 
 // validate checks the compute block against the backend's constraints.

--- a/experimental/air/cmd/compute.go
+++ b/experimental/air/cmd/compute.go
@@ -91,8 +91,8 @@ func gpusPerNode(g gpuType) (int, error) {
 type computeConfig struct {
 	NumAccelerators       int     `yaml:"num_accelerators" help:"Total number of GPUs to allocate. Must be a positive multiple of the accelerator type's per-node GPU count. See https://docs.databricks.com/aws/en/machine-learning/ai-runtime/cli/yaml-config#reference for supported GPU types."`
 	AcceleratorType       string  `yaml:"accelerator_type" help:"Which accelerator to run on, e.g. GPU_1xA10. See https://docs.databricks.com/aws/en/machine-learning/ai-runtime/cli/yaml-config#reference for the current list of supported GPU types. Matched case-sensitively."`
-	ProvisionedCapacityID *string `yaml:"provisioned_capacity_id,omitempty" help:"Pre-provisioned AIR capacity reservation id. Must be 1-255 characters. Contact your Databricks account team to provision capacity."`
-	PriorityClass         *string `yaml:"priority_class,omitempty" help:"Scheduling priority within the reservation: BEST_EFFORT (lowest, preemptable), NORMAL, or CRITICAL (highest). Requires provisioned_capacity_id."`
+	ProvisionedCapacityID *string `yaml:"provisioned_capacity_id" help:"Pre-provisioned AIR capacity reservation id. Must be 1-255 characters. Contact your Databricks account team to provision capacity."`
+	PriorityClass         *string `yaml:"priority_class" help:"Scheduling priority within the reservation: BEST_EFFORT (lowest, preemptable), NORMAL, or CRITICAL (highest). Requires provisioned_capacity_id."`
 }
 
 // validate checks the compute block against the backend's constraints.

--- a/experimental/air/cmd/convert_to_dabs.go
+++ b/experimental/air/cmd/convert_to_dabs.go
@@ -156,7 +156,7 @@ func convertToDabs(ctx context.Context, cfg *runConfig, configPath, bundleDir st
 	// their paths from command_path. It no longer produces a requirements.yaml —
 	// file-form deps are folded into the environments[] spec — so there is nothing to
 	// filter out here.
-	artifacts, err := buildArtifacts(cfg, configPath)
+	artifacts, err := buildArtifacts(cfg)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/experimental/air/cmd/runconfig.go
+++ b/experimental/air/cmd/runconfig.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"regexp"
 	"slices"
+	"strconv"
 	"strings"
 
 	"go.yaml.in/yaml/v3"
@@ -43,23 +44,23 @@ var uuidRe = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[
 type runConfig struct {
 	ExperimentName string             `yaml:"experiment_name" help:"Name of the experiment. Becomes the Jobs API task key: max 100 characters, alphanumerics, hyphens, and underscores only." required:"yes"`
 	Compute        *computeConfig     `yaml:"compute" help:"Which accelerators to run on and how many." required:"yes"`
-	Environment    *environmentConfig `yaml:"environment" help:"Python dependencies, or a custom Docker image, for the run's runtime."`
+	Environment    *environmentConfig `yaml:"environment,omitempty" help:"Python dependencies, or a custom Docker image, for the run's runtime."`
 	Command        *string            `yaml:"command" help:"Shell command that starts the workload. Max 1000 lines; move longer logic into a script under code_source." required:"yes"`
-	EnvVariables   map[string]string  `yaml:"env_variables" help:"Plain environment variables, as NAME: value. A name here cannot also appear in secrets."`
-	Secrets        map[string]string  `yaml:"secrets" help:"Environment variables sourced from secrets, as NAME: scope/key."`
-	CodeSource     *codeSourceConfig  `yaml:"code_source" help:"Local code to upload and make available to the run."`
+	EnvVariables   map[string]string  `yaml:"env_variables,omitempty" help:"Plain environment variables, as NAME: value. A name here cannot also appear in secrets."`
+	Secrets        map[string]string  `yaml:"secrets,omitempty" help:"Environment variables sourced from secrets, as NAME: scope/key."`
+	CodeSource     *codeSourceConfig  `yaml:"code_source,omitempty" help:"Local code to upload and make available to the run."`
 	// MaxRetries defaults to 3 when unset; default-filling is a normalization
 	// concern handled at launch, so a nil pointer is left as-is here.
-	MaxRetries                *int           `yaml:"max_retries" help:"How many times to retry a failed run. Must be >= 0. Defaults to 3 when unset."`
-	TimeoutMinutes            *int           `yaml:"timeout_minutes" help:"Wall-clock limit for the run in minutes. Must be >= 1."`
-	IdempotencyToken          *string        `yaml:"idempotency_token" help:"Reuse token: a repeat submission with the same token returns the existing run instead of starting another. Max 64 characters."`
-	Parameters                map[string]any `yaml:"parameters" help:"Free-form values passed through to the workload. Any nested structure is allowed."`
-	MLflowRunName             *string        `yaml:"mlflow_run_name" help:"Name for the MLflow run. Max 100 characters, alphanumerics, hyphens, and underscores only."`
-	MLflowExperimentDirectory *string        `yaml:"mlflow_experiment_directory" help:"Workspace directory holding the MLflow experiment. Must start with /Workspace."`
-	MLflowArtifactLocation    *string        `yaml:"mlflow_artifact_location" help:"DBFS location where MLflow artifacts are written. A /Volumes path is normalized to dbfs:/Volumes/... ."`
-	Permissions               []permission   `yaml:"permissions" help:"Who may view or manage the run, as a list of principal plus level grants."`
-	UsagePolicyName           *string        `yaml:"usage_policy_name" help:"Usage policy to bill the run to, by name. Max 127 characters. Mutually exclusive with usage_policy_id."`
-	UsagePolicyID             *string        `yaml:"usage_policy_id" help:"Usage policy to bill the run to, by id. Mutually exclusive with usage_policy_name."`
+	MaxRetries                *int           `yaml:"max_retries,omitempty" help:"How many times to retry a failed run. Must be >= 0. Defaults to 3 when unset."`
+	TimeoutMinutes            *int           `yaml:"timeout_minutes,omitempty" help:"Wall-clock limit for the run in minutes. Must be >= 1."`
+	IdempotencyToken          *string        `yaml:"idempotency_token,omitempty" help:"Reuse token: a repeat submission with the same token returns the existing run instead of starting another. Max 64 characters."`
+	Parameters                map[string]any `yaml:"parameters,omitempty" help:"Free-form values passed through to the workload. Any nested structure is allowed."`
+	MLflowRunName             *string        `yaml:"mlflow_run_name,omitempty" help:"Name for the MLflow run. Max 100 characters, alphanumerics, hyphens, and underscores only."`
+	MLflowExperimentDirectory *string        `yaml:"mlflow_experiment_directory,omitempty" help:"Workspace directory holding the MLflow experiment. Must start with /Workspace."`
+	MLflowArtifactLocation    *string        `yaml:"mlflow_artifact_location,omitempty" help:"DBFS location where MLflow artifacts are written. A /Volumes path is normalized to dbfs:/Volumes/... ."`
+	Permissions               []permission   `yaml:"permissions,omitempty" help:"Who may view or manage the run, as a list of principal plus level grants."`
+	UsagePolicyName           *string        `yaml:"usage_policy_name,omitempty" help:"Usage policy to bill the run to, by name. Max 127 characters. Mutually exclusive with usage_policy_id."`
+	UsagePolicyID             *string        `yaml:"usage_policy_id,omitempty" help:"Usage policy to bill the run to, by id. Mutually exclusive with usage_policy_name."`
 }
 
 // validate runs structural validation over the whole config, returning the first
@@ -244,9 +245,9 @@ func validateSecretRefs(secrets map[string]string) error {
 // environmentConfig is the `environment` block: dependencies and/or a custom
 // docker image.
 type environmentConfig struct {
-	Dependencies dependencies       `yaml:"dependencies" help:"Inline list of packages to install. Not allowed alongside docker_image."`
-	Version      stringOrInt        `yaml:"version" help:"Client image version to pin. Only valid alongside inline dependencies."`
-	DockerImage  *dockerImageConfig `yaml:"docker_image" help:"Custom image supplying the whole runtime. Not allowed alongside dependencies or version."`
+	Dependencies dependencies       `yaml:"dependencies,omitempty" help:"Inline list of packages to install. Not allowed alongside docker_image."`
+	Version      stringOrInt        `yaml:"version,omitempty" help:"Client image version to pin. Only valid alongside inline dependencies."`
+	DockerImage  *dockerImageConfig `yaml:"docker_image,omitempty" help:"Custom image supplying the whole runtime. Not allowed alongside dependencies or version."`
 }
 
 func (e *environmentConfig) validate() error {
@@ -285,7 +286,7 @@ func (e *environmentConfig) validate() error {
 // dependencies is environment.dependencies: an inline list of packages. A scalar
 // (e.g. a path to a requirements file) is rejected — the list may itself reference
 // a requirements.txt, but dependencies must be given as a list.
-type dependencies struct {
+type dependencies struct { //nolint:recvcheck
 	set  bool
 	list []string
 }
@@ -298,12 +299,21 @@ func (d *dependencies) UnmarshalYAML(node *yaml.Node) error {
 	return node.Decode(&d.list)
 }
 
+func (d dependencies) MarshalYAML() (any, error) {
+	return d.list, nil
+}
+
+func (d dependencies) IsZero() bool {
+	return !d.set
+}
+
 // stringOrInt holds a scalar that may be a string or an integer in YAML
 // (environment.version). The raw text is kept; integer-format validation is a
 // launch-time concern.
-type stringOrInt struct {
-	set bool
-	raw string
+type stringOrInt struct { //nolint:recvcheck
+	set      bool
+	isString bool
+	raw      string
 }
 
 func (s *stringOrInt) UnmarshalYAML(node *yaml.Node) error {
@@ -311,8 +321,20 @@ func (s *stringOrInt) UnmarshalYAML(node *yaml.Node) error {
 		return errors.New("environment.version must be a string or integer")
 	}
 	s.set = true
+	s.isString = node.Tag == "!!str"
 	s.raw = node.Value
 	return nil
+}
+
+func (s stringOrInt) MarshalYAML() (any, error) {
+	if s.isString {
+		return s.raw, nil
+	}
+	return strconv.Atoi(s.raw)
+}
+
+func (s stringOrInt) IsZero() bool {
+	return !s.set
 }
 
 // dockerImageConfig is environment.docker_image.
@@ -320,11 +342,11 @@ type dockerImageConfig struct {
 	URL string `yaml:"url" help:"Fully qualified image URL, e.g. myregistry.io/team/train:v3." required:"when environment.docker_image is set"`
 	// "latest" re-checks the registry for the tag's newest digest each run;
 	// "auto" (default) reuses the existing registration.
-	TagPolicy string `yaml:"tag_policy" help:"\"auto\" (default) reuses the existing registration; \"latest\" re-checks the registry for the tag's newest digest each run."`
+	TagPolicy string `yaml:"tag_policy,omitempty" help:"\"auto\" (default) reuses the existing registration; \"latest\" re-checks the registry for the tag's newest digest each run."`
 	// Credentials for a private image that "latest" re-resolves; discovered from
 	// the local Docker config when unset.
-	CredentialsScope string `yaml:"credentials_scope" help:"Secret scope holding registry credentials for a private image re-resolved under tag_policy \"latest\"; discovered from the local Docker config when unset."`
-	CredentialsKey   string `yaml:"credentials_key" help:"Secret key (paired with credentials_scope) for private-image registry credentials."`
+	CredentialsScope string `yaml:"credentials_scope,omitempty" help:"Secret scope holding registry credentials for a private image re-resolved under tag_policy \"latest\"; discovered from the local Docker config when unset."`
+	CredentialsKey   string `yaml:"credentials_key,omitempty" help:"Secret key (paired with credentials_scope) for private-image registry credentials."`
 }
 
 const (
@@ -385,9 +407,9 @@ func (c *codeSourceConfig) validate() error {
 // snapshotSourceConfig describes a local directory to tar and upload.
 type snapshotSourceConfig struct {
 	RootPath     string   `yaml:"root_path" help:"Root of the code source to archive. A git-pinned subdirectory packages only that subtree." required:"when code_source.snapshot is set"`
-	RemoteVolume *string  `yaml:"remote_volume" help:"Volume to upload the archive to. Must start with /Volumes/."`
-	Git          *gitRef  `yaml:"git" help:"Pin the snapshot to a specific git revision."`
-	IncludePaths []string `yaml:"include_paths" help:"Restrict the archive to these paths, relative to root_path and without \"..\". Omit to include everything."`
+	RemoteVolume *string  `yaml:"remote_volume,omitempty" help:"Volume to upload the archive to. Must start with /Volumes/."`
+	Git          *gitRef  `yaml:"git,omitempty" help:"Pin the snapshot to a specific git revision."`
+	IncludePaths []string `yaml:"include_paths,omitempty" help:"Restrict the archive to these paths, relative to root_path and without \"..\". Omit to include everything."`
 }
 
 func (s *snapshotSourceConfig) validate() error {
@@ -426,9 +448,9 @@ func (s *snapshotSourceConfig) validate() error {
 // gitRef pins a snapshot to a specific git ref. branch and commit are mutually
 // exclusive; remote is only meaningful with branch.
 type gitRef struct {
-	Branch *string   `yaml:"branch" help:"Branch to pin to, resolved to its local HEAD. Mutually exclusive with commit." required:"one of branch or commit"`
-	Commit *string   `yaml:"commit" help:"Commit to pin to. Mutually exclusive with branch." required:"one of branch or commit"`
-	Remote gitRemote `yaml:"remote" help:"No longer supported: the snapshot archives your local copy. Only false is accepted; use commit to pin a revision."`
+	Branch *string   `yaml:"branch,omitempty" help:"Branch to pin to, resolved to its local HEAD. Mutually exclusive with commit." required:"one of branch or commit"`
+	Commit *string   `yaml:"commit,omitempty" help:"Commit to pin to. Mutually exclusive with branch." required:"one of branch or commit"`
+	Remote gitRemote `yaml:"remote,omitempty" help:"No longer supported: the snapshot archives your local copy. Only false is accepted; use commit to pin a revision."`
 }
 
 func (g *gitRef) validate() error {
@@ -454,7 +476,7 @@ func (g *gitRef) validate() error {
 
 // gitRemote is git.remote: false (default, use local HEAD), true (auto-detect the
 // remote), or a remote name string.
-type gitRemote struct {
+type gitRemote struct { //nolint:recvcheck
 	set      bool
 	isString bool
 	name     string
@@ -474,6 +496,17 @@ func (r *gitRemote) UnmarshalYAML(node *yaml.Node) error {
 	return nil
 }
 
+func (r gitRemote) MarshalYAML() (any, error) {
+	if r.isString {
+		return r.name, nil
+	}
+	return r.enabled, nil
+}
+
+func (r gitRemote) IsZero() bool {
+	return !r.set
+}
+
 // truthy reports whether remote requests a remote fetch (mirrors Python's
 // truthiness of the bool|str union).
 func (r *gitRemote) truthy() bool {
@@ -486,9 +519,9 @@ func (r *gitRemote) truthy() bool {
 // permission is a DABs-compatible permission grant: exactly one principal plus a
 // level.
 type permission struct {
-	UserName             *string `yaml:"user_name" help:"Grant to this user, by email. Exactly one principal field per grant." required:"one principal per grant"`
-	GroupName            *string `yaml:"group_name" help:"Grant to this group, by name. Exactly one principal field per grant." required:"one principal per grant"`
-	ServicePrincipalName *string `yaml:"service_principal_name" help:"Grant to this service principal, by name. Exactly one principal field per grant." required:"one principal per grant"`
+	UserName             *string `yaml:"user_name,omitempty" help:"Grant to this user, by email. Exactly one principal field per grant." required:"one principal per grant"`
+	GroupName            *string `yaml:"group_name,omitempty" help:"Grant to this group, by name. Exactly one principal field per grant." required:"one principal per grant"`
+	ServicePrincipalName *string `yaml:"service_principal_name,omitempty" help:"Grant to this service principal, by name. Exactly one principal field per grant." required:"one principal per grant"`
 	// Level is a databricks PermissionLevel (e.g. CAN_VIEW, CAN_MANAGE). Enum
 	// membership is validated server-side; here we only require it to be set.
 	Level string `yaml:"level" help:"Permission level to grant, e.g. CAN_VIEW or CAN_MANAGE. Validated server-side." required:"when a grant is listed"`

--- a/experimental/air/cmd/runconfig.go
+++ b/experimental/air/cmd/runconfig.go
@@ -8,7 +8,6 @@ import (
 	"reflect"
 	"regexp"
 	"slices"
-	"strconv"
 	"strings"
 
 	"go.yaml.in/yaml/v3"
@@ -44,23 +43,26 @@ var uuidRe = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[
 type runConfig struct {
 	ExperimentName string             `yaml:"experiment_name" help:"Name of the experiment. Becomes the Jobs API task key: max 100 characters, alphanumerics, hyphens, and underscores only." required:"yes"`
 	Compute        *computeConfig     `yaml:"compute" help:"Which accelerators to run on and how many." required:"yes"`
-	Environment    *environmentConfig `yaml:"environment,omitempty" help:"Python dependencies, or a custom Docker image, for the run's runtime."`
+	Environment    *environmentConfig `yaml:"environment" help:"Python dependencies, or a custom Docker image, for the run's runtime."`
 	Command        *string            `yaml:"command" help:"Shell command that starts the workload. Max 1000 lines; move longer logic into a script under code_source." required:"yes"`
-	EnvVariables   map[string]string  `yaml:"env_variables,omitempty" help:"Plain environment variables, as NAME: value. A name here cannot also appear in secrets."`
-	Secrets        map[string]string  `yaml:"secrets,omitempty" help:"Environment variables sourced from secrets, as NAME: scope/key."`
-	CodeSource     *codeSourceConfig  `yaml:"code_source,omitempty" help:"Local code to upload and make available to the run."`
+	EnvVariables   map[string]string  `yaml:"env_variables" help:"Plain environment variables, as NAME: value. A name here cannot also appear in secrets."`
+	Secrets        map[string]string  `yaml:"secrets" help:"Environment variables sourced from secrets, as NAME: scope/key."`
+	CodeSource     *codeSourceConfig  `yaml:"code_source" help:"Local code to upload and make available to the run."`
 	// MaxRetries defaults to 3 when unset; default-filling is a normalization
 	// concern handled at launch, so a nil pointer is left as-is here.
-	MaxRetries                *int           `yaml:"max_retries,omitempty" help:"How many times to retry a failed run. Must be >= 0. Defaults to 3 when unset."`
-	TimeoutMinutes            *int           `yaml:"timeout_minutes,omitempty" help:"Wall-clock limit for the run in minutes. Must be >= 1."`
-	IdempotencyToken          *string        `yaml:"idempotency_token,omitempty" help:"Reuse token: a repeat submission with the same token returns the existing run instead of starting another. Max 64 characters."`
-	Parameters                map[string]any `yaml:"parameters,omitempty" help:"Free-form values passed through to the workload. Any nested structure is allowed."`
-	MLflowRunName             *string        `yaml:"mlflow_run_name,omitempty" help:"Name for the MLflow run. Max 100 characters, alphanumerics, hyphens, and underscores only."`
-	MLflowExperimentDirectory *string        `yaml:"mlflow_experiment_directory,omitempty" help:"Workspace directory holding the MLflow experiment. Must start with /Workspace."`
-	MLflowArtifactLocation    *string        `yaml:"mlflow_artifact_location,omitempty" help:"DBFS location where MLflow artifacts are written. A /Volumes path is normalized to dbfs:/Volumes/... ."`
-	Permissions               []permission   `yaml:"permissions,omitempty" help:"Who may view or manage the run, as a list of principal plus level grants."`
-	UsagePolicyName           *string        `yaml:"usage_policy_name,omitempty" help:"Usage policy to bill the run to, by name. Max 127 characters. Mutually exclusive with usage_policy_id."`
-	UsagePolicyID             *string        `yaml:"usage_policy_id,omitempty" help:"Usage policy to bill the run to, by id. Mutually exclusive with usage_policy_name."`
+	MaxRetries                *int           `yaml:"max_retries" help:"How many times to retry a failed run. Must be >= 0. Defaults to 3 when unset."`
+	TimeoutMinutes            *int           `yaml:"timeout_minutes" help:"Wall-clock limit for the run in minutes. Must be >= 1."`
+	IdempotencyToken          *string        `yaml:"idempotency_token" help:"Reuse token: a repeat submission with the same token returns the existing run instead of starting another. Max 64 characters."`
+	Parameters                map[string]any `yaml:"parameters" help:"Free-form values passed through to the workload. Any nested structure is allowed."`
+	MLflowRunName             *string        `yaml:"mlflow_run_name" help:"Name for the MLflow run. Max 100 characters, alphanumerics, hyphens, and underscores only."`
+	MLflowExperimentDirectory *string        `yaml:"mlflow_experiment_directory" help:"Workspace directory holding the MLflow experiment. Must start with /Workspace."`
+	MLflowArtifactLocation    *string        `yaml:"mlflow_artifact_location" help:"DBFS location where MLflow artifacts are written. A /Volumes path is normalized to dbfs:/Volumes/... ."`
+	Permissions               []permission   `yaml:"permissions" help:"Who may view or manage the run, as a list of principal plus level grants."`
+	UsagePolicyName           *string        `yaml:"usage_policy_name" help:"Usage policy to bill the run to, by name. Max 127 characters. Mutually exclusive with usage_policy_id."`
+	UsagePolicyID             *string        `yaml:"usage_policy_id" help:"Usage policy to bill the run to, by id. Mutually exclusive with usage_policy_name."`
+
+	// artifactYAML is the source-derived config serialized for upload after overrides.
+	artifactYAML []byte
 }
 
 // validate runs structural validation over the whole config, returning the first
@@ -245,9 +247,9 @@ func validateSecretRefs(secrets map[string]string) error {
 // environmentConfig is the `environment` block: dependencies and/or a custom
 // docker image.
 type environmentConfig struct {
-	Dependencies dependencies       `yaml:"dependencies,omitempty" help:"Inline list of packages to install. Not allowed alongside docker_image."`
-	Version      stringOrInt        `yaml:"version,omitempty" help:"Client image version to pin. Only valid alongside inline dependencies."`
-	DockerImage  *dockerImageConfig `yaml:"docker_image,omitempty" help:"Custom image supplying the whole runtime. Not allowed alongside dependencies or version."`
+	Dependencies dependencies       `yaml:"dependencies" help:"Inline list of packages to install. Not allowed alongside docker_image."`
+	Version      stringOrInt        `yaml:"version" help:"Client image version to pin. Only valid alongside inline dependencies."`
+	DockerImage  *dockerImageConfig `yaml:"docker_image" help:"Custom image supplying the whole runtime. Not allowed alongside dependencies or version."`
 }
 
 func (e *environmentConfig) validate() error {
@@ -286,7 +288,7 @@ func (e *environmentConfig) validate() error {
 // dependencies is environment.dependencies: an inline list of packages. A scalar
 // (e.g. a path to a requirements file) is rejected — the list may itself reference
 // a requirements.txt, but dependencies must be given as a list.
-type dependencies struct { //nolint:recvcheck
+type dependencies struct {
 	set  bool
 	list []string
 }
@@ -299,21 +301,12 @@ func (d *dependencies) UnmarshalYAML(node *yaml.Node) error {
 	return node.Decode(&d.list)
 }
 
-func (d dependencies) MarshalYAML() (any, error) {
-	return d.list, nil
-}
-
-func (d dependencies) IsZero() bool {
-	return !d.set
-}
-
 // stringOrInt holds a scalar that may be a string or an integer in YAML
 // (environment.version). The raw text is kept; integer-format validation is a
 // launch-time concern.
-type stringOrInt struct { //nolint:recvcheck
-	set      bool
-	isString bool
-	raw      string
+type stringOrInt struct {
+	set bool
+	raw string
 }
 
 func (s *stringOrInt) UnmarshalYAML(node *yaml.Node) error {
@@ -321,20 +314,8 @@ func (s *stringOrInt) UnmarshalYAML(node *yaml.Node) error {
 		return errors.New("environment.version must be a string or integer")
 	}
 	s.set = true
-	s.isString = node.Tag == "!!str"
 	s.raw = node.Value
 	return nil
-}
-
-func (s stringOrInt) MarshalYAML() (any, error) {
-	if s.isString {
-		return s.raw, nil
-	}
-	return strconv.Atoi(s.raw)
-}
-
-func (s stringOrInt) IsZero() bool {
-	return !s.set
 }
 
 // dockerImageConfig is environment.docker_image.
@@ -342,11 +323,11 @@ type dockerImageConfig struct {
 	URL string `yaml:"url" help:"Fully qualified image URL, e.g. myregistry.io/team/train:v3." required:"when environment.docker_image is set"`
 	// "latest" re-checks the registry for the tag's newest digest each run;
 	// "auto" (default) reuses the existing registration.
-	TagPolicy string `yaml:"tag_policy,omitempty" help:"\"auto\" (default) reuses the existing registration; \"latest\" re-checks the registry for the tag's newest digest each run."`
+	TagPolicy string `yaml:"tag_policy" help:"\"auto\" (default) reuses the existing registration; \"latest\" re-checks the registry for the tag's newest digest each run."`
 	// Credentials for a private image that "latest" re-resolves; discovered from
 	// the local Docker config when unset.
-	CredentialsScope string `yaml:"credentials_scope,omitempty" help:"Secret scope holding registry credentials for a private image re-resolved under tag_policy \"latest\"; discovered from the local Docker config when unset."`
-	CredentialsKey   string `yaml:"credentials_key,omitempty" help:"Secret key (paired with credentials_scope) for private-image registry credentials."`
+	CredentialsScope string `yaml:"credentials_scope" help:"Secret scope holding registry credentials for a private image re-resolved under tag_policy \"latest\"; discovered from the local Docker config when unset."`
+	CredentialsKey   string `yaml:"credentials_key" help:"Secret key (paired with credentials_scope) for private-image registry credentials."`
 }
 
 const (
@@ -407,9 +388,9 @@ func (c *codeSourceConfig) validate() error {
 // snapshotSourceConfig describes a local directory to tar and upload.
 type snapshotSourceConfig struct {
 	RootPath     string   `yaml:"root_path" help:"Root of the code source to archive. A git-pinned subdirectory packages only that subtree." required:"when code_source.snapshot is set"`
-	RemoteVolume *string  `yaml:"remote_volume,omitempty" help:"Volume to upload the archive to. Must start with /Volumes/."`
-	Git          *gitRef  `yaml:"git,omitempty" help:"Pin the snapshot to a specific git revision."`
-	IncludePaths []string `yaml:"include_paths,omitempty" help:"Restrict the archive to these paths, relative to root_path and without \"..\". Omit to include everything."`
+	RemoteVolume *string  `yaml:"remote_volume" help:"Volume to upload the archive to. Must start with /Volumes/."`
+	Git          *gitRef  `yaml:"git" help:"Pin the snapshot to a specific git revision."`
+	IncludePaths []string `yaml:"include_paths" help:"Restrict the archive to these paths, relative to root_path and without \"..\". Omit to include everything."`
 }
 
 func (s *snapshotSourceConfig) validate() error {
@@ -448,9 +429,9 @@ func (s *snapshotSourceConfig) validate() error {
 // gitRef pins a snapshot to a specific git ref. branch and commit are mutually
 // exclusive; remote is only meaningful with branch.
 type gitRef struct {
-	Branch *string   `yaml:"branch,omitempty" help:"Branch to pin to, resolved to its local HEAD. Mutually exclusive with commit." required:"one of branch or commit"`
-	Commit *string   `yaml:"commit,omitempty" help:"Commit to pin to. Mutually exclusive with branch." required:"one of branch or commit"`
-	Remote gitRemote `yaml:"remote,omitempty" help:"No longer supported: the snapshot archives your local copy. Only false is accepted; use commit to pin a revision."`
+	Branch *string   `yaml:"branch" help:"Branch to pin to, resolved to its local HEAD. Mutually exclusive with commit." required:"one of branch or commit"`
+	Commit *string   `yaml:"commit" help:"Commit to pin to. Mutually exclusive with branch." required:"one of branch or commit"`
+	Remote gitRemote `yaml:"remote" help:"No longer supported: the snapshot archives your local copy. Only false is accepted; use commit to pin a revision."`
 }
 
 func (g *gitRef) validate() error {
@@ -476,7 +457,7 @@ func (g *gitRef) validate() error {
 
 // gitRemote is git.remote: false (default, use local HEAD), true (auto-detect the
 // remote), or a remote name string.
-type gitRemote struct { //nolint:recvcheck
+type gitRemote struct {
 	set      bool
 	isString bool
 	name     string
@@ -496,17 +477,6 @@ func (r *gitRemote) UnmarshalYAML(node *yaml.Node) error {
 	return nil
 }
 
-func (r gitRemote) MarshalYAML() (any, error) {
-	if r.isString {
-		return r.name, nil
-	}
-	return r.enabled, nil
-}
-
-func (r gitRemote) IsZero() bool {
-	return !r.set
-}
-
 // truthy reports whether remote requests a remote fetch (mirrors Python's
 // truthiness of the bool|str union).
 func (r *gitRemote) truthy() bool {
@@ -519,9 +489,9 @@ func (r *gitRemote) truthy() bool {
 // permission is a DABs-compatible permission grant: exactly one principal plus a
 // level.
 type permission struct {
-	UserName             *string `yaml:"user_name,omitempty" help:"Grant to this user, by email. Exactly one principal field per grant." required:"one principal per grant"`
-	GroupName            *string `yaml:"group_name,omitempty" help:"Grant to this group, by name. Exactly one principal field per grant." required:"one principal per grant"`
-	ServicePrincipalName *string `yaml:"service_principal_name,omitempty" help:"Grant to this service principal, by name. Exactly one principal field per grant." required:"one principal per grant"`
+	UserName             *string `yaml:"user_name" help:"Grant to this user, by email. Exactly one principal field per grant." required:"one principal per grant"`
+	GroupName            *string `yaml:"group_name" help:"Grant to this group, by name. Exactly one principal field per grant." required:"one principal per grant"`
+	ServicePrincipalName *string `yaml:"service_principal_name" help:"Grant to this service principal, by name. Exactly one principal field per grant." required:"one principal per grant"`
 	// Level is a databricks PermissionLevel (e.g. CAN_VIEW, CAN_MANAGE). Enum
 	// membership is validated server-side; here we only require it to be set.
 	Level string `yaml:"level" help:"Permission level to grant, e.g. CAN_VIEW or CAN_MANAGE. Validated server-side." required:"when a grant is listed"`

--- a/experimental/air/cmd/runconfig_load.go
+++ b/experimental/air/cmd/runconfig_load.go
@@ -14,22 +14,6 @@ import (
 	"go.yaml.in/yaml/v3"
 )
 
-// decodeRunConfig reads and decodes the run YAML into the schema. Unknown keys
-// are rejected (KnownFields).
-//
-// The `_bases_` composition feature is not yet ported; a config using `_bases_`
-// is currently rejected as an unknown field. CLI `--override` handling lives in
-// runconfig_override.go and is applied to the parsed map before this decode.
-func decodeRunConfig(path string) (*runConfig, error) {
-	f, err := os.Open(path)
-	if err != nil {
-		return nil, err
-	}
-	defer f.Close()
-
-	return decodeRunConfigReader(f, path)
-}
-
 // decodeRunConfigReader decodes and unknown-key-checks a run YAML from r. path is
 // used only for error messages.
 func decodeRunConfigReader(r io.Reader, path string) (*runConfig, error) {
@@ -52,23 +36,24 @@ func validateRunConfig(cfg *runConfig) error {
 }
 
 // loadRunConfig decodes and structurally validates a run YAML config file.
+// The `_bases_` composition feature is not yet supported and is rejected as an
+// unknown field.
 func loadRunConfig(path string) (*runConfig, error) {
-	cfg, err := decodeRunConfig(path)
+	document, raw, err := readRunConfigDocument(path)
 	if err != nil {
 		return nil, err
 	}
-	if err := validateRunConfig(cfg); err != nil {
-		return nil, err
+	if len(document.Content) == 0 {
+		return nil, fmt.Errorf("config %s is empty", path)
 	}
-	return cfg, nil
+	return finishRunConfigLoad(path, document, raw)
 }
 
-// loadRunConfigWithOverrides decodes a run YAML config, applies any
-// --override KEY=VALUE entries to the parsed map, then re-decodes (with unknown
-// keys rejected) and structurally validates the result. Applying overrides to
-// the map — rather than the typed config — lets the single decode+validate
-// pipeline enforce path existence, type coercion, and the semantic rules at
-// once. ctx is used only to log applied overrides.
+// loadRunConfigWithOverrides decodes a run YAML config, applies any --override
+// KEY=VALUE entries to its ordered YAML tree, then re-decodes (with unknown keys
+// rejected) and structurally validates the result. The serialized tree is kept
+// for training_config.yaml, while validation may normalize the typed config used
+// to submit the workload. ctx is used only to log applied overrides.
 func loadRunConfigWithOverrides(ctx context.Context, path string, overrides []string) (*runConfig, error) {
 	if len(overrides) == 0 {
 		return loadRunConfig(path)
@@ -81,36 +66,62 @@ func loadRunConfigWithOverrides(ctx context.Context, path string, overrides []st
 	if err := validateOverridePaths(entries); err != nil {
 		return nil, err
 	}
+	document, _, err := readRunConfigDocument(path)
+	if err != nil {
+		return nil, err
+	}
+	if len(document.Content) == 0 {
+		document.Kind = yaml.DocumentNode
+		document.Content = []*yaml.Node{newMappingNode()}
+	}
+	if err := applyOverrides(ctx, document, entries); err != nil {
+		return nil, err
+	}
+	validationYAML, err := yaml.Marshal(document)
+	if err != nil {
+		return nil, fmt.Errorf("failed to serialize config %s: %w", path, err)
+	}
+	return finishRunConfigLoad(path, document, validationYAML)
+}
 
+func readRunConfigDocument(path string) (*yaml.Node, []byte, error) {
 	raw, err := os.ReadFile(path)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	var m map[string]any
-	if err := yaml.Unmarshal(raw, &m); err != nil {
-		return nil, fmt.Errorf("invalid config %s: %w", path, err)
+	var document yaml.Node
+	if err := yaml.Unmarshal(raw, &document); err != nil {
+		return nil, nil, fmt.Errorf("invalid config %s: %w", path, err)
 	}
-	if m == nil {
-		// An empty file decodes to a nil map; start from an empty one so overrides
-		// can populate it (the re-decode still enforces required fields).
-		m = map[string]any{}
-	}
-	if err := applyOverrides(ctx, m, entries); err != nil {
-		return nil, err
-	}
+	return &document, raw, nil
+}
 
-	merged, err := yaml.Marshal(m)
-	if err != nil {
-		return nil, err
-	}
-	cfg, err := decodeRunConfigReader(bytes.NewReader(merged), path)
+func finishRunConfigLoad(path string, document *yaml.Node, validationYAML []byte) (*runConfig, error) {
+	// Validate before stripping comments so YAML errors retain source line numbers.
+	cfg, err := decodeRunConfigReader(bytes.NewReader(validationYAML), path)
 	if err != nil {
 		return nil, err
 	}
 	if err := validateRunConfig(cfg); err != nil {
 		return nil, err
 	}
+
+	stripYAMLComments(document)
+	artifactYAML, err := yaml.Marshal(document)
+	if err != nil {
+		return nil, fmt.Errorf("failed to serialize config %s: %w", path, err)
+	}
+	cfg.artifactYAML = artifactYAML
 	return cfg, nil
+}
+
+func stripYAMLComments(node *yaml.Node) {
+	node.HeadComment = ""
+	node.LineComment = ""
+	node.FootComment = ""
+	for _, child := range node.Content {
+		stripYAMLComments(child)
+	}
 }
 
 var runtimeVersionRe = regexp.MustCompile(`^[0-9]+$`)

--- a/experimental/air/cmd/runconfig_override.go
+++ b/experimental/air/cmd/runconfig_override.go
@@ -2,6 +2,7 @@ package aircmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 	"strings"
@@ -11,8 +12,9 @@ import (
 )
 
 // This file implements the `--override KEY=VALUE` flag. Overrides are applied to
-// the parsed YAML map (not the typed runConfig) before re-decode, so one pipeline
-// covers path existence, type coercion, and the semantic validate() rules.
+// the parsed YAML tree (not the typed runConfig) before re-decode, so one pipeline
+// covers path existence, type coercion, and the semantic validate() rules while
+// preserving source key order for training_config.yaml.
 
 // parseOverrides parses --override KEY=VALUE arguments, preserving order.
 func parseOverrides(overrides []string) ([]overrideEntry, error) {
@@ -85,38 +87,94 @@ func checkOverridePath(parts []string, node configField, fullPath string) error 
 	return checkOverridePath(parts[1:], child, fullPath)
 }
 
-// applyOverrides walks each dotted path into the parsed YAML map and sets the
-// leaf to the RHS parsed as a YAML scalar. Intermediate maps are auto-created so
+// applyOverrides walks each dotted path into the parsed YAML tree and sets the
+// leaf to the RHS parsed as YAML. Intermediate maps are auto-created so
 // an override can add a field the YAML omits; the later re-decode rejects paths
 // absent from the schema. Changes are logged to stderr to keep JSON stdout clean.
-func applyOverrides(ctx context.Context, m map[string]any, entries []overrideEntry) error {
+func applyOverrides(ctx context.Context, document *yaml.Node, entries []overrideEntry) error {
+	root := document
+	if document.Kind == yaml.DocumentNode {
+		root = document.Content[0]
+	}
+	if root.Kind != yaml.MappingNode {
+		return errors.New("run config must be a YAML mapping")
+	}
+
 	for _, e := range entries {
-		var value any
-		if err := yaml.Unmarshal([]byte(e.raw), &value); err != nil {
+		value, err := parseOverrideNode(e.raw)
+		if err != nil {
 			return fmt.Errorf("invalid --override %q: cannot parse value %q: %w", e.path, e.raw, err)
 		}
 
 		parts := strings.Split(e.path, ".")
-		current := m
+		current := root
 		for _, part := range parts[:len(parts)-1] {
-			next, ok := current[part].(map[string]any)
-			if !ok {
-				next = map[string]any{}
-				current[part] = next
+			next, index := mappingValue(current, part)
+			if next == nil {
+				next = newMappingNode()
+				current.Content = append(current.Content, newStringNode(part), next)
+			} else if next.Kind != yaml.MappingNode {
+				next = newMappingNode()
+				current.Content[index] = next
 			}
 			current = next
 		}
 
 		leaf := parts[len(parts)-1]
-		old, had := current[leaf]
-		current[leaf] = value
-		if had {
-			logOverride(ctx, fmt.Sprintf("Override: changing %s from %v to %v", e.path, old, value))
+		oldNode, index := mappingValue(current, leaf)
+		newValue, err := decodeYAMLNode(value)
+		if err != nil {
+			return fmt.Errorf("invalid --override %q: cannot decode value %q: %w", e.path, e.raw, err)
+		}
+		if oldNode != nil {
+			oldValue, err := decodeYAMLNode(oldNode)
+			if err != nil {
+				return fmt.Errorf("invalid value at override path %q: %w", e.path, err)
+			}
+			current.Content[index] = value
+			logOverride(ctx, fmt.Sprintf("Override: changing %s from %v to %v", e.path, oldValue, newValue))
 		} else {
-			logOverride(ctx, fmt.Sprintf("Override: setting %s to %v", e.path, value))
+			current.Content = append(current.Content, newStringNode(leaf), value)
+			logOverride(ctx, fmt.Sprintf("Override: setting %s to %v", e.path, newValue))
 		}
 	}
 	return nil
+}
+
+func parseOverrideNode(raw string) (*yaml.Node, error) {
+	var document yaml.Node
+	if err := yaml.Unmarshal([]byte(raw), &document); err != nil {
+		return nil, err
+	}
+	if len(document.Content) == 0 {
+		return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!null", Value: "null"}, nil
+	}
+	return document.Content[0], nil
+}
+
+func mappingValue(mapping *yaml.Node, key string) (*yaml.Node, int) {
+	for i := 0; i < len(mapping.Content); i += 2 {
+		if mapping.Content[i].Value == key {
+			return mapping.Content[i+1], i + 1
+		}
+	}
+	return nil, -1
+}
+
+func newMappingNode() *yaml.Node {
+	return &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+}
+
+func newStringNode(value string) *yaml.Node {
+	return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: value}
+}
+
+func decodeYAMLNode(node *yaml.Node) (any, error) {
+	var value any
+	if err := node.Decode(&value); err != nil {
+		return nil, err
+	}
+	return value, nil
 }
 
 // logOverride writes to stderr only when a cmdIO is present; cmdio.LogString

--- a/experimental/air/cmd/runconfig_test.go
+++ b/experimental/air/cmd/runconfig_test.go
@@ -147,6 +147,28 @@ func TestLoadRunConfig_UnknownFieldRejected(t *testing.T) {
 	}
 }
 
+func TestLoadRunConfig_ErrorLineNumbersUseSource(t *testing.T) {
+	path := writeConfig(t, `# first comment
+# second comment
+experiment_name: smoke
+command: echo hi
+compute:
+  accelerator_type: GPU_1xH100
+  num_accelerators: 1
+unknown_field: true
+`)
+
+	t.Run("without overrides", func(t *testing.T) {
+		_, err := loadRunConfig(path)
+		require.ErrorContains(t, err, "line 8: field unknown_field")
+	})
+
+	t.Run("with overrides", func(t *testing.T) {
+		_, err := loadRunConfigWithOverrides(t.Context(), path, []string{"compute.num_accelerators=2"})
+		require.ErrorContains(t, err, "line 8: field unknown_field")
+	})
+}
+
 func TestLoadRunConfig_Errors(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/experimental/air/cmd/runsubmit.go
+++ b/experimental/air/cmd/runsubmit.go
@@ -302,7 +302,7 @@ func submitWorkload(ctx context.Context, w *databricks.WorkspaceClient, cfg *run
 	if err != nil {
 		return 0, "", err
 	}
-	items, err := buildArtifacts(cfg, configPath)
+	items, err := buildArtifacts(cfg)
 	if err != nil {
 		return 0, "", err
 	}

--- a/experimental/air/cmd/runupload.go
+++ b/experimental/air/cmd/runupload.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"maps"
-	"os"
 	"slices"
 	"strings"
 
@@ -43,18 +42,15 @@ type fileWriter interface {
 	Write(ctx context.Context, name string, reader io.Reader, mode ...filer.WriteMode) error
 }
 
-// buildArtifacts assembles the files to upload for a run: the merged config, the
-// inline command as a script, and hyperparameters. configPath is the local YAML
-// path.
+// buildArtifacts assembles the files to upload for a run: the final config, the
+// inline command as a script, and hyperparameters.
 //
 // Dependencies are not uploaded here; they ride inline on the serverless
 // environment's spec.dependencies (see buildSubmitPayload).
-func buildArtifacts(cfg *runConfig, configPath string) ([]uploadItem, error) {
-	// TODO(DABs): with no _bases_/overrides ported yet, the merged config is the
-	// file as-is; once those land, upload the re-serialized merged YAML instead.
-	configData, err := os.ReadFile(configPath)
+func buildArtifacts(cfg *runConfig) ([]uploadItem, error) {
+	configData, err := yaml.Marshal(cfg)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read config %s: %w", configPath, err)
+		return nil, fmt.Errorf("failed to serialize config: %w", err)
 	}
 	if len(configData) > maxConfigYAMLBytes {
 		return nil, fmt.Errorf("config YAML is %.2f MB, over the %d MB limit; reduce 'parameters' or 'command'",

--- a/experimental/air/cmd/runupload.go
+++ b/experimental/air/cmd/runupload.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"maps"
@@ -48,9 +49,9 @@ type fileWriter interface {
 // Dependencies are not uploaded here; they ride inline on the serverless
 // environment's spec.dependencies (see buildSubmitPayload).
 func buildArtifacts(cfg *runConfig) ([]uploadItem, error) {
-	configData, err := yaml.Marshal(cfg)
-	if err != nil {
-		return nil, fmt.Errorf("failed to serialize config: %w", err)
+	configData := cfg.artifactYAML
+	if len(configData) == 0 {
+		return nil, errors.New("serialized config YAML is unavailable")
 	}
 	if len(configData) > maxConfigYAMLBytes {
 		return nil, fmt.Errorf("config YAML is %.2f MB, over the %d MB limit; reduce 'parameters' or 'command'",

--- a/experimental/air/cmd/runupload_test.go
+++ b/experimental/air/cmd/runupload_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/databricks/cli/libs/filer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.yaml.in/yaml/v3"
 )
 
 // fakeWriter records artifact writes in place of a workspace filer.
@@ -70,16 +69,21 @@ func TestBuildArtifacts_CommandAndConfig(t *testing.T) {
 }
 
 func TestBuildArtifacts_ParametersButNoRequirements(t *testing.T) {
-	cfg := &runConfig{
-		ExperimentName: "test",
-		Compute:        &computeConfig{AcceleratorType: "GPU_1xH100", NumAccelerators: 1},
-		Command:        new("echo hi"),
-		Environment: &environmentConfig{
-			Dependencies: dependencies{set: true, list: []string{"torch", "numpy"}},
-			Version:      stringOrInt{set: true, raw: "5"},
-		},
-		Parameters: map[string]any{"lr": 0.1},
-	}
+	cfg, err := loadRunConfig(writeConfigFile(t, "run.yaml", `
+experiment_name: test
+compute:
+  num_accelerators: 1
+  accelerator_type: GPU_1xH100
+environment:
+  dependencies:
+    - torch
+    - numpy
+  version: 5
+command: echo hi
+parameters:
+  lr: 0.1
+`))
+	require.NoError(t, err)
 
 	// Inline deps are not uploaded, so the artifacts are config, command, and params.
 	items, err := buildArtifacts(cfg)
@@ -102,11 +106,18 @@ parameters:
 }
 
 func TestBuildArtifacts_EnvVarsAndSecrets(t *testing.T) {
-	cfg := &runConfig{
-		Command:      new("echo hi"),
-		EnvVariables: map[string]string{"WANDB": "demo"},
-		Secrets:      map[string]string{"HF_TOKEN": "myscope/hf"},
-	}
+	cfg, err := loadRunConfig(writeConfigFile(t, "run.yaml", `
+experiment_name: test
+compute:
+  accelerator_type: GPU_1xH100
+  num_accelerators: 1
+command: echo hi
+env_variables:
+  WANDB: demo
+secrets:
+  HF_TOKEN: myscope/hf
+`))
+	require.NoError(t, err)
 
 	items, err := buildArtifacts(cfg)
 	require.NoError(t, err)
@@ -120,8 +131,9 @@ func TestBuildArtifacts_EnvVarsAndSecrets(t *testing.T) {
 	assert.JSONEq(t, `[{"name":"HF_TOKEN","secret_scope":"myscope","secret_key":"hf"}]`, string(byName[secretEnvVarsName]))
 }
 
-func TestBuildArtifacts_FinalNormalizedConfigWithNestedOverrides(t *testing.T) {
+func TestBuildArtifacts_SourceOrderedConfigWithNestedOverrides(t *testing.T) {
 	path := writeConfigFile(t, "run.yaml", `
+# This comment is intentionally not retained.
 experiment_name: artifact-test
 command: python train.py
 compute:
@@ -132,6 +144,9 @@ parameters:
     hidden_size: 1024
   optimizer:
     name: adamw
+  empty_map: {}
+  empty_list: []
+  empty_value: null
 mlflow_artifact_location: /Volumes/main/default/artifacts
 `)
 	cfg, err := loadRunConfigWithOverrides(t.Context(), path, []string{
@@ -140,24 +155,33 @@ mlflow_artifact_location: /Volumes/main/default/artifacts
 		"parameters.optimizer.learning_rate=0.001",
 	})
 	require.NoError(t, err)
+	require.NotNil(t, cfg.MLflowArtifactLocation)
+	assert.Equal(t, "dbfs:/Volumes/main/default/artifacts", *cfg.MLflowArtifactLocation)
 
 	items, err := buildArtifacts(cfg)
 	require.NoError(t, err)
 
-	var uploaded map[string]any
-	require.NoError(t, yaml.Unmarshal(itemData(t, items, trainingConfigName), &uploaded))
-	assert.Equal(t, 4, uploaded["compute"].(map[string]any)["num_accelerators"])
-	parameters := uploaded["parameters"].(map[string]any)
-	assert.Equal(t, 2048, parameters["model"].(map[string]any)["hidden_size"])
-	assert.InDelta(t, 0.001, parameters["optimizer"].(map[string]any)["learning_rate"], 0)
-	assert.Equal(t, "adamw", parameters["optimizer"].(map[string]any)["name"])
-	assert.Equal(t, "dbfs:/Volumes/main/default/artifacts", uploaded["mlflow_artifact_location"])
+	assert.Equal(t, `experiment_name: artifact-test
+command: python train.py
+compute:
+    accelerator_type: GPU_1xH100
+    num_accelerators: 4
+parameters:
+    model:
+        hidden_size: 2048
+    optimizer:
+        name: adamw
+        learning_rate: 0.001
+    empty_map: {}
+    empty_list: []
+    empty_value: null
+mlflow_artifact_location: /Volumes/main/default/artifacts
+`, string(itemData(t, items, trainingConfigName)))
 }
 
 func TestBuildArtifacts_OversizeConfigRejected(t *testing.T) {
 	_, err := buildArtifacts(&runConfig{
-		Command:    new("x"),
-		Parameters: map[string]any{"value": strings.Repeat("a", maxConfigYAMLBytes+1)},
+		artifactYAML: []byte(strings.Repeat("a", maxConfigYAMLBytes+1)),
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "over the 1 MB limit")

--- a/experimental/air/cmd/runupload_test.go
+++ b/experimental/air/cmd/runupload_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/databricks/cli/libs/filer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.yaml.in/yaml/v3"
 )
 
 // fakeWriter records artifact writes in place of a workspace filer.
@@ -46,21 +47,33 @@ func itemNames(items []uploadItem) []string {
 	return names
 }
 
-func TestBuildArtifacts_CommandAndConfig(t *testing.T) {
-	path := writeConfigFile(t, "run.yaml", minimalConfig)
-	cfg := &runConfig{Command: new("python train.py")}
+func itemData(t *testing.T, items []uploadItem, name string) []byte {
+	t.Helper()
+	for _, item := range items {
+		if item.name == name {
+			return item.data
+		}
+	}
+	require.FailNow(t, "artifact not found", name)
+	return nil
+}
 
-	items, err := buildArtifacts(cfg, path)
+func TestBuildArtifacts_CommandAndConfig(t *testing.T) {
+	cfg, err := loadRunConfig(writeConfigFile(t, "run.yaml", minimalConfig))
+	require.NoError(t, err)
+
+	items, err := buildArtifacts(cfg)
 	require.NoError(t, err)
 	assert.Equal(t, []string{trainingConfigName, commandScriptName}, itemNames(items))
-	assert.Equal(t, minimalConfig, string(items[0].data))
+	assert.YAMLEq(t, minimalConfig, string(items[0].data))
 	assert.Equal(t, "python train.py", string(items[1].data))
 }
 
 func TestBuildArtifacts_ParametersButNoRequirements(t *testing.T) {
-	path := writeConfigFile(t, "run.yaml", "x: y\n")
 	cfg := &runConfig{
-		Command: new("echo hi"),
+		ExperimentName: "test",
+		Compute:        &computeConfig{AcceleratorType: "GPU_1xH100", NumAccelerators: 1},
+		Command:        new("echo hi"),
 		Environment: &environmentConfig{
 			Dependencies: dependencies{set: true, list: []string{"torch", "numpy"}},
 			Version:      stringOrInt{set: true, raw: "5"},
@@ -69,20 +82,33 @@ func TestBuildArtifacts_ParametersButNoRequirements(t *testing.T) {
 	}
 
 	// Inline deps are not uploaded, so the artifacts are config, command, and params.
-	items, err := buildArtifacts(cfg, path)
+	items, err := buildArtifacts(cfg)
 	require.NoError(t, err)
 	assert.Equal(t, []string{trainingConfigName, commandScriptName, hyperparametersName}, itemNames(items))
+	assert.YAMLEq(t, `
+experiment_name: test
+compute:
+  num_accelerators: 1
+  accelerator_type: GPU_1xH100
+environment:
+  dependencies:
+    - torch
+    - numpy
+  version: 5
+command: echo hi
+parameters:
+  lr: 0.1
+`, string(itemData(t, items, trainingConfigName)))
 }
 
 func TestBuildArtifacts_EnvVarsAndSecrets(t *testing.T) {
-	path := writeConfigFile(t, "run.yaml", "x: y\n")
 	cfg := &runConfig{
 		Command:      new("echo hi"),
 		EnvVariables: map[string]string{"WANDB": "demo"},
 		Secrets:      map[string]string{"HF_TOKEN": "myscope/hf"},
 	}
 
-	items, err := buildArtifacts(cfg, path)
+	items, err := buildArtifacts(cfg)
 	require.NoError(t, err)
 	assert.Subset(t, itemNames(items), []string{envVarsName, secretEnvVarsName})
 
@@ -94,9 +120,45 @@ func TestBuildArtifacts_EnvVarsAndSecrets(t *testing.T) {
 	assert.JSONEq(t, `[{"name":"HF_TOKEN","secret_scope":"myscope","secret_key":"hf"}]`, string(byName[secretEnvVarsName]))
 }
 
+func TestBuildArtifacts_FinalNormalizedConfigWithNestedOverrides(t *testing.T) {
+	path := writeConfigFile(t, "run.yaml", `
+experiment_name: artifact-test
+command: python train.py
+compute:
+  accelerator_type: GPU_1xH100
+  num_accelerators: 1
+parameters:
+  model:
+    hidden_size: 1024
+  optimizer:
+    name: adamw
+mlflow_artifact_location: /Volumes/main/default/artifacts
+`)
+	cfg, err := loadRunConfigWithOverrides(t.Context(), path, []string{
+		"compute.num_accelerators=4",
+		"parameters.model.hidden_size=2048",
+		"parameters.optimizer.learning_rate=0.001",
+	})
+	require.NoError(t, err)
+
+	items, err := buildArtifacts(cfg)
+	require.NoError(t, err)
+
+	var uploaded map[string]any
+	require.NoError(t, yaml.Unmarshal(itemData(t, items, trainingConfigName), &uploaded))
+	assert.Equal(t, 4, uploaded["compute"].(map[string]any)["num_accelerators"])
+	parameters := uploaded["parameters"].(map[string]any)
+	assert.Equal(t, 2048, parameters["model"].(map[string]any)["hidden_size"])
+	assert.InDelta(t, 0.001, parameters["optimizer"].(map[string]any)["learning_rate"], 0)
+	assert.Equal(t, "adamw", parameters["optimizer"].(map[string]any)["name"])
+	assert.Equal(t, "dbfs:/Volumes/main/default/artifacts", uploaded["mlflow_artifact_location"])
+}
+
 func TestBuildArtifacts_OversizeConfigRejected(t *testing.T) {
-	path := writeConfigFile(t, "run.yaml", strings.Repeat("a", maxConfigYAMLBytes+1))
-	_, err := buildArtifacts(&runConfig{Command: new("x")}, path)
+	_, err := buildArtifacts(&runConfig{
+		Command:    new("x"),
+		Parameters: map[string]any{"value": strings.Repeat("a", maxConfigYAMLBytes+1)},
+	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "over the 1 MB limit")
 }


### PR DESCRIPTION
## What did you change, and why?

- Previously, command-line overrides and validation normalization were applied to the typed run configuration, but `buildArtifacts` reread the original YAML when creating `training_config.yaml`. The submitted workload used the overridden configuration while the uploaded artifact and `air get` still showed the original values.
- Keep an ordered, source-derived YAML representation through config loading, apply nested command-line overrides to it, and upload that final representation as `training_config.yaml`. The separately decoded configuration remains responsible for validation, normalization, and API submission.
- Preserve source key ordering and explicit empty or null values in the artifact. Reserialization does not preserve original comments or spacing.
- Add focused unit and acceptance coverage for nested overrides and uploaded artifact contents.

## How do you know it works?

- `go test ./experimental/air/cmd`
- `go test ./acceptance -run TestAccept/experimental/air/run-submit-overrides$ -tail -test.v`
- `./task fmt-q`
- `./task lint-q`
- `./task checks`
- `./task test`
- Manually verified against a real workspace that `air get` displays the overridden nested value.