### PR TITLE
Remove unused bundle.Context / bundle.Get context helpers

### DIFF
--- a/bundle/context.go
+++ b/bundle/context.go
@@ -7,12 +7,6 @@ import (
 // Placeholder to use as unique key in context.Context.
 var bundleKey int
 
-// Context stores the specified bundle on a new context.
-// The bundle is available through the `Get()` function.
-func Context(ctx context.Context, b *Bundle) context.Context {
-	return context.WithValue(ctx, &bundleKey, b)
-}
-
 // GetOrNil returns the bundle as configured on the context.
 // It returns nil if it isn't configured.
 func GetOrNil(ctx context.Context) *Bundle {
@@ -21,14 +15,4 @@ func GetOrNil(ctx context.Context) *Bundle {
 		return nil
 	}
 	return bundle
-}
-
-// Get returns the bundle as configured on the context.
-// It panics if it isn't configured.
-func Get(ctx context.Context) *Bundle {
-	b := GetOrNil(ctx)
-	if b == nil {
-		panic("context not configured with bundle")
-	}
-	return b
 }

--- a/bundle/context_test.go
+++ b/bundle/context_test.go
@@ -4,20 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
-func TestGetPanics(t *testing.T) {
-	defer func() {
-		r := recover()
-		require.NotNil(t, r, "The function did not panic")
-		assert.Equal(t, "context not configured with bundle", r)
-	}()
-
-	Get(t.Context())
-}
-
-func TestGetSuccess(t *testing.T) {
-	ctx := Context(t.Context(), &Bundle{})
-	require.NotNil(t, Get(ctx))
+func TestGetOrNilReturnsNilWhenUnset(t *testing.T) {
+	assert.Nil(t, GetOrNil(t.Context()))
 }


### PR DESCRIPTION
`bundle.Context` (store a bundle on a `context.Context`) and `bundle.Get` (read it, panicking if absent) date back to #95 (Nov 2022), but neither has a production caller: `cmd/root` and `cmd/sync` use `bundle.GetOrNil` directly. `Context` was the only writer of the context value, so this set/get path was already vestigial in production.

Both were reachable only from their own unit tests, so `deadcode -test ./...` didn't flag them. Keeps `GetOrNil` (live) and adds a small test for it.

This pull request and its description were written by Isaac.