### PR TITLE
acceptance: cover ssh tunnel transfers larger than the resume window

### DIFF
--- a/acceptance/ssh/bulk-transfer/out.test.toml
+++ b/acceptance/ssh/bulk-transfer/out.test.toml
@@ -1,0 +1,5 @@
+Cloud = true
+GOOS.darwin = false
+GOOS.linux = true
+GOOS.windows = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/ssh/bulk-transfer/output.txt
+++ b/acceptance/ssh/bulk-transfer/output.txt
@@ -1,0 +1,6 @@
+
+=== Download 8388608 bytes over the tunnel
+received 8388608 of 8388608 bytes
+
+=== Upload 8388608 bytes over the tunnel
+delivered 8388608 of 8388608 bytes

--- a/acceptance/ssh/bulk-transfer/script
+++ b/acceptance/ssh/bulk-transfer/script
@@ -1,0 +1,51 @@
+# A tunnel session must survive a payload larger than the proxy's internal buffers, in both
+# directions. `ssh connect --ide` pushes several megabytes while the remote IDE server starts,
+# so a ceiling here breaks the IDE outright: #6558 capped the unacknowledged replay window at
+# 1 MiB and read a full window as a peer that had stopped acknowledging, which ended every
+# session that moved more than that. That shipped in v1.16.0 and was reverted in #6608; this test
+# is here so a re-introduction is caught before users are.
+#
+# The byte counts below are the assertion, not the exit code: the regression ended the session
+# with truncated output and, depending on which side noticed the drop first, exit code 0.
+#
+# 8 MiB is the size that matters: the remote IDE server pushes about 7 MiB while it starts, and
+# it is eight times the window that broke. Keep the payload under 10,000,000 bytes - the root
+# test.toml rewrites any run of 8 or more digits to [NUMID], which would erase the counts.
+PAYLOAD_BYTES=8388608
+
+# Generated rather than committed: 8 MiB does not belong in the repo, and the exact bytes do not
+# matter. SSH MACs the byte stream (RFC 4253 section 6), so anything lost, duplicated or
+# reordered ends the session, which shows up here as a short count. The same command runs
+# remotely for the download and locally for the upload, so both directions move the same bytes.
+payload_cmd="yes 0123456789abcdefghijklmnopqrstuvwxyz | head -c $PAYLOAD_BYTES"
+
+if [ -n "${CLOUD_ENV:-}" ]; then
+  # Serverless CPU: nothing to provision, so this is the cheapest real tunnel to open.
+  CONNECT_FLAGS="--releases-dir=$CLI_RELEASES_DIR"
+else
+  # No compute locally: the test server backs the driver-proxy /ssh websocket with a real sshd,
+  # so the transfer crosses a real ssh session over a ws:// tunnel. Needs sshd (only task
+  # test-exp-ssh provisions it); the test server probes the same way, so skip where it's absent.
+  if [ -z "$(command -v sshd || ls /usr/sbin/sshd /usr/local/sbin/sshd /sbin/sshd 2>/dev/null)" ]; then
+    echo "SKIP_TEST sshd (openssh-server) not installed"
+    exit 0
+  fi
+
+  # No release artifacts locally and they're never executed; stand in empty archives.
+  mkdir -p releases
+  : >releases/databricks_cli_linux_amd64.zip
+  : >releases/databricks_cli_linux_arm64.zip
+  CONNECT_FLAGS="--releases-dir=$PWD/releases --known-hosts-dir=known-hosts"
+fi
+
+title "Download $PAYLOAD_BYTES bytes over the tunnel\n"
+errcode $CLI ssh connect $CONNECT_FLAGS -- "$payload_cmd" >received.bin 2>LOG.download
+echo "received $(wc -c <received.bin | tr -d ' ') of $PAYLOAD_BYTES bytes"
+
+title "Upload $PAYLOAD_BYTES bytes over the tunnel\n"
+sh -c "$payload_cmd" >sent.bin
+errcode $CLI ssh connect $CONNECT_FLAGS -- "wc -c" <sent.bin >remote-count.txt 2>LOG.upload
+# The remote count is empty when the session ended before `wc` could report; say 0 rather than
+# leaving a blank in the output.
+remote_count=$(tr -dc 0-9 <remote-count.txt)
+echo "delivered ${remote_count:-0} of $PAYLOAD_BYTES bytes"

--- a/acceptance/ssh/bulk-transfer/test.toml
+++ b/acceptance/ssh/bulk-transfer/test.toml
@@ -1,0 +1,18 @@
+Cloud = true
+
+# Staged release archives, the pinned host key, and the payload files: none are golden output.
+Ignore = [
+  "releases",
+  "known-hosts",
+  "received.bin",
+  "sent.bin",
+  "remote-count.txt",
+]
+
+# The local run drives a real sshd, reliable only on Linux. Absent GOOS keys default to enabled,
+# so the other OSes must be disabled explicitly.
+GOOS.linux = true
+GOOS.darwin = false
+GOOS.windows = false
+
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]


### PR DESCRIPTION
## Why

#6558 capped the tunnel's unacknowledged replay window at 1 MiB and read a full window as a peer that had stopped acknowledging, so ordinary in-flight data ended the session:

```
Proxy server error: proxy websocket dropped
failed to send message: resume send buffer is full: the peer stopped acknowledging:
1045563 unacknowledged bytes, limit 1048576
```

It shipped in v1.16.0, broke `ssh connect --ide` outright (the remote IDE server pushes several megabytes as it starts), and was reverted in #6608. **No test noticed, in pre- or post-merge CI** — this PR is that missing coverage, so a re-introduction is caught before users are.

## What it does

`acceptance/ssh/bulk-transfer` moves 8 MiB in each direction over a real `ssh connect` session and asserts the byte counts. Measured against a real workspace, on the tree as it was before the revert and after:

| | result |
|---|---|
| local (test server's sshd over `ws://`) | pass, 3.4s |
| cloud, serverless CPU, with #6558 present | **fail** — `received 1032192 of 4194304`, `delivered 0 of 4194304` |
| cloud, serverless CPU, with #6558 out of the path | pass, 23s cold start |
| cloud, on this PR's own CI run | pass, 72s (cold serverless start plus the one-time binary upload) |

Some details worth flagging for review:

- **8 MiB, and it must stay under 10,000,000.** The root `test.toml` rewrites any run of 8+ digits to `[NUMID]`, which would silently erase the counts and leave the test asserting nothing. 8 MiB is also the size that matters — roughly what the IDE server pushes at startup.
- **The byte counts are the assertion, not the exit code.** The regression could end the session with truncated output *and* exit code 0, so an exit-code check would have passed on it.
- **First ssh test to run on cloud since #4838** disabled the old cloud-only ones as too flaky. Serverless CPU has no cluster to provision and no accelerator to wait for, which is what makes this one dependable.
- **Deliberately not `CloudSlow`.** PR cloud runs pass `-short` (`task cloud-select`), so `CloudSlow` would keep this off every PR — including one that changes the test itself — and leave it only to the full suite on main. At ~70s in CI - a cold serverless start plus the one-time upload of the two release archives, not the transfer - it does not belong with the multi-minute infra tests that carry that flag.
- **Locally the test server never negotiates the resume protocol**, so the local run covers the plumbing over a real ssh session (real sshd, real handshake, 16 MiB through the websocket) and the cloud run is what would catch the window coming back.

## Tests

- `go test ./acceptance -run TestAccept/ssh` — pass
- `go test ./experimental/ssh/...` — pass
- cloud runs on serverless CPU in both configurations (table above)
- this PR's own `Integration Tests` check ran it and nothing else: the cloud leg's selection resolves to `^ssh$/^bulk-transfer$`, and its log shows `PASS acceptance.TestAccept/ssh/bulk-transfer (72.08s)` against a real serverless tunnel

This pull request and its description were written by Isaac.
