### PR TITLE
Preserve SSH descendant filesystem access after bootstrap exit

### DIFF
--- a/.nextchanges/cli/ssh-filesystem-registration.md
+++ b/.nextchanges/cli/ssh-filesystem-registration.md
@@ -1,0 +1,1 @@
+* Preserve workspace-file and volume access for SSH server descendants when the bootstrap notebook exits and the server survives.

--- a/.nextchanges/cli/ssh-filesystem-registration.md
+++ b/.nextchanges/cli/ssh-filesystem-registration.md
@@ -1,1 +1,1 @@
-* Preserve workspace-file and volume access for SSH server descendants when the bootstrap notebook exits and the server survives.
+* Preserve workspace-file and volume access for SSH server descendants when the bootstrap notebook exits and the server survives. ([#6645](https://github.com/databricks/cli/pull/6645))

--- a/experimental/ssh/FAILURE_MODES.md
+++ b/experimental/ssh/FAILURE_MODES.md
@@ -156,3 +156,29 @@ The proxy-layer behaviors have unit tests that don't need a cluster:
 ```shell
 go test ./experimental/ssh/...
 ```
+
+## Filesystem access after the bootstrap notebook exits
+
+If SSH still connects but `/Workspace` or `/Volumes` operations return permission errors,
+check whether the tunnel server registered successfully. Its startup logs contain
+`Registered SSH server PID` for each filesystem daemon that accepted registration.
+`Failed to register SSH filesystem credentials` means at least one registration failed;
+the tunnel continues to run and retries in the background.
+
+From an SSH session, read the process used for workspace-file authorization:
+
+```sh
+cat /Workspace/.proc/self/metadata/pid
+ps -o pid,ppid,args -p <registered-pid>
+```
+
+On dedicated compute, the reported PID should identify the tunnel server. If it identifies
+the bootstrap Python process, workspace-file access still depends on that process.
+The server checks this every ten minutes and attempts to restore a lost registration.
+An unavailable daemon produces a warning rather than preventing SSH startup.
+
+This registration only covers the server and its descendants. A detached process that
+leaves that ancestry can still lose access. The compute can also terminate the server
+after the bootstrap notebook exits; registration does not extend either lifetime.
+An expired or revoked bootstrap credential cannot be repaired by re-registering it.
+In these cases, reconnect to start a new server after the existing server has stopped.

--- a/experimental/ssh/README.md
+++ b/experimental/ssh/README.md
@@ -36,7 +36,27 @@ file with `StrictHostKeyChecking yes`. Tunnel host keys therefore never land in
 `~/.ssh/known_hosts`, where a name - unique only within one workspace - would collide with an
 entry left by other compute.
 
+### Filesystem access
+
+On dedicated compute, the tunnel server registers its own process with the filesystem
+daemons. SSH sessions that remain descendants of that server can keep accessing
+`/Workspace` and `/Volumes` if the bootstrap notebook exits and the server survives.
+This does not keep the compute or server alive, preserve detached processes that leave
+the server's process tree, or restore them after a server restart.
+
+The server checks its filesystem registration and current credential every ten minutes.
+It updates registration when the credential changes or the registered process is lost,
+and retries failed registrations. Unchanged registrations do not generate updates.
+The bootstrap supplies a fixed credential; checking it again cannot renew an expired or
+revoked credential. Registration entries may remain until compute shutdown. Matching
+the process start time prevents a reused PID from inheriting an old registration.
+
+Registration failures are warnings. On compute where the daemon APIs are unavailable,
+including serverless, the tunnel starts and file access continues to depend on the
+bootstrap notebook as before. See [filesystem troubleshooting](./FAILURE_MODES.md#filesystem-access-after-the-bootstrap-notebook-exits).
+
 ## Development
+
 ```shell
 ./task build snapshot-release
 ./cli ssh connect --cluster=<id> --releases-dir=./dist --debug # or modify ssh config accordingly

--- a/experimental/ssh/internal/fuse/client.go
+++ b/experimental/ssh/internal/fuse/client.go
@@ -1,0 +1,147 @@
+// Package fuse registers the SSH server's credentials with the compute's filesystem daemons.
+package fuse
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/databricks/cli/libs/log"
+)
+
+const (
+	commandOrigin  = "RemoteSshServer"
+	requestTimeout = 2 * time.Second
+)
+
+type request struct {
+	APIToken       string            `json:"apiToken"`
+	ProcStartTime  uint64            `json:"procStartTime"`
+	CommandOrigin  string            `json:"commandOrigin"`
+	PIDNamespaceID uint32            `json:"namespaceId"`
+	AdditionalTags map[string]string `json:"additionalTags,omitempty"`
+}
+
+type daemon struct {
+	name  string
+	port  int
+	path  string
+	host  string
+	token string
+}
+
+// Client tracks the last successful registration for each daemon. It must not be used concurrently.
+type Client struct {
+	registration Registration
+	hosts        []string
+	daemons      []daemon
+	http         *http.Client
+	readPID      func() (int, error)
+}
+
+// NewClient creates a client for the node-local filesystem daemons.
+func NewClient(r Registration) (*Client, error) {
+	if r.PID <= 0 || r.PIDNamespaceID == 0 || r.StartTime == 0 {
+		return nil, errors.New("FUSE registration requires a positive PID, PID namespace and process start time")
+	}
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	// Credentials belong on this node, even when the server has HTTP_PROXY set.
+	transport.Proxy = nil
+	return &Client{
+		registration: r,
+		readPID:      registeredPID,
+		hosts:        []string{"databricks.node.host.local", "node.host.local", "localhost"},
+		daemons: []daemon{
+			{name: "workspace files", port: 1021, path: fmt.Sprintf("/api/1/pid/%d", r.PID)},
+			{name: "volumes", port: 1015, path: fmt.Sprintf("/dbfs-fuse-api/1/pid/%d", r.PID)},
+		},
+		http: &http.Client{
+			Timeout:       requestTimeout,
+			Transport:     transport,
+			CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
+		},
+	}, nil
+}
+
+// Register updates changed credentials and retries failed registrations. Force also restores a lost registration.
+func (c *Client) Register(ctx context.Context, token, userID string, force bool) error {
+	if token == "" {
+		return errors.New("cannot register an empty FUSE token")
+	}
+	body := request{
+		APIToken:       token,
+		ProcStartTime:  c.registration.StartTime,
+		CommandOrigin:  commandOrigin,
+		PIDNamespaceID: c.registration.PIDNamespaceID,
+	}
+	if userID != "" {
+		body.AdditionalTags = map[string]string{"userId": userID}
+	}
+	encoded, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("failed to encode FUSE registration: %w", err)
+	}
+
+	var errs []error
+	for i := range c.daemons {
+		d := &c.daemons[i]
+		if force {
+			d.token = ""
+		}
+		if d.token == token {
+			continue
+		}
+		if err := c.registerDaemon(ctx, d, encoded); err != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", d.name, err))
+			continue
+		}
+		d.token = token
+		log.Infof(ctx, "Registered SSH server PID %d with %s", c.registration.PID, d.name)
+	}
+	return errors.Join(errs...)
+}
+
+func (c *Client) registerDaemon(ctx context.Context, d *daemon, body []byte) error {
+	if d.host != "" {
+		return c.put(ctx, d, d.host, body)
+	}
+	var errs []error
+	for _, host := range c.hosts {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := c.put(ctx, d, host, body); err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		// DNS resolution alone does not establish that this endpoint serves the daemon.
+		d.host = host
+		return nil
+	}
+	return errors.Join(errs...)
+}
+
+func (c *Client) put(ctx context.Context, d *daemon, host string, body []byte) error {
+	url := "http://" + net.JoinHostPort(host, strconv.Itoa(d.port)) + d.path
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, url, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("failed to build FUSE request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to register with %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		// Error bodies may echo credentials from the request.
+		return fmt.Errorf("%s returned HTTP %d", url, resp.StatusCode)
+	}
+	return nil
+}

--- a/experimental/ssh/internal/fuse/client_test.go
+++ b/experimental/ssh/internal/fuse/client_test.go
@@ -1,0 +1,217 @@
+package fuse_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/databricks/cli/experimental/ssh/internal/fuse"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var testHosts = []string{"first.test", "second.test", "third.test"}
+
+type recordedRequest struct {
+	Host string
+	Path string
+	Body map[string]any
+}
+
+type testDaemon struct {
+	mu       sync.Mutex
+	requests []recordedRequest
+	status   func(*http.Request) int
+}
+
+func newTestClient(t *testing.T, d *testDaemon) *fuse.Client {
+	t.Helper()
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		var body map[string]any
+		if !assert.NoError(t, json.NewDecoder(r.Body).Decode(&body)) {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		d.mu.Lock()
+		defer d.mu.Unlock()
+		d.requests = append(d.requests, recordedRequest{r.Host, r.URL.Path, body})
+		status := http.StatusOK
+		if d.status != nil {
+			status = d.status(r)
+		}
+		w.WriteHeader(status)
+		if status != http.StatusOK {
+			_, _ = io.WriteString(w, "secret-token-in-error-body")
+		}
+	}))
+	t.Cleanup(s.Close)
+	c, err := fuse.NewClient(registration)
+	require.NoError(t, err)
+	httpClient := fuse.HTTPClient(c)
+	httpClient.Transport.(*http.Transport).DialContext = func(ctx context.Context, network, _ string) (net.Conn, error) {
+		return (&net.Dialer{}).DialContext(ctx, network, s.Listener.Addr().String())
+	}
+	fuse.ConfigureTestClient(c, httpClient, testHosts, func() (int, error) { return registration.PID, nil })
+	t.Cleanup(httpClient.CloseIdleConnections)
+	return c
+}
+
+func (d *testDaemon) snapshot() []recordedRequest {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return append([]recordedRequest(nil), d.requests...)
+}
+
+func TestRegister(t *testing.T) {
+	for _, userID := range []string{"", "12345"} {
+		t.Run("user="+userID, func(t *testing.T) {
+			d := &testDaemon{}
+			c := newTestClient(t, d)
+			require.NoError(t, c.Register(t.Context(), "token-one", userID, false))
+			requests := d.snapshot()
+			require.Len(t, requests, 2)
+			assert.Equal(t, "first.test:1021", requests[0].Host)
+			assert.Equal(t, "/api/1/pid/4242", requests[0].Path)
+			assert.Equal(t, "first.test:1015", requests[1].Host)
+			assert.Equal(t, "/dbfs-fuse-api/1/pid/4242", requests[1].Path)
+			want := map[string]any{
+				"apiToken": "token-one", "procStartTime": float64(8613244),
+				"commandOrigin": "RemoteSshServer", "namespaceId": float64(4026531836),
+			}
+			if userID != "" {
+				want["additionalTags"] = map[string]any{"userId": userID}
+			}
+			for _, req := range requests {
+				assert.Equal(t, want, req.Body)
+			}
+
+			require.NoError(t, c.Register(t.Context(), "token-one", userID, false))
+			assert.Len(t, d.snapshot(), 2, "unchanged credentials must not invalidate caches")
+			require.NoError(t, c.Register(t.Context(), "token-two", userID, false))
+			requests = d.snapshot()
+			require.Len(t, requests, 4)
+			assert.Equal(t, "token-two", requests[2].Body["apiToken"])
+			assert.Equal(t, "token-two", requests[3].Body["apiToken"])
+			require.NoError(t, c.Register(t.Context(), "token-two", userID, true))
+			assert.Len(t, d.snapshot(), 6, "restore a lost registration with the same token")
+		})
+	}
+}
+
+func TestRegisterSelectsReachableHostPerDaemon(t *testing.T) {
+	d := &testDaemon{status: func(r *http.Request) int {
+		if r.Host == "second.test:1021" || r.Host == "third.test:1015" {
+			return http.StatusOK
+		}
+		return http.StatusNotFound
+	}}
+	c := newTestClient(t, d)
+	require.NoError(t, c.Register(t.Context(), "token-one", "", false))
+	require.Len(t, d.snapshot(), 5)
+	require.NoError(t, c.Register(t.Context(), "token-two", "", false))
+	requests := d.snapshot()
+	require.Len(t, requests, 7)
+	assert.Equal(t, "second.test:1021", requests[5].Host)
+	assert.Equal(t, "third.test:1015", requests[6].Host)
+}
+
+func TestRegisterRetriesOnlyFailedDaemon(t *testing.T) {
+	d := &testDaemon{status: func(r *http.Request) int {
+		if strings.HasSuffix(r.Host, ":1015") {
+			return http.StatusServiceUnavailable
+		}
+		return http.StatusOK
+	}}
+	c := newTestClient(t, d)
+	err := c.Register(t.Context(), "token-one", "", false)
+	require.ErrorContains(t, err, "volumes:")
+	assert.NotContains(t, err.Error(), "secret-token-in-error-body")
+	assert.Len(t, d.snapshot(), 4)
+	d.mu.Lock()
+	d.status = nil
+	d.mu.Unlock()
+	require.NoError(t, c.Register(t.Context(), "token-one", "", false))
+	requests := d.snapshot()
+	require.Len(t, requests, 5)
+	assert.Equal(t, "first.test:1015", requests[4].Host)
+}
+
+func TestRegisterRejectsInvalidCredentials(t *testing.T) {
+	for _, r := range []fuse.Registration{
+		{PID: -1, PIDNamespaceID: 1, StartTime: 1},
+		{PID: 0, PIDNamespaceID: 1, StartTime: 1},
+		{PID: 1, PIDNamespaceID: 0, StartTime: 1},
+		{PID: 1, PIDNamespaceID: 1, StartTime: 0},
+	} {
+		_, err := fuse.NewClient(r)
+		require.Error(t, err)
+	}
+	d := &testDaemon{}
+	c := newTestClient(t, d)
+	require.ErrorContains(t, c.Register(t.Context(), "", "", false), "empty FUSE token")
+	assert.Empty(t, d.snapshot())
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func TestRegisterBoundsRequests(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		c, err := fuse.NewClient(registration)
+		require.NoError(t, err)
+		httpClient := fuse.HTTPClient(c)
+		calls := 0
+		httpClient.Transport = roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			calls++
+			<-r.Context().Done()
+			return nil, r.Context().Err()
+		})
+		start := time.Now()
+		err = c.Register(t.Context(), "token-one", "", false)
+		require.Error(t, err)
+		assert.Equal(t, 6, calls)
+		assert.Equal(t, 12*time.Second, time.Since(start))
+		assert.ErrorIs(t, err, context.DeadlineExceeded)
+	})
+}
+
+func TestRegisterCancellation(t *testing.T) {
+	c, err := fuse.NewClient(registration)
+	require.NoError(t, err)
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	err = c.Register(ctx, "token-one", "", false)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestRegisterDoesNotRedirectOrProxyCredentials(t *testing.T) {
+	c, err := fuse.NewClient(registration)
+	require.NoError(t, err)
+	httpClient := fuse.HTTPClient(c)
+	assert.Nil(t, httpClient.Transport.(*http.Transport).Proxy)
+	requests := 0
+	httpClient.Transport = roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		requests++
+		assert.NotEqual(t, "redirect.test", r.URL.Hostname())
+		return &http.Response{
+			StatusCode: http.StatusTemporaryRedirect,
+			Header:     http.Header{"Location": {"http://redirect.test/"}},
+			Body:       io.NopCloser(strings.NewReader("secret-token-in-error-body")),
+		}, nil
+	})
+	err = c.Register(t.Context(), "token-one", "", false)
+	require.ErrorContains(t, err, "HTTP 307")
+	assert.NotContains(t, err.Error(), "secret-token-in-error-body")
+	assert.Equal(t, 6, requests)
+}

--- a/experimental/ssh/internal/fuse/export_test.go
+++ b/experimental/ssh/internal/fuse/export_test.go
@@ -1,0 +1,17 @@
+package fuse
+
+import "net/http"
+
+var ParseRegistration = parseRegistration
+
+const RefreshInterval = refreshInterval
+
+func ConfigureTestClient(c *Client, httpClient *http.Client, hosts []string, readPID func() (int, error)) {
+	c.http = httpClient
+	c.hosts = hosts
+	c.readPID = readPID
+}
+
+func HTTPClient(c *Client) *http.Client {
+	return c.http
+}

--- a/experimental/ssh/internal/fuse/keepalive.go
+++ b/experimental/ssh/internal/fuse/keepalive.go
@@ -1,0 +1,61 @@
+package fuse
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/databricks/cli/libs/log"
+)
+
+const refreshInterval = 10 * time.Minute
+
+// TokenFunc returns the current credential, including any refresh performed by the SDK.
+type TokenFunc func(context.Context) (string, error)
+
+// KeepRegistered makes an initial attempt before returning, then retries in the background,
+// even if that attempt failed. Cancellation stops refresh; entries remain until compute shutdown.
+func KeepRegistered(ctx context.Context, client *Client, token TokenFunc, userID string) error {
+	err := refresh(ctx, client, token, userID, false)
+	go refreshUntilDone(ctx, client, token, userID)
+	return err
+}
+
+func refresh(ctx context.Context, client *Client, token TokenFunc, userID string, force bool) error {
+	value, err := token(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get FUSE credentials: %w", err)
+	}
+	return client.Register(ctx, value, userID, force)
+}
+
+func refreshUntilDone(ctx context.Context, client *Client, token TokenFunc, userID string) {
+	ticker := time.NewTicker(refreshInterval)
+	defer ticker.Stop()
+	defer client.http.CloseIdleConnections()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			pid, err := client.readPID()
+			// Re-register only after credential rotation or loss of the registered ancestor.
+			// Unchanged registrations unnecessarily invalidate the daemon's caches.
+			force := err != nil || pid != client.registration.PID
+			if err := refresh(ctx, client, token, userID, force); err != nil {
+				log.Warnf(ctx, "Failed to refresh SSH filesystem credentials; retrying in %v: %v", refreshInterval, err)
+			}
+		}
+	}
+}
+
+func registeredPID() (int, error) {
+	content, err := os.ReadFile("/Workspace/.proc/self/metadata/pid")
+	if err != nil {
+		return 0, err
+	}
+	return strconv.Atoi(strings.TrimSpace(string(content)))
+}

--- a/experimental/ssh/internal/fuse/keepalive_test.go
+++ b/experimental/ssh/internal/fuse/keepalive_test.go
@@ -1,0 +1,105 @@
+package fuse_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/databricks/cli/experimental/ssh/internal/fuse"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKeepRegistered(t *testing.T) {
+	for _, initialFailure := range []string{"", "token", "workspace", "volumes", "both"} {
+		t.Run("initialFailure="+initialFailure, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				ctx, cancel := context.WithCancel(t.Context())
+				defer cancel()
+				c, err := fuse.NewClient(registration)
+				require.NoError(t, err)
+				failure := initialFailure
+				token := "token-one"
+				pid := registration.PID
+				var probeErr error
+				var requests []recordedRequest
+				httpClient := fuse.HTTPClient(c)
+				httpClient.Transport = roundTripFunc(func(r *http.Request) (*http.Response, error) {
+					var body map[string]any
+					require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+					assert.NotEmpty(t, body["apiToken"], "cancellation must not send a revoke")
+					requests = append(requests, recordedRequest{r.Host, r.URL.Path, body})
+					status := http.StatusOK
+					if failure == "both" || (failure == "workspace" && r.URL.Port() == "1021") || (failure == "volumes" && r.URL.Port() == "1015") {
+						status = http.StatusServiceUnavailable
+					}
+					return &http.Response{StatusCode: status, Body: io.NopCloser(strings.NewReader(""))}, nil
+				})
+				fuse.ConfigureTestClient(c, httpClient, testHosts, func() (int, error) { return pid, probeErr })
+				tokenCalls := 0
+				err = fuse.KeepRegistered(ctx, c, func(context.Context) (string, error) {
+					tokenCalls++
+					if failure == "token" {
+						return "", errors.New("token unavailable")
+					}
+					return token, nil
+				}, "12345")
+				if initialFailure == "" {
+					require.NoError(t, err)
+				} else {
+					require.Error(t, err)
+				}
+				synctest.Wait()
+				initialRequests := len(requests)
+				failure = ""
+				time.Sleep(fuse.RefreshInterval)
+				synctest.Wait()
+				retries := 0
+				switch initialFailure {
+				case "token", "both":
+					retries = 2
+				case "workspace", "volumes":
+					retries = 1
+				}
+				assert.Len(t, requests, initialRequests+retries)
+				assert.Equal(t, 2, tokenCalls, "a failed startup must still start the refresh loop")
+
+				before := len(requests)
+				time.Sleep(3 * fuse.RefreshInterval)
+				synctest.Wait()
+				assert.Len(t, requests, before, "steady state must not re-register")
+
+				token = "token-two"
+				time.Sleep(fuse.RefreshInterval)
+				synctest.Wait()
+				require.Len(t, requests, before+2)
+				assert.Equal(t, token, requests[before].Body["apiToken"])
+				assert.Equal(t, token, requests[before+1].Body["apiToken"])
+
+				pid = registration.PID - 1
+				time.Sleep(fuse.RefreshInterval)
+				synctest.Wait()
+				assert.Len(t, requests, before+4, "restore registration when a different ancestor is reported")
+				pid = registration.PID
+				probeErr = errors.New("filesystem metadata unavailable")
+				time.Sleep(fuse.RefreshInterval)
+				synctest.Wait()
+				assert.Len(t, requests, before+6, "restore registration when the probe fails")
+				probeErr = nil
+				cancel()
+				synctest.Wait()
+				callsAtCancel := tokenCalls
+				time.Sleep(2 * fuse.RefreshInterval)
+				synctest.Wait()
+				assert.Equal(t, callsAtCancel, tokenCalls)
+				assert.Len(t, requests, before+6)
+			})
+		})
+	}
+}

--- a/experimental/ssh/internal/fuse/keepalive_test.go
+++ b/experimental/ssh/internal/fuse/keepalive_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -24,6 +25,7 @@ func TestKeepRegistered(t *testing.T) {
 				defer cancel()
 				c, err := fuse.NewClient(registration)
 				require.NoError(t, err)
+				var mu sync.Mutex
 				failure := initialFailure
 				token := "token-one"
 				pid := registration.PID
@@ -31,8 +33,12 @@ func TestKeepRegistered(t *testing.T) {
 				var requests []recordedRequest
 				httpClient := fuse.HTTPClient(c)
 				httpClient.Transport = roundTripFunc(func(r *http.Request) (*http.Response, error) {
+					mu.Lock()
+					defer mu.Unlock()
 					var body map[string]any
-					require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+					if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+						return nil, err
+					}
 					assert.NotEmpty(t, body["apiToken"], "cancellation must not send a revoke")
 					requests = append(requests, recordedRequest{r.Host, r.URL.Path, body})
 					status := http.StatusOK
@@ -41,9 +47,11 @@ func TestKeepRegistered(t *testing.T) {
 					}
 					return &http.Response{StatusCode: status, Body: io.NopCloser(strings.NewReader(""))}, nil
 				})
-				fuse.ConfigureTestClient(c, httpClient, testHosts, func() (int, error) { return pid, probeErr })
+				fuse.ConfigureTestClient(c, httpClient, testHosts, func() (int, error) { mu.Lock(); defer mu.Unlock(); return pid, probeErr })
 				tokenCalls := 0
 				err = fuse.KeepRegistered(ctx, c, func(context.Context) (string, error) {
+					mu.Lock()
+					defer mu.Unlock()
 					tokenCalls++
 					if failure == "token" {
 						return "", errors.New("token unavailable")
@@ -56,10 +64,13 @@ func TestKeepRegistered(t *testing.T) {
 					require.Error(t, err)
 				}
 				synctest.Wait()
+				mu.Lock()
 				initialRequests := len(requests)
 				failure = ""
+				mu.Unlock()
 				time.Sleep(fuse.RefreshInterval)
 				synctest.Wait()
+				mu.Lock()
 				retries := 0
 				switch initialFailure {
 				case "token", "both":
@@ -71,34 +82,47 @@ func TestKeepRegistered(t *testing.T) {
 				assert.Equal(t, 2, tokenCalls, "a failed startup must still start the refresh loop")
 
 				before := len(requests)
+				mu.Unlock()
 				time.Sleep(3 * fuse.RefreshInterval)
 				synctest.Wait()
+				mu.Lock()
 				assert.Len(t, requests, before, "steady state must not re-register")
 
 				token = "token-two"
+				mu.Unlock()
 				time.Sleep(fuse.RefreshInterval)
 				synctest.Wait()
+				mu.Lock()
 				require.Len(t, requests, before+2)
 				assert.Equal(t, token, requests[before].Body["apiToken"])
 				assert.Equal(t, token, requests[before+1].Body["apiToken"])
 
 				pid = registration.PID - 1
+				mu.Unlock()
 				time.Sleep(fuse.RefreshInterval)
 				synctest.Wait()
+				mu.Lock()
 				assert.Len(t, requests, before+4, "restore registration when a different ancestor is reported")
 				pid = registration.PID
 				probeErr = errors.New("filesystem metadata unavailable")
+				mu.Unlock()
 				time.Sleep(fuse.RefreshInterval)
 				synctest.Wait()
+				mu.Lock()
 				assert.Len(t, requests, before+6, "restore registration when the probe fails")
 				probeErr = nil
 				cancel()
+				mu.Unlock()
 				synctest.Wait()
+				mu.Lock()
 				callsAtCancel := tokenCalls
+				mu.Unlock()
 				time.Sleep(2 * fuse.RefreshInterval)
 				synctest.Wait()
+				mu.Lock()
 				assert.Equal(t, callsAtCancel, tokenCalls)
 				assert.Len(t, requests, before+6)
+				mu.Unlock()
 			})
 		})
 	}

--- a/experimental/ssh/internal/fuse/process.go
+++ b/experimental/ssh/internal/fuse/process.go
@@ -1,0 +1,60 @@
+package fuse
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// Registration identifies a process without allowing a recycled PID to inherit its credentials.
+type Registration struct {
+	PID            int
+	PIDNamespaceID uint32
+	StartTime      uint64
+}
+
+// Self describes the calling process using Linux procfs.
+func Self() (Registration, error) {
+	link, err := os.Readlink("/proc/self/ns/pid")
+	if err != nil {
+		return Registration{}, fmt.Errorf("failed to read the PID namespace: %w", err)
+	}
+	stat, err := os.ReadFile("/proc/self/stat")
+	if err != nil {
+		return Registration{}, fmt.Errorf("failed to read process stat: %w", err)
+	}
+	return parseRegistration(os.Getpid(), link, string(stat))
+}
+
+func parseRegistration(pid int, namespace, stat string) (Registration, error) {
+	inner, ok := strings.CutPrefix(namespace, "pid:[")
+	if !ok {
+		return Registration{}, fmt.Errorf("unexpected PID namespace link %q", namespace)
+	}
+	inner, ok = strings.CutSuffix(inner, "]")
+	if !ok {
+		return Registration{}, fmt.Errorf("unexpected PID namespace link %q", namespace)
+	}
+	namespaceID, err := strconv.ParseUint(inner, 10, 32)
+	if err != nil {
+		return Registration{}, fmt.Errorf("failed to parse the PID namespace: %w", err)
+	}
+
+	// Field 2 can contain spaces and parentheses. Count field 22 from the last ')'.
+	// https://man7.org/linux/man-pages/man5/proc_pid_stat.5.html
+	end := strings.LastIndex(stat, ")")
+	if end < 0 {
+		return Registration{}, fmt.Errorf("missing process name in process stat")
+	}
+	fields := strings.Fields(stat[end+1:])
+	const startTimeIndex = 19
+	if len(fields) <= startTimeIndex {
+		return Registration{}, fmt.Errorf("missing start time in process stat")
+	}
+	startTime, err := strconv.ParseUint(fields[startTimeIndex], 10, 64)
+	if err != nil {
+		return Registration{}, fmt.Errorf("failed to parse process start time: %w", err)
+	}
+	return Registration{PID: pid, PIDNamespaceID: uint32(namespaceID), StartTime: startTime}, nil
+}

--- a/experimental/ssh/internal/fuse/process.go
+++ b/experimental/ssh/internal/fuse/process.go
@@ -1,6 +1,7 @@
 package fuse
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -45,12 +46,12 @@ func parseRegistration(pid int, namespace, stat string) (Registration, error) {
 	// https://man7.org/linux/man-pages/man5/proc_pid_stat.5.html
 	end := strings.LastIndex(stat, ")")
 	if end < 0 {
-		return Registration{}, fmt.Errorf("missing process name in process stat")
+		return Registration{}, errors.New("missing process name in process stat")
 	}
 	fields := strings.Fields(stat[end+1:])
 	const startTimeIndex = 19
 	if len(fields) <= startTimeIndex {
-		return Registration{}, fmt.Errorf("missing start time in process stat")
+		return Registration{}, errors.New("missing start time in process stat")
 	}
 	startTime, err := strconv.ParseUint(fields[startTimeIndex], 10, 64)
 	if err != nil {

--- a/experimental/ssh/internal/fuse/process_test.go
+++ b/experimental/ssh/internal/fuse/process_test.go
@@ -1,0 +1,53 @@
+package fuse_test
+
+import (
+	"os"
+	"runtime"
+	"testing"
+
+	"github.com/databricks/cli/experimental/ssh/internal/fuse"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const processStat = "4242 (databricks) S 1 1234 1234 0 -1 4194560 5407 0 0 0 33 12 0 0 20 0 14 0 8613244 1234"
+
+var registration = fuse.Registration{PID: 4242, PIDNamespaceID: 4026531836, StartTime: 8613244}
+
+func TestParseRegistration(t *testing.T) {
+	for _, tc := range []struct {
+		name, namespace, stat, err string
+	}{
+		{name: "valid", namespace: "pid:[4026531836]", stat: processStat},
+		{name: "spaces and parentheses", namespace: "pid:[4026531836]", stat: "4242 (weird ) name)) S 1 1234 1234 0 -1 4194560 5407 0 0 0 33 12 0 0 20 0 14 0 8613244"},
+		{name: "wrong namespace", namespace: "mnt:[4026531836]", stat: processStat, err: "unexpected PID namespace"},
+		{name: "incomplete namespace", namespace: "pid:[4026531836", stat: processStat, err: "unexpected PID namespace"},
+		{name: "empty namespace", namespace: "pid:[]", stat: processStat, err: "failed to parse the PID namespace"},
+		{name: "namespace overflow", namespace: "pid:[4294967296]", stat: processStat, err: "failed to parse the PID namespace"},
+		{name: "missing name", namespace: "pid:[4026531836]", stat: "4242 databricks S 1", err: "missing process name"},
+		{name: "truncated stat", namespace: "pid:[4026531836]", stat: "4242 (databricks) S 1", err: "missing start time"},
+		{name: "invalid time", namespace: "pid:[4026531836]", stat: "4242 (databricks) S 1 1234 1234 0 -1 4194560 5407 0 0 0 33 12 0 0 20 0 14 0 invalid", err: "failed to parse process start time"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := fuse.ParseRegistration(registration.PID, tc.namespace, tc.stat)
+			if tc.err != "" {
+				require.ErrorContains(t, err, tc.err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, registration, got)
+		})
+	}
+}
+
+func TestSelf(t *testing.T) {
+	r, err := fuse.Self()
+	if runtime.GOOS != "linux" {
+		require.Error(t, err)
+		return
+	}
+	require.NoError(t, err)
+	assert.Equal(t, os.Getpid(), r.PID)
+	assert.Positive(t, r.PIDNamespaceID)
+	assert.Positive(t, r.StartTime)
+}

--- a/experimental/ssh/internal/server/export_test.go
+++ b/experimental/ssh/internal/server/export_test.go
@@ -1,0 +1,4 @@
+package server
+
+var WorkspaceToken = workspaceToken
+var FuseUserID = fuseUserID

--- a/experimental/ssh/internal/server/export_test.go
+++ b/experimental/ssh/internal/server/export_test.go
@@ -1,4 +1,6 @@
 package server
 
-var WorkspaceToken = workspaceToken
-var FuseUserID = fuseUserID
+var (
+	WorkspaceToken = workspaceToken
+	FuseUserID     = fuseUserID
+)

--- a/experimental/ssh/internal/server/fuse.go
+++ b/experimental/ssh/internal/server/fuse.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -49,7 +50,7 @@ func workspaceToken(client *databricks.WorkspaceClient) fuse.TokenFunc {
 		}
 		token, ok := strings.CutPrefix(req.Header.Get("Authorization"), "Bearer ")
 		if !ok || token == "" {
-			return "", fmt.Errorf("resolved credentials do not provide a bearer token")
+			return "", errors.New("resolved credentials do not provide a bearer token")
 		}
 		return token, nil
 	}

--- a/experimental/ssh/internal/server/fuse.go
+++ b/experimental/ssh/internal/server/fuse.go
@@ -1,0 +1,56 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/databricks/cli/experimental/ssh/internal/fuse"
+	"github.com/databricks/cli/libs/log"
+	"github.com/databricks/databricks-sdk-go"
+	"github.com/databricks/databricks-sdk-go/service/iam"
+)
+
+func registerFuseCredentials(ctx context.Context, client *databricks.WorkspaceClient) error {
+	self, err := fuse.Self()
+	if err != nil {
+		return err
+	}
+	fuseClient, err := fuse.NewClient(self)
+	if err != nil {
+		return err
+	}
+	return fuse.KeepRegistered(ctx, fuseClient, workspaceToken(client), fuseUserID(ctx, client))
+}
+
+func fuseUserID(ctx context.Context, client *databricks.WorkspaceClient) string {
+	// The user ID is an optional audit tag. Limit its lookup before publishing the server port.
+	userCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	me, err := client.CurrentUser.Me(userCtx, iam.MeRequest{})
+	if err != nil {
+		log.Debugf(ctx, "Registering filesystem credentials without a user ID: %v", err)
+		return ""
+	}
+	return me.Id
+}
+
+func workspaceToken(client *databricks.WorkspaceClient) fuse.TokenFunc {
+	return func(ctx context.Context) (string, error) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, client.Config.Host, nil)
+		if err != nil {
+			return "", fmt.Errorf("failed to build authentication request: %w", err)
+		}
+		// Authenticate picks up refreshed credentials, unlike reading Config.Token directly.
+		if err := client.Config.Authenticate(req); err != nil {
+			return "", fmt.Errorf("failed to authenticate: %w", err)
+		}
+		token, ok := strings.CutPrefix(req.Header.Get("Authorization"), "Bearer ")
+		if !ok || token == "" {
+			return "", fmt.Errorf("resolved credentials do not provide a bearer token")
+		}
+		return token, nil
+	}
+}

--- a/experimental/ssh/internal/server/fuse_test.go
+++ b/experimental/ssh/internal/server/fuse_test.go
@@ -1,0 +1,113 @@
+package server_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/databricks/cli/experimental/ssh/internal/server"
+	"github.com/databricks/databricks-sdk-go"
+	"github.com/databricks/databricks-sdk-go/config"
+	"github.com/databricks/databricks-sdk-go/config/credentials"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testCredentials struct{ authenticate func(*http.Request) error }
+
+func (c testCredentials) Name() string { return "test" }
+
+func (c testCredentials) Configure(context.Context, *config.Config) (credentials.CredentialsProvider, error) {
+	return credentials.CredentialsProviderFn(c.authenticate), nil
+}
+
+func TestWorkspaceToken(t *testing.T) {
+	for _, header := range []string{"Bearer token-one", "Basic private-credential", "Bearer ", ""} {
+		t.Run(header, func(t *testing.T) {
+			c, err := databricks.NewWorkspaceClient(&databricks.Config{
+				Host: "https://workspace.test", HostMetadataResolver: noHostMetadata, Token: "stale-config-token",
+				Credentials: testCredentials{authenticate: func(r *http.Request) error {
+					r.Header.Set("Authorization", header)
+					return nil
+				}},
+			})
+			require.NoError(t, err)
+			token, err := server.WorkspaceToken(c)(t.Context())
+			if header == "Bearer token-one" {
+				require.NoError(t, err)
+				assert.Equal(t, "token-one", token)
+				return
+			}
+			require.ErrorContains(t, err, "do not provide a bearer token")
+			assert.NotContains(t, err.Error(), "private-credential")
+			assert.Empty(t, token)
+		})
+	}
+}
+
+func TestWorkspaceTokenRefreshAndFailure(t *testing.T) {
+	value := "first"
+	var authErr error
+	c, err := databricks.NewWorkspaceClient(&databricks.Config{
+		Host: "https://workspace.test", HostMetadataResolver: noHostMetadata,
+		Credentials: testCredentials{authenticate: func(r *http.Request) error {
+			r.Header.Set("Authorization", "Bearer "+value)
+			return authErr
+		}},
+	})
+	require.NoError(t, err)
+	token := server.WorkspaceToken(c)
+	first, err := token(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, "first", first)
+	value = "second"
+	second, err := token(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, "second", second)
+	authErr = errors.New("credentials unavailable")
+	_, err = token(t.Context())
+	require.ErrorIs(t, err, authErr)
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func TestFuseUserID(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		status     int
+		body, want string
+	}{
+		{name: "available", status: http.StatusOK, body: `{"id":"12345"}`, want: "12345"},
+		{name: "forbidden", status: http.StatusForbidden, body: `{"message":"forbidden"}`},
+		{name: "timeout"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				c, err := databricks.NewWorkspaceClient(&databricks.Config{
+					Host: "https://workspace.test", HostMetadataResolver: noHostMetadata, Token: "test-token",
+					HTTPTransport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+						assert.Equal(t, "/api/2.0/preview/scim/v2/Me", r.URL.Path)
+						if tc.status == 0 {
+							<-r.Context().Done()
+							return nil, r.Context().Err()
+						}
+						return &http.Response{StatusCode: tc.status, Header: http.Header{"Content-Type": {"application/json"}}, Body: io.NopCloser(strings.NewReader(tc.body)), Request: r}, nil
+					}),
+				})
+				require.NoError(t, err)
+				start := time.Now()
+				assert.Equal(t, tc.want, server.FuseUserID(t.Context(), c))
+				assert.LessOrEqual(t, time.Since(start), 2*time.Second)
+			})
+		})
+	}
+}
+
+func noHostMetadata(context.Context, string) (*config.HostMetadata, error) { return nil, nil }

--- a/experimental/ssh/internal/server/server.go
+++ b/experimental/ssh/internal/server/server.go
@@ -62,6 +62,13 @@ type ServerOptions struct {
 
 func Run(ctx context.Context, client *databricks.WorkspaceClient, opts ServerOptions) error {
 	ctx, logBuf := captureWarnLogs(ctx)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// Filesystem registration is best-effort on compute without reachable daemons.
+	if err := registerFuseCredentials(ctx, client); err != nil {
+		log.Warnf(ctx, "Failed to register SSH filesystem credentials; file access may depend on the bootstrap notebook: %v", err)
+	}
 
 	port, err := findAvailablePort(opts.DefaultPort, opts.PortRange)
 	if err != nil {


### PR DESCRIPTION
## Changes

Register the SSH server process with the workspace-file and volume daemons. Check credentials and registration every minute, retry failures, and avoid updates when nothing changed. Bound daemon requests and keep SSH startup available when registration fails.

## Why

SSH descendants need filesystem access when the bootstrap notebook exits while the server survives. Registration does not extend the server lifetime, preserve detached processes, or renew a fixed bootstrap credential. Document these limits and troubleshooting steps.

## Tests

- SSH unit and acceptance suites, targeted race tests, full formatting, lint, repository checks, and builds for all supported platforms passed.
- Dedicated compute passed SSH, PTY, a 1 MiB SCP round trip, concurrent sessions, and workspace/volume file operations. Registration recovery was observed, but a concurrent file stress test hit an unresolved missing-file error during recovery. After terminating the bootstrap process, file operations passed through 60 seconds before the driver proxy closed.

_This PR was written with Codex._
