### PR TITLE
testarchive: expect bundled arm64 tool binaries in TestArchive

### DIFF
--- a/integration/testarchive/archive_test.go
+++ b/integration/testarchive/archive_test.go
@@ -36,11 +36,11 @@ func TestArchive(t *testing.T) {
 	assert.FileExists(t, filepath.Join(assertDir, "bin", "amd64", "uv"))
 	assert.FileExists(t, filepath.Join(assertDir, "bin", "amd64", "jq"))
 
-	// TODO: Serverless clusters do not support arm64 yet.
-	// Assert these files exist after we support arm64.
-	assert.NoFileExists(t, filepath.Join(assertDir, "bin", "arm64", "go", "bin", "go"))
-	assert.NoFileExists(t, filepath.Join(assertDir, "bin", "arm64", "uv"))
-	assert.NoFileExists(t, filepath.Join(assertDir, "bin", "arm64", "jq"))
+	// arm64 tool binaries are bundled alongside amd64 because the serverless
+	// driver's CPU architecture is chosen at runtime (see CreateArchive).
+	assert.FileExists(t, filepath.Join(assertDir, "bin", "arm64", "go", "bin", "go"))
+	assert.FileExists(t, filepath.Join(assertDir, "bin", "arm64", "uv"))
+	assert.FileExists(t, filepath.Join(assertDir, "bin", "arm64", "jq"))
 
 	assert.FileExists(t, filepath.Join(assertDir, "cli", "go.mod"))
 	assert.FileExists(t, filepath.Join(assertDir, "cli", "go.sum"))


### PR DESCRIPTION
## Changes

`TestArchive` asserted that the arm64 tool binaries (`bin/arm64/{go,uv,jq}`) were absent from the archive. #6601 re-enabled the arm64 downloaders in `CreateArchive`, so those files are now present and the three `assert.NoFileExists` checks fail. Flip them to `assert.FileExists` and update the now-stale comment.

## Why

The archive is expected to carry both architectures: `acceptance/dbr_runner.py` picks the arch at runtime from the serverless driver's `platform.machine()`, and the driver may be Graviton/arm64. The test was left asserting the old amd64-only layout, so it failed deterministically in every cloud environment after #6601.

## Tests

`TestArchive` is a cloud test (`CLOUD_ENV`-gated) that builds the real archive. Confirmed against nightly run 34545033694, where the failure was exactly the three `bin/arm64/...` `NoFileExists` assertions on lines 41-43. `go vet` and `golangci-lint` pass locally.

_This PR was written by Isaac._