### PR TITLE
Auto-generate output_only field behaviour for model_services

### DIFF
--- a/bundle/direct/dresources/apitypes.yml
+++ b/bundle/direct/dresources/apitypes.yml
@@ -11,6 +11,8 @@
 # caller-supplied optimistic-concurrency token and that behavior is lost.
 genie_spaces: dashboards.GenieSpace
 
+model_services: catalog.ModelService
+
 postgres_branches: postgres.BranchSpec
 
 postgres_databases: postgres.DatabaseDatabaseSpec

--- a/bundle/direct/dresources/resources.generated.yml
+++ b/bundle/direct/dresources/resources.generated.yml
@@ -233,7 +233,21 @@ resources:
 
   # jobs: no api field behaviors
 
-  # model_services: no api field behaviors
+  model_services:
+
+    ignore_remote_changes:
+      - field: config.inference_table.is_deleted
+        reason: spec:output_only
+      - field: config.inference_table.table
+        reason: spec:output_only
+      - field: config.routing.destinations[*].is_deleted
+        reason: spec:output_only
+      - field: config.routing.destinations[*].provisioned_throughput_config.model
+        reason: spec:output_only
+      - field: config.routing.fallback.destinations[*].is_deleted
+        reason: spec:output_only
+      - field: config.routing.fallback.destinations[*].provisioned_throughput_config.model
+        reason: spec:output_only
 
   model_serving_endpoints:
 

--- a/bundle/direct/dresources/resources.yml
+++ b/bundle/direct/dresources/resources.yml
@@ -382,29 +382,6 @@ resources:
         reason: id_field
       - field: model_service_id
         reason: id_field
-    ignore_remote_changes:
-      # Server-resolved / tombstone fields returned on read, not user-authored.
-      # The generator maps model_services to the create-request type (config
-      # nested under model_service.*) so it can't emit these config.* paths;
-      # classify them by hand to avoid phantom drift.
-      - field: config.inference_table.table
-        reason: output_only
-      - field: config.inference_table.is_deleted
-        reason: output_only
-      # A routing target (model / MPS) that gets soft-deleted stays visible on
-      # read with is_deleted=true so the broken dependency is identifiable; the
-      # field is server-computed, not user-authored, so suppress it like above.
-      - field: config.routing.destinations[*].is_deleted
-        reason: output_only
-      - field: config.routing.fallback.destinations[*].is_deleted
-        reason: output_only
-      # A provisioned-throughput destination resolves the backing UC model FQN
-      # from model_serving_endpoint server-side; it is returned on read but
-      # never user-authored, so suppress it like the tombstone fields above.
-      - field: config.routing.destinations[*].provisioned_throughput_config.model
-        reason: output_only
-      - field: config.routing.fallback.destinations[*].provisioned_throughput_config.model
-        reason: output_only
 
   registered_models:
     ignore_remote_changes:


### PR DESCRIPTION
Follow-up to #6525 after #6618 enabled this.

Added `catalog.ModelService` to apitypes.yml, removed the override from resources.yml, and generated the rest