### PR TITLE
testrunner: allow wildcard path in known_failures

### DIFF
--- a/tools/testrunner/main.go
+++ b/tools/testrunner/main.go
@@ -247,13 +247,18 @@ func hasFailedSubtest(failed map[string]bool, key string) bool {
 // Where:
 // - Lines with whitespace only are ignored
 // - Everything after '#' is a comment and is ignored
-// - Both package and testcase can be '*' meaning any package or any testcase
-// - Both can end with '/' which means it's a prefix match
+// - Both package and testcase are matched segment by segment, split on '/'
+// - A '*' segment matches any number of segments (including zero), so a whole
+//   field of '*' matches anything and an interior '*' spans the segments
+//   between two fixed ones
+// - A trailing '/' makes the pattern a prefix: it matches the listed segments
+//   plus any number of segments below them
 //
 // Examples:
-//   "libs/ *"           - all packages starting with "libs/" and all testcases are allowed to fail
-//   "* TestAccept/"     - all testcases starting with "TestAccept/" are allowed to fail
-//   "bundle TestDeploy" - exact match for package "bundle" and testcase "TestDeploy"
+//   "libs/ *"                  - all packages under "libs/" and all testcases are allowed to fail
+//   "* TestAccept/"            - all testcases under "TestAccept/" are allowed to fail
+//   "bundle TestDeploy"        - exact match for package "bundle" and testcase "TestDeploy"
+//   "* TestAccept/*/DMS=true/" - every testcase with a "DMS=true" segment, at any depth
 //
 // Parse errors for individual lines are logged but do not abort processing.
 
@@ -271,10 +276,8 @@ func (c *Config) matches(packageName, testName string) string {
 }
 
 type ConfigRule struct {
-	PackagePattern string
-	TestPattern    string
-	PackagePrefix  bool
-	TestPrefix     bool
+	PackagePattern []string
+	TestPattern    []string
 	OriginalLine   string
 }
 
@@ -313,12 +316,16 @@ func parseConfig(content string) (*Config, error) {
 	return config, scanner.Err()
 }
 
-// parsePattern returns the pattern and whether it's a prefix match.
-func parsePattern(pattern string) (string, bool) {
-	if pattern == "*" {
-		return "", true
+// parsePattern splits a pattern field into segments. A trailing "/" marks a
+// prefix match, represented as a trailing "*" segment so it matches any number
+// of segments below the listed ones.
+func parsePattern(pattern string) []string {
+	prefix := strings.HasSuffix(pattern, "/")
+	segments := strings.Split(strings.TrimSuffix(pattern, "/"), "/")
+	if prefix {
+		segments = append(segments, "*")
 	}
-	return strings.CutSuffix(pattern, "/")
+	return segments
 }
 
 func parseConfigRule(line, originalLine string) (ConfigRule, error) {
@@ -327,50 +334,44 @@ func parseConfigRule(line, originalLine string) (ConfigRule, error) {
 		return ConfigRule{}, fmt.Errorf("expected 2 fields, got %d", len(parts))
 	}
 
-	packagePattern := parts[0]
-	testPattern := parts[1]
-
-	rule := ConfigRule{
-		PackagePattern: packagePattern,
-		TestPattern:    testPattern,
+	return ConfigRule{
+		PackagePattern: parsePattern(parts[0]),
+		TestPattern:    parsePattern(parts[1]),
 		OriginalLine:   strings.TrimSpace(originalLine),
-	}
-
-	// Check for wildcard or prefix
-	rule.PackagePattern, rule.PackagePrefix = parsePattern(packagePattern)
-	rule.TestPattern, rule.TestPrefix = parsePattern(testPattern)
-
-	return rule, nil
+	}, nil
 }
 
 func (r ConfigRule) matches(packageName, testName string) bool {
-	// Check package pattern
-	var packageMatch bool
-	if r.PackagePrefix {
-		packageMatch = matchesPathPrefix(packageName, r.PackagePattern)
-	} else {
-		packageMatch = packageName == r.PackagePattern
-	}
-
-	if !packageMatch {
-		return false
-	}
-
-	// Check test pattern
-	if r.TestPrefix {
-		return matchesPathPrefix(testName, r.TestPattern)
-	}
-	return testName == r.TestPattern
+	return matchSegments(r.PackagePattern, strings.Split(packageName, "/")) &&
+		matchSegments(r.TestPattern, strings.Split(testName, "/"))
 }
 
-// matchesPathPrefix returns true if s matches pattern or starts with pattern + "/"
-// If pattern is empty (wildcard "*"), it matches any string
-func matchesPathPrefix(s, prefix string) bool {
-	if prefix == "" {
-		return true
+// matchSegments reports whether name matches pattern segment by segment, where
+// a "*" pattern segment matches any number of name segments (including zero).
+// It is the standard linear wildcard match that backtracks on the latest "*".
+func matchSegments(pattern, name []string) bool {
+	pi, ni := 0, 0
+	star, match := -1, 0
+	for ni < len(name) {
+		switch {
+		case pi < len(pattern) && pattern[pi] == "*":
+			star = pi
+			match = ni
+			pi++
+		case pi < len(pattern) && pattern[pi] == name[ni]:
+			pi++
+			ni++
+		case star >= 0:
+			// Backtrack: let the last "*" consume one more name segment.
+			pi = star + 1
+			match++
+			ni = match
+		default:
+			return false
+		}
 	}
-	if s == prefix {
-		return true
+	for pi < len(pattern) && pattern[pi] == "*" {
+		pi++
 	}
-	return strings.HasPrefix(s, prefix+"/")
+	return pi == len(pattern)
 }

--- a/tools/testrunner/main.go
+++ b/tools/testrunner/main.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"slices"
 	"strings"
 	"sync/atomic"
 	"syscall"
@@ -326,10 +327,8 @@ func parseConfig(content string) (*Config, error) {
 func parsePattern(pattern string) ([]string, error) {
 	prefix := strings.HasSuffix(pattern, "/")
 	segments := strings.Split(strings.TrimSuffix(pattern, "/"), "/")
-	for _, s := range segments {
-		if s == "" {
-			return nil, fmt.Errorf("empty segment in pattern %q", pattern)
-		}
+	if slices.Contains(segments, "") {
+		return nil, fmt.Errorf("empty segment in pattern %q", pattern)
 	}
 	if prefix {
 		segments = append(segments, "*")

--- a/tools/testrunner/main.go
+++ b/tools/testrunner/main.go
@@ -320,14 +320,21 @@ func parseConfig(content string) (*Config, error) {
 
 // parsePattern splits a pattern field into segments. A trailing "/" marks a
 // prefix match, represented as a trailing "*" segment so it matches any number
-// of segments below the listed ones.
-func parsePattern(pattern string) []string {
+// of segments below the listed ones. An empty segment (from "//" or a bare "/")
+// can never match a real path segment, so it is rejected rather than silently
+// producing a rule that matches nothing.
+func parsePattern(pattern string) ([]string, error) {
 	prefix := strings.HasSuffix(pattern, "/")
 	segments := strings.Split(strings.TrimSuffix(pattern, "/"), "/")
+	for _, s := range segments {
+		if s == "" {
+			return nil, fmt.Errorf("empty segment in pattern %q", pattern)
+		}
+	}
 	if prefix {
 		segments = append(segments, "*")
 	}
-	return segments
+	return segments, nil
 }
 
 func parseConfigRule(line, originalLine string) (ConfigRule, error) {
@@ -336,9 +343,18 @@ func parseConfigRule(line, originalLine string) (ConfigRule, error) {
 		return ConfigRule{}, fmt.Errorf("expected 2 fields, got %d", len(parts))
 	}
 
+	packagePattern, err := parsePattern(parts[0])
+	if err != nil {
+		return ConfigRule{}, err
+	}
+	testPattern, err := parsePattern(parts[1])
+	if err != nil {
+		return ConfigRule{}, err
+	}
+
 	return ConfigRule{
-		PackagePattern: parsePattern(parts[0]),
-		TestPattern:    parsePattern(parts[1]),
+		PackagePattern: packagePattern,
+		TestPattern:    testPattern,
 		OriginalLine:   strings.TrimSpace(originalLine),
 	}, nil
 }

--- a/tools/testrunner/main.go
+++ b/tools/testrunner/main.go
@@ -267,8 +267,10 @@ type Config struct {
 }
 
 func (c *Config) matches(packageName, testName string) string {
+	pkg := strings.Split(packageName, "/")
+	test := strings.Split(testName, "/")
 	for _, rule := range c.rules {
-		if rule.matches(packageName, testName) {
+		if rule.matches(pkg, test) {
 			return rule.OriginalLine
 		}
 	}
@@ -341,9 +343,9 @@ func parseConfigRule(line, originalLine string) (ConfigRule, error) {
 	}, nil
 }
 
-func (r ConfigRule) matches(packageName, testName string) bool {
-	return matchSegments(r.PackagePattern, strings.Split(packageName, "/")) &&
-		matchSegments(r.TestPattern, strings.Split(testName, "/"))
+func (r ConfigRule) matches(packageName, testName []string) bool {
+	return matchSegments(r.PackagePattern, packageName) &&
+		matchSegments(r.TestPattern, testName)
 }
 
 // matchSegments reports whether name matches pattern segment by segment, where

--- a/tools/testrunner/main_test.go
+++ b/tools/testrunner/main_test.go
@@ -85,7 +85,7 @@ func TestConfigRuleMatches(t *testing.T) {
 		t.Run(tt.input+"_"+tt.packageName+"_"+tt.testcase, func(t *testing.T) {
 			rule, err := parseConfigRule(tt.input, tt.input)
 			require.NoError(t, err)
-			result := rule.matches(tt.packageName, tt.testcase)
+			result := rule.matches(strings.Split(tt.packageName, "/"), strings.Split(tt.testcase, "/"))
 			assert.Equal(t, tt.match, result)
 		})
 	}

--- a/tools/testrunner/main_test.go
+++ b/tools/testrunner/main_test.go
@@ -91,6 +91,21 @@ func TestConfigRuleMatches(t *testing.T) {
 	}
 }
 
+func TestParseConfigRuleErrors(t *testing.T) {
+	for _, input := range []string{
+		"bundle",
+		"a b c",
+		"bundle// TestDeploy",
+		"bundle /",
+		"* TestAccept//Deploy",
+	} {
+		t.Run(input, func(t *testing.T) {
+			_, err := parseConfigRule(input, input)
+			assert.Error(t, err)
+		})
+	}
+}
+
 func TestCheckFailures(t *testing.T) {
 	const config = "* TestAccept/ssh/connection\n"
 

--- a/tools/testrunner/main_test.go
+++ b/tools/testrunner/main_test.go
@@ -60,6 +60,25 @@ func TestConfigRuleMatches(t *testing.T) {
 		{"acceptance TestAccept/bundle/templates/default-python/combinations/classic/", "acceptance", "TestAccept/bundle/templates/default-python/combinations/classic/x", true},
 		{"acceptance TestAccept/bundle/templates/default-python/combinations/classic/", "acceptance", "TestAccept/bundle/templates/default-python/combinations/classic", true},
 		{"acceptance TestAccept/bundle/templates/default-python/combinations/classic/", "acceptance", "TestAccept/bundle/templates/default-python/combinations", false},
+
+		// Interior "*" spans any number of path segments. This is the DMS=true
+		// use case: match every permutation that carries a DMS=true segment,
+		// regardless of the test name or engine segments preceding it.
+		{"acceptance TestAccept/*/DMS=true/", "acceptance", "TestAccept/bundle/invariant/no_drift/DATABRICKS_BUNDLE_ENGINE=direct/DMS=true/INPUT_CONFIG=job.yml.tmpl", true},
+		{"acceptance TestAccept/*/DMS=true/", "acceptance", "TestAccept/bundle/invariant/migrate/DATABRICKS_BUNDLE_ENGINE=terraform/DMS=true", true},
+		{"acceptance TestAccept/*/DMS=true/", "acceptance", "TestAccept/bundle/invariant/no_drift/DATABRICKS_BUNDLE_ENGINE=direct/DMS=/INPUT_CONFIG=job.yml.tmpl", false},
+		{"acceptance TestAccept/*/DMS=true/", "acceptance", "TestAccept", false},
+
+		// Interior "*" matching zero segments.
+		{"* TestAccept/*/leaf", "any", "TestAccept/leaf", true},
+		{"* a/*/b", "any", "a/b", true},
+		{"* a/*/b", "any", "a/x/y/b", true},
+		{"* a/*/b", "any", "a/x/b/c", false},
+
+		// Multiple interior wildcards.
+		{"* a/*/b/*/c", "any", "a/1/b/2/c", true},
+		{"* a/*/b/*/c", "any", "a/1/2/b/3/4/c", true},
+		{"* a/*/b/*/c", "any", "a/b/c", true},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Changes
Allow wildcard matching for known failures from ciconfig

This way, you can specify
```
acceptance TestAccept/*/DMS=true/
```
and it will wildcard match all `DMS=true` test permutations

Other updates:
- split once per lookup
- reject empty-segment patterns

## Why

DMS is failing everywhere, making CI red

## Tests
Follow-up: set pattern on ciconfig and verify. Docs already added https://github.com/databricks/cli/commit/79e9c75da4e573ccf081ed6e246b76d37e85fb21

Tested this locally with a pulled gh log