### PR TITLE
Remove unused testserver HandleSQLPattern

### DIFF
--- a/libs/testserver/handlers.go
+++ b/libs/testserver/handlers.go
@@ -761,7 +761,7 @@ func AddDefaultHandlers(server *Server) {
 	})
 
 	// SQL Statement Execution lifecycle. Tests program these by registering
-	// matchers via Server.HandleSQL / HandleSQLPattern (see statements.go).
+	// matchers via Server.HandleSQL (see statements.go).
 	// They live here, not in New, so they act as overridable defaults: a test
 	// that needs raw control over a SQL endpoint (malformed body, transport
 	// error, custom status) can register its own handler for the same pattern

--- a/libs/testserver/statements.go
+++ b/libs/testserver/statements.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"regexp"
 	"strconv"
 
 	"github.com/databricks/cli/libs/testserver/testsql"
@@ -15,12 +14,6 @@ import (
 // statement exactly (after trimming).
 func (s *Server) HandleSQL(statement string, fn func(testsql.Request) testsql.Result) {
 	s.sqlHandler.Handle(statement, fn)
-}
-
-// HandleSQLPattern registers a matcher that runs fn when re matches a submitted
-// statement, passing the submatches through as Request.Match.
-func (s *Server) HandleSQLPattern(re *regexp.Regexp, fn func(testsql.Request) testsql.Result) {
-	s.sqlHandler.HandlePattern(re, fn)
 }
 
 // sqlExecuteStatement handles POST /api/2.0/sql/statements. A statement that

--- a/libs/testserver/statements_test.go
+++ b/libs/testserver/statements_test.go
@@ -2,7 +2,6 @@ package testserver
 
 import (
 	"encoding/json"
-	"regexp"
 	"testing"
 
 	"github.com/databricks/cli/libs/testserver/testsql"
@@ -33,19 +32,4 @@ func TestHandleSQL(t *testing.T) {
 	assert.Equal(t, sql.StatementStateSucceeded, resp.Status.State)
 	require.NotNil(t, resp.Result)
 	assert.Equal(t, [][]string{{"1"}}, resp.Result.DataArray)
-}
-
-func TestHandleSQLPattern(t *testing.T) {
-	server := New(t)
-	// A regex matcher echoes back a captured submatch, exercising both the
-	// HandleSQLPattern registration and Request.Match.
-	server.HandleSQLPattern(regexp.MustCompile(`^SELECT (\d+)$`), func(r testsql.Request) testsql.Result {
-		return testsql.Result{Columns: []string{"n"}, Rows: [][]string{{r.Match[1]}}}
-	})
-
-	resp := submitSQL(t, server, "SELECT 42")
-	require.NotNil(t, resp.Status)
-	assert.Equal(t, sql.StatementStateSucceeded, resp.Status.State)
-	require.NotNil(t, resp.Result)
-	assert.Equal(t, [][]string{{"42"}}, resp.Result.DataArray)
 }


### PR DESCRIPTION
The testsql fake (added in #5432 (Jun 2026)) supports regex matchers, but the `Server.HandleSQLPattern` wrapper that exposed them to tests was never used — no test registers a pattern matcher through the testserver; they use the exact-match `Server.HandleSQL`. Reachable only from its own unit test, so `deadcode -test ./...` didn't flag it.

The underlying `testsql.Handler.HandlePattern` is kept — it's still exercised by the `testsql` package's own tests.

This pull request and its description were written by Isaac.