### PR TITLE
Re-run changelog guard on label change

### DIFF
--- a/.github/workflows/changelog-guard.yml
+++ b/.github/workflows/changelog-guard.yml
@@ -2,6 +2,7 @@ name: Changelog Guard
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
     paths:
       - CHANGELOG.md
 


### PR DESCRIPTION
## Changes
Add `types:` to the changelog guard workflow

## Why
So when a CHANGELOG.md edit is intentional (like in #6615) you don't need an empty commit push to re-trigger after adding the label to the PR (the guard's recommendation).
