### PR TITLE
test: reproduce config-sync dropping remote cluster additions

### DIFF
--- a/acceptance/bundle/config-remote-sync/cluster_policy_remote_addition/databricks.yml.tmpl
+++ b/acceptance/bundle/config-remote-sync/cluster_policy_remote_addition/databricks.yml.tmpl
@@ -1,0 +1,66 @@
+bundle:
+  name: test-bundle-$UNIQUE_NAME
+
+workspace:
+  root_path: ~/.bundle/$UNIQUE_NAME
+
+resources:
+  cluster_policies:
+    policy:
+      name: test-policy-$UNIQUE_NAME
+      definition:
+        # This rule controls only PolicyTag, not the Spark setting edited below.
+        custom_tags.PolicyTag:
+          type: fixed
+          value: from-policy
+  jobs:
+    test_job:
+      name: test-job-$UNIQUE_NAME
+      max_concurrent_runs: 1
+      job_clusters:
+        - job_cluster_key: shared
+          new_cluster:
+            policy_id: ${resources.cluster_policies.policy.id}
+            spark_version: $DEFAULT_SPARK_VERSION
+            node_type_id: $NODE_TYPE_ID
+            num_workers: 1
+            custom_tags:
+              PolicyTag: from-policy
+        - job_cluster_key: ungated
+          new_cluster:
+            spark_version: $DEFAULT_SPARK_VERSION
+            node_type_id: $NODE_TYPE_ID
+            num_workers: 1
+      tasks:
+        - task_key: shared_task
+          job_cluster_key: shared
+          spark_python_task:
+            python_file: ./hello.py
+        - task_key: ungated_task
+          job_cluster_key: ungated
+          spark_python_task:
+            python_file: ./hello.py
+        - task_key: own_cluster
+          new_cluster:
+            policy_id: ${resources.cluster_policies.policy.id}
+            spark_version: $DEFAULT_SPARK_VERSION
+            node_type_id: $NODE_TYPE_ID
+            num_workers: 1
+            custom_tags:
+              PolicyTag: from-policy
+          spark_python_task:
+            python_file: ./hello.py
+        - task_key: loop
+          for_each_task:
+            inputs: "[1]"
+            task:
+              task_key: nested_cluster
+              new_cluster:
+                policy_id: ${resources.cluster_policies.policy.id}
+                spark_version: $DEFAULT_SPARK_VERSION
+                node_type_id: $NODE_TYPE_ID
+                num_workers: 1
+                custom_tags:
+                  PolicyTag: from-policy
+              spark_python_task:
+                python_file: ./hello.py

--- a/acceptance/bundle/config-remote-sync/cluster_policy_remote_addition/databricks.yml.tmpl
+++ b/acceptance/bundle/config-remote-sync/cluster_policy_remote_addition/databricks.yml.tmpl
@@ -9,38 +9,15 @@ resources:
     policy:
       name: test-policy-$UNIQUE_NAME
       definition:
-        # This rule controls only PolicyTag, not the Spark setting edited below.
+        # The policy does not constrain spark_conf.
         custom_tags.PolicyTag:
           type: fixed
           value: from-policy
   jobs:
     test_job:
       name: test-job-$UNIQUE_NAME
-      max_concurrent_runs: 1
-      job_clusters:
-        - job_cluster_key: shared
-          new_cluster:
-            policy_id: ${resources.cluster_policies.policy.id}
-            spark_version: $DEFAULT_SPARK_VERSION
-            node_type_id: $NODE_TYPE_ID
-            num_workers: 1
-            custom_tags:
-              PolicyTag: from-policy
-        - job_cluster_key: ungated
-          new_cluster:
-            spark_version: $DEFAULT_SPARK_VERSION
-            node_type_id: $NODE_TYPE_ID
-            num_workers: 1
       tasks:
-        - task_key: shared_task
-          job_cluster_key: shared
-          spark_python_task:
-            python_file: ./hello.py
-        - task_key: ungated_task
-          job_cluster_key: ungated
-          spark_python_task:
-            python_file: ./hello.py
-        - task_key: own_cluster
+        - task_key: test
           new_cluster:
             policy_id: ${resources.cluster_policies.policy.id}
             spark_version: $DEFAULT_SPARK_VERSION
@@ -50,17 +27,3 @@ resources:
               PolicyTag: from-policy
           spark_python_task:
             python_file: ./hello.py
-        - task_key: loop
-          for_each_task:
-            inputs: "[1]"
-            task:
-              task_key: nested_cluster
-              new_cluster:
-                policy_id: ${resources.cluster_policies.policy.id}
-                spark_version: $DEFAULT_SPARK_VERSION
-                node_type_id: $NODE_TYPE_ID
-                num_workers: 1
-                custom_tags:
-                  PolicyTag: from-policy
-              spark_python_task:
-                python_file: ./hello.py

--- a/acceptance/bundle/config-remote-sync/cluster_policy_remote_addition/hello.py
+++ b/acceptance/bundle/config-remote-sync/cluster_policy_remote_addition/hello.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python3
+
+print("hello")

--- a/acceptance/bundle/config-remote-sync/cluster_policy_remote_addition/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/cluster_policy_remote_addition/out.test.toml
@@ -1,0 +1,4 @@
+Cloud = true
+GOOS.windows = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]
+EnvMatrix.DMS = ["", "true"]

--- a/acceptance/bundle/config-remote-sync/cluster_policy_remote_addition/output.txt
+++ b/acceptance/bundle/config-remote-sync/cluster_policy_remote_addition/output.txt
@@ -1,0 +1,49 @@
+
+>>> [CLI] bundle deploy
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/[UNIQUE_NAME]/files...
+Created cluster_policies.policy
+Created jobs.test_job
+Files: 6 uploaded, 0 deleted
+Resources: 2 created, 0 changed, 0 deleted, 0 unchanged
+
+>>> [CLI] bundle config-remote-sync
+No changes detected.
+
+
+=== Sync remote user edits unrelated to the attached policy
+
+>>> [CLI] bundle config-remote-sync --save
+Detected changes in 1 resource(s):
+
+Resource: resources.jobs.test_job
+  job_clusters[job_cluster_key='shared'].new_cluster.num_workers: replace
+  job_clusters[job_cluster_key='shared'].new_cluster.spark_conf: add
+  job_clusters[job_cluster_key='ungated'].new_cluster.num_workers: replace
+  job_clusters[job_cluster_key='ungated'].new_cluster.spark_conf: add
+  max_concurrent_runs: replace
+  tasks[task_key='loop'].for_each_task.task.new_cluster.num_workers: replace
+  tasks[task_key='loop'].for_each_task.task.new_cluster.spark_conf: add
+  tasks[task_key='own_cluster'].new_cluster.num_workers: replace
+  tasks[task_key='own_cluster'].new_cluster.spark_conf: add
+
+
+
+>>> [CLI] bundle validate -o json
+json.resources.jobs.test_job.job_clusters[0].new_cluster.num_workers = 2;
+json.resources.jobs.test_job.job_clusters[0].new_cluster.spark_conf.spark.sql.shuffle.partitions = "7";
+json.resources.jobs.test_job.job_clusters[1].new_cluster.num_workers = 2;
+json.resources.jobs.test_job.job_clusters[1].new_cluster.spark_conf.spark.sql.shuffle.partitions = "7";
+json.resources.jobs.test_job.max_concurrent_runs = 5;
+json.resources.jobs.test_job.tasks[0].for_each_task.task.new_cluster.num_workers = 2;
+json.resources.jobs.test_job.tasks[0].for_each_task.task.new_cluster.spark_conf.spark.sql.shuffle.partitions = "7";
+json.resources.jobs.test_job.tasks[1].new_cluster.num_workers = 2;
+json.resources.jobs.test_job.tasks[1].new_cluster.spark_conf.spark.sql.shuffle.partitions = "7";
+
+>>> [CLI] bundle destroy --auto-approve
+The following resources will be deleted:
+  delete resources.cluster_policies.policy
+  delete resources.jobs.test_job
+
+All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/[UNIQUE_NAME]
+
+Destroy: 2 deleted

--- a/acceptance/bundle/config-remote-sync/cluster_policy_remote_addition/output.txt
+++ b/acceptance/bundle/config-remote-sync/cluster_policy_remote_addition/output.txt
@@ -6,38 +6,24 @@ Created jobs.test_job
 Files: 6 uploaded, 0 deleted
 Resources: 2 created, 0 changed, 0 deleted, 0 unchanged
 
->>> [CLI] bundle config-remote-sync
-No changes detected.
-
-
-=== Sync remote user edits unrelated to the attached policy
-
 >>> [CLI] bundle config-remote-sync --save
 Detected changes in 1 resource(s):
 
 Resource: resources.jobs.test_job
-  job_clusters[job_cluster_key='shared'].new_cluster.num_workers: replace
-  job_clusters[job_cluster_key='shared'].new_cluster.spark_conf: add
-  job_clusters[job_cluster_key='ungated'].new_cluster.num_workers: replace
-  job_clusters[job_cluster_key='ungated'].new_cluster.spark_conf: add
-  max_concurrent_runs: replace
-  tasks[task_key='loop'].for_each_task.task.new_cluster.num_workers: replace
-  tasks[task_key='loop'].for_each_task.task.new_cluster.spark_conf: add
-  tasks[task_key='own_cluster'].new_cluster.num_workers: replace
-  tasks[task_key='own_cluster'].new_cluster.spark_conf: add
+  tasks[task_key='test'].new_cluster.spark_conf: add
 
 
 
->>> [CLI] bundle validate -o json
-json.resources.jobs.test_job.job_clusters[0].new_cluster.num_workers = 2;
-json.resources.jobs.test_job.job_clusters[0].new_cluster.spark_conf.spark.sql.shuffle.partitions = "7";
-json.resources.jobs.test_job.job_clusters[1].new_cluster.num_workers = 2;
-json.resources.jobs.test_job.job_clusters[1].new_cluster.spark_conf.spark.sql.shuffle.partitions = "7";
-json.resources.jobs.test_job.max_concurrent_runs = 5;
-json.resources.jobs.test_job.tasks[0].for_each_task.task.new_cluster.num_workers = 2;
-json.resources.jobs.test_job.tasks[0].for_each_task.task.new_cluster.spark_conf.spark.sql.shuffle.partitions = "7";
-json.resources.jobs.test_job.tasks[1].new_cluster.num_workers = 2;
-json.resources.jobs.test_job.tasks[1].new_cluster.spark_conf.spark.sql.shuffle.partitions = "7";
+>>> diff.py databricks.yml.backup databricks.yml
+--- databricks.yml.backup
++++ databricks.yml
+@@ -26,4 +26,6 @@
+             custom_tags:
+               PolicyTag: from-policy
++            spark_conf:
++              spark.sql.shuffle.partitions: "7"
+           spark_python_task:
+             python_file: ./hello.py
 
 >>> [CLI] bundle destroy --auto-approve
 The following resources will be deleted:

--- a/acceptance/bundle/config-remote-sync/cluster_policy_remote_addition/script
+++ b/acceptance/bundle/config-remote-sync/cluster_policy_remote_addition/script
@@ -1,0 +1,29 @@
+envsubst < databricks.yml.tmpl > databricks.yml
+
+cleanup() {
+    trace $CLI bundle destroy --auto-approve
+}
+trap cleanup EXIT
+
+trace $CLI bundle deploy
+job_id=$(read_id.py test_job)
+
+trace $CLI bundle config-remote-sync | contains.py "No changes detected"
+
+title "Sync remote user edits unrelated to the attached policy\n"
+edit_resource.py jobs "$job_id" <<'EOF'
+r["max_concurrent_runs"] = 5
+clusters = [jc["new_cluster"] for jc in r["job_clusters"]]
+for task in r["tasks"]:
+    if "new_cluster" in task:
+        clusters.append(task["new_cluster"])
+    if "for_each_task" in task:
+        clusters.append(task["for_each_task"]["task"]["new_cluster"])
+for cluster in clusters:
+    cluster["spark_conf"] = {"spark.sql.shuffle.partitions": "7"}
+    cluster["num_workers"] = 2
+EOF
+
+trace $CLI bundle config-remote-sync --save
+# The snapshot must include the user addition for every cluster, including those with a policy.
+trace $CLI bundle validate -o json | gron.py | grep -E 'max_concurrent_runs|num_workers|spark.sql.shuffle.partitions'

--- a/acceptance/bundle/config-remote-sync/cluster_policy_remote_addition/script
+++ b/acceptance/bundle/config-remote-sync/cluster_policy_remote_addition/script
@@ -8,22 +8,11 @@ trap cleanup EXIT
 trace $CLI bundle deploy
 job_id=$(read_id.py test_job)
 
-trace $CLI bundle config-remote-sync | contains.py "No changes detected"
-
-title "Sync remote user edits unrelated to the attached policy\n"
 edit_resource.py jobs "$job_id" <<'EOF'
-r["max_concurrent_runs"] = 5
-clusters = [jc["new_cluster"] for jc in r["job_clusters"]]
-for task in r["tasks"]:
-    if "new_cluster" in task:
-        clusters.append(task["new_cluster"])
-    if "for_each_task" in task:
-        clusters.append(task["for_each_task"]["task"]["new_cluster"])
-for cluster in clusters:
-    cluster["spark_conf"] = {"spark.sql.shuffle.partitions": "7"}
-    cluster["num_workers"] = 2
+r["tasks"][0]["new_cluster"]["spark_conf"] = {"spark.sql.shuffle.partitions": "7"}
 EOF
 
+cp databricks.yml databricks.yml.backup
 trace $CLI bundle config-remote-sync --save
-# The snapshot must include the user addition for every cluster, including those with a policy.
-trace $CLI bundle validate -o json | gron.py | grep -E 'max_concurrent_runs|num_workers|spark.sql.shuffle.partitions'
+trace diff.py databricks.yml.backup databricks.yml
+rm databricks.yml.backup

--- a/acceptance/bundle/config-remote-sync/cluster_policy_remote_addition/test.toml
+++ b/acceptance/bundle/config-remote-sync/cluster_policy_remote_addition/test.toml
@@ -1,4 +1,4 @@
 Cloud = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]
 RecordRequests = false
-Ignore = [".databricks", "databricks.yml"]
+Ignore = [".databricks", "databricks.yml", "databricks.yml.backup"]

--- a/acceptance/bundle/config-remote-sync/cluster_policy_remote_addition/test.toml
+++ b/acceptance/bundle/config-remote-sync/cluster_policy_remote_addition/test.toml
@@ -1,0 +1,4 @@
+Cloud = true
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]
+RecordRequests = false
+Ignore = [".databricks", "databricks.yml"]


### PR DESCRIPTION
Superseded by #6631, which uses the same commits on a branch in `databricks/cli`.

## Changes

Add an acceptance test showing that #6531 makes `bundle config-remote-sync --save` silently ignore a remotely added Spark setting on a job cluster with a policy.

## Why

The test's policy fixes only `custom_tags.PolicyTag`; it leaves `spark_conf` unrestricted. After deployment, the test adds `spark.sql.shuffle.partitions: "7"` to the job's task cluster through the Jobs API. Config-sync should copy this change into `databricks.yml`:

```diff
+            spark_conf:
+              spark.sql.shuffle.partitions: "7"
```

Main produces this diff. With #6531, config-sync reports `No changes detected` and leaves YAML unchanged. The new rule skips remote-only additions whenever the cluster has `policy_id`, without checking whether the policy defines the field.

This test-only PR is stacked on #6531 and intentionally fails until that regression is fixed.

## Tests

- Main (`9caaff0c`): the exact acceptance test passes locally with deployment history off/on and on `e2-dogfood` with history off. Snapshot generated by running main.
- #6531 (`8aeb76c4`): the same local and cloud runs fail because the YAML diff is missing.
- Main's cloud runs with deployment history enabled were blocked by backend HTTP 500s during deploy/cleanup.
- Formatting, checks, and lint pass. The full suite stopped on unrelated `libs/patchwheel` failures (`ModuleNotFoundError: myproj`).

_This PR was written by Codex._
