### PR TITLE
Update tagging with upstream changes

### DIFF
--- a/.github/workflows/tagging.yml
+++ b/.github/workflows/tagging.yml
@@ -36,13 +36,13 @@ jobs:
       github.repository == 'databricks/databricks-sdk-java'
     env:
       # Ref the release is cut from. Releasing from a branch is currently
-      # supported in the terraform repository only: for
-      # terraform-provider-databricks this follows the dispatched branch
+      # supported in the terraform-provider-databricks and cli repositories:
+      # for those two this follows the dispatched branch
       # (``github.ref_name``), so a release can be cut from a branch other
       # than main; every other synced repo (SDK go/py/java, …) stays pinned
       # to main, preserving the pre-existing hardcoded-main behaviour and
       # blocking branch releases even via a manual non-main dispatch.
-      RELEASE_REF: ${{ github.repository == 'databricks/terraform-provider-databricks' && github.ref_name || 'main' }}
+      RELEASE_REF: ${{ (github.repository == 'databricks/terraform-provider-databricks' || github.repository == 'databricks/cli') && github.ref_name || 'main' }}
       # Changelog source. databricks/cli builds the release changelog from
       # per-PR ``.nextchanges/<section>/*.md`` fragments and a
       # ``.nextchanges/version`` file rather than a single hand-maintained
@@ -66,10 +66,10 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # Check out the release ref. ``RELEASE_REF`` is the dispatched
-          # branch for terraform-provider-databricks and ``main`` for every
+          # branch for terraform-provider-databricks and cli, and ``main`` for every
           # other repo (see the job-level ``env``). For scheduled runs and
           # manual dispatches left at defaults this is the default branch
-          # (main); dispatching terraform with ``--ref <branch>`` cuts the
+          # (main); dispatching terraform or cli with ``--ref <branch>`` cuts the
           # release from that branch instead.
           #
           # Naming the ref explicitly (rather than omitting ``ref:``)
@@ -99,7 +99,7 @@ jobs:
           # changelog bump and creates the tag on this branch, and its
           # concurrent-advance guard checks this branch. Matches the ref
           # checked out above (``RELEASE_REF``): the dispatched branch for
-          # terraform, main everywhere else.
+          # terraform and cli, main everywhere else.
           DECO_TAGGING_REF: ${{ env.RELEASE_REF }}
           # Non-empty only for databricks/cli (see job-level env). When set,
           # internal/genkit/tagging.py renders the changelog from ``$NEXTCHANGES_DIR/`` fragments

--- a/internal/genkit/tagging.py
+++ b/internal/genkit/tagging.py
@@ -650,9 +650,13 @@ def get_next_tag_info_from_nextchanges(package: Package) -> Optional[TagInfo]:
     ``.codegen.json`` — matching the ``NEXT_CHANGELOG.md`` skip behavior.
     """
     body = render_nextchanges(package.path)
-    if body is None and not _load_codegen_config(package.path).get("allow_empty_changelog", False):
-        print(f"No {_nextchanges_dir()}/ entries. No changes will be made to the changelog.")
-        return None
+    if body is None:
+        if not _load_codegen_config(package.path).get("allow_empty_changelog", False):
+            print(f"No {_nextchanges_dir()}/ entries. No changes will be made to the changelog.")
+            return None
+        if not _source_changed_since_last_release(package):
+            print(f"No {_nextchanges_dir()}/ entries and no source changes since the last release; skipping.")
+            return None
 
     version = read_nextchanges_version(package)
     # write_changelog() keys off the "## Release v…" header, so include it.
@@ -710,12 +714,15 @@ def get_next_tag_info(package: Package) -> Optional[TagInfo]:
     # By default, packages whose NEXT_CHANGELOG.md has no populated
     # sections are skipped — there's nothing meaningful to release.
     # Repos like sdk-js which are still in development can opt in
-    # by setting ``allow_empty_changelog: true`` in .codegen.json.
-    if not re.search(r"###", next_changelog) and not _load_codegen_config(package.path).get(
-        "allow_empty_changelog", False
-    ):
-        print("All sections are empty. No changes will be made to the changelog.")
-        return None
+    # by setting ``allow_empty_changelog: true`` in .codegen.json — but
+    # even then, only when the package's source actually changed.
+    if not re.search(r"###", next_changelog):
+        if not _load_codegen_config(package.path).get("allow_empty_changelog", False):
+            print("All sections are empty. No changes will be made to the changelog.")
+            return None
+        if not _source_changed_since_last_release(package):
+            print("All sections are empty and no source changes since the last release; skipping.")
+            return None
 
     version_match = re.search(rf"## Release v({Version.PATTERN})", next_changelog)
 
@@ -832,9 +839,10 @@ def find_last_release_tag(package: Package) -> Optional[str]:
 def has_commits_since_tag(tag: str, path: str) -> bool:
     """
     Returns True iff at least one commit reachable from HEAD but not from
-    ``tag`` touches ``path``. Used to detect that a sibling dependency has
-    unreleased changes that would ship stale if we tagged a dependent
-    without re-tagging the dependency.
+    ``tag`` touches ``path``. Detects both that a sibling dependency has
+    unreleased changes that would ship stale (freshness) and, via
+    ``_source_changed_since_last_release``, whether a package has anything to
+    release under allow_empty_changelog.
 
     :raises Exception: If the git command fails.
     """
@@ -844,6 +852,25 @@ def has_commits_since_tag(tag: str, path: str) -> bool:
     except subprocess.CalledProcessError as e:
         raise Exception(f"Git command failed: {e.stderr.strip() or e}") from e
     return bool(output)
+
+
+def _source_changed_since_last_release(package: Package) -> bool:
+    """
+    True when the package has any commits since its last release tag. A
+    never-released package (no tag) counts as changed. Gates the
+    ``allow_empty_changelog`` path so a package with no changelog entries
+    releases only when something actually changed since it was last released.
+
+    Uses the same commit-based check as ``check_dependency_freshness`` — a
+    package's release bookkeeping is committed *at* its release tag, not after
+    it, so it never falls in the ``tag..HEAD`` window. Sharing the check keeps
+    the two consistent: a package this skips is exactly one freshness will not
+    flag as stale.
+    """
+    tag = find_last_release_tag(package)
+    if tag is None:
+        return True
+    return has_commits_since_tag(tag, package.path)
 
 
 def check_dependency_freshness(tag_infos: List[TagInfo], all_packages: List[Package]) -> None:


### PR DESCRIPTION
`task generate-clijson` to pull upstream changes for tagging
- cutting releases from non-main
- skip releases if there's no source changes
